### PR TITLE
happstack: Added python setup file to replace .sh setup file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+import os
+os.system("python3 ./utilities/svg_parsing/svg_parser.py > ./hs/SVGGen.hs")
+os.system("runhaskell ./hs/cssGen.hs")


### PR DESCRIPTION
This file is meant to replace the .sh setup file so that both Windows and Unix users can set up Courseography. In the future, it might be worthwhile to look into `subprocess`, however I have not read up on it yet.
