### PR TITLE
Hotfix 225

### DIFF
--- a/hs/cssGen.hs
+++ b/hs/cssGen.hs
@@ -598,7 +598,7 @@ infoCSS = "#info-layout" ? do
 aboutStyles = "#aboutDiv" ? do
     maxWidth (px 1000)
     padding (em 0) (em 1) (em 0) (em 1)
-    margin nil auto nil auto
+    margin (em 0) auto (em 0) auto
     textAlign justify
     h1 <> h2 <> h3 <? do
         color blue3


### PR DESCRIPTION
Fixes #225

@david-yz-liu I have created a fix for the Clay issue, #225. Let me know what you think.

Also, if you think we should just stick to the old version of Clay, I will not be disappointed.

Note that `(em 0)` can be replaced with `nil`. I chose `(em 0)` because I think that it is easier to read, and easier to modify. All size modifications occur in lines whose sizes are either specified in em, or not at all.
