### PR TITLE
Tutorial parse fix

### DIFF
--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -158,7 +158,7 @@ instance ToJSON Tutorial where
   toJSON (Tutorial tutorialSection times timeStr) 
           = Array ((V.singleton (case tutorialSection of
                         Just value -> toJSON value
-                        Nothing -> toJSON timeStr)) V.++ V.singleton (toJSON (map toJSON times)) V.++ (V.singleton $ toJSON timeStr))
+                        Nothing -> toJSON (B.unpack "N/A"))) V.++ V.singleton (toJSON (map toJSON times)) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.
 processDirectory :: IO ()

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -33,14 +33,14 @@ courseDirectory = "../../res/courses/"
 
 -- | A Lecture.
 data Lecture =
-    Lecture { extra      :: Int,
-              section    :: T.Text,
-              cap        :: Int,
-              time_str   :: T.Text,
-              time       :: [[Int]],
+    Lecture { extra :: Int,
+              section :: T.Text,
+              cap :: Int,
+              time_str :: T.Text,
+              time :: [[Int]],
               instructor :: T.Text,
-              enrol      :: Maybe Int,
-              wait       :: Maybe Int
+              enrol :: Maybe Int,
+              wait :: Maybe Int
             } deriving Show
 
 -- | A Tutorial.
@@ -52,24 +52,24 @@ data Tutorial =
 
 -- | A Session.
 data Session =
-    Session { lectures   :: [Lecture],
-              tutorials  :: [Tutorial]
+    Session { lectures :: [Lecture],
+              tutorials :: [Tutorial]
             } deriving Show
 
 -- | A Course.
 data Course =
-    Course { breadth               :: Maybe T.Text,
-             description           :: Maybe T.Text,
-             title                 :: Maybe T.Text,
-             prereqString          :: Maybe T.Text,
-             f                     :: Maybe Session,
-             s                     :: Maybe Session,
-             y                     :: Maybe Session,
-             name                  :: !T.Text,
-             exclusions            :: Maybe T.Text,
-             manualTutorialEnrol   :: Maybe Bool,
-             distribution          :: Maybe T.Text,
-             prereqs               :: Maybe Array
+    Course { breadth :: Maybe T.Text,
+             description :: Maybe T.Text,
+             title :: Maybe T.Text,
+             prereqString :: Maybe T.Text,
+             f :: Maybe Session,
+             s :: Maybe Session,
+             y :: Maybe Session,
+             name :: !T.Text,
+             exclusions :: Maybe T.Text,
+             manualTutorialEnrol :: Maybe Bool,
+             distribution :: Maybe T.Text,
+             prereqs :: Maybe Array
            } deriving Show
 
 instance FromJSON Course where
@@ -143,7 +143,7 @@ instance ToJSON Lecture where
 instance FromJSON Tutorial where
     parseJSON (Array v)
         | V.length v == 2 = do
-            times   <- parseJSON $ v V.! 0
+            times <- parseJSON $ v V.! 0
             timeStr <- parseJSON $ v V.! 1
             return $ Tutorial Nothing times timeStr
         | V.length v == 3 = do
@@ -158,7 +158,7 @@ instance ToJSON Tutorial where
   toJSON (Tutorial tutorialSection times timeStr) 
           = Array ((V.singleton (case tutorialSection of
                         Just value -> toJSON value
-                        Nothing    -> toJSON timeStr)) V.++ V.singleton (toJSON (map toJSON times)) V.++ (V.singleton $ toJSON timeStr))
+                        Nothing -> toJSON timeStr)) V.++ V.singleton (toJSON (map toJSON times)) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.
 processDirectory :: IO ()
@@ -252,18 +252,18 @@ insertTutorial session course tutorial = runSqlite dbStr $ do
 -- | 6 indicates a parsing error.
 getBreadthRequirement :: T.Text -> Int
 getBreadthRequirement reqString
-    |   (T.isInfixOf "5" reqString) = 5
-    |   (T.isInfixOf "4" reqString) = 4
-    |   (T.isInfixOf "3" reqString) = 3
-    |   (T.isInfixOf "2" reqString) = 2
-    |   (T.isInfixOf "1" reqString) = 1
-    |   otherwise = 6
+    | (T.isInfixOf "5" reqString) = 5
+    | (T.isInfixOf "4" reqString) = 4
+    | (T.isInfixOf "3" reqString) = 3
+    | (T.isInfixOf "2" reqString) = 2
+    | (T.isInfixOf "1" reqString) = 1
+    | otherwise = 6
 
 -- | Gets the corresponding numeric requirement from a distribution requirement description.
 -- | 6 indicates a parsing error.
 getDistributionRequirement :: T.Text -> Int
 getDistributionRequirement reqString
-    |   (T.isInfixOf "This is a Science course" reqString) = 3
-    |   (T.isInfixOf "This is a Social Science course" reqString) = 2
-    |   (T.isInfixOf "This is a Humanities course" reqString) = 1
-    |   otherwise = 6
+    | (T.isInfixOf "This is a Science course" reqString) = 3
+    | (T.isInfixOf "This is a Social Science course" reqString) = 2
+    | (T.isInfixOf "This is a Humanities course" reqString) = 1
+    | otherwise = 6

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -147,15 +147,18 @@ instance FromJSON Tutorial where
             timeStr <- parseJSON $ v V.! 1
             return $ Tutorial Nothing times timeStr
         | V.length v == 3 = do
-            times   <- parseJSON $ v V.! 1
+            tutorialSection <- parseJSON $ v V.! 0
+            times <- parseJSON $ v V.! 1
             timeStr <- parseJSON $ v V.! 2
-            return $ Tutorial Nothing times timeStr
+            return $ Tutorial tutorialSection times timeStr
         | otherwise = mzero
     parseJSON _ = mzero
 
 instance ToJSON Tutorial where
   toJSON (Tutorial tutorialSection times timeStr) 
-          = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
+          = Array ((V.singleton (case tutorialSection of
+                        Just value -> toJSON value
+                        Nothing    -> toJSON timeStr)) V.++ V.singleton (toJSON (map toJSON times)) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.
 processDirectory :: IO ()

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -243,6 +243,7 @@ insertTutorial :: T.Text -> Course -> Tutorial -> IO ()
 insertTutorial session course tutorial = runSqlite dbStr $ do
                                        runMigration migrateAll
                                        insert_ $ Tutorials (name course)
+                                                           (tutorialSection tutorial)
                                                            session
                                                            (map Time (times tutorial))
                                                            (timeStr tutorial)

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -58,9 +58,9 @@ courseDirectory = "../../res/courses/"
 
 -- | A Course.
 data Course =
-    Course { breadth               :: !T.Text,
-             description           :: !T.Text,
-             title                 :: !T.Text,
+    Course { breadth               :: Maybe T.Text,
+             description           :: Maybe T.Text,
+             title                 :: Maybe T.Text,
              prereqString          :: Maybe T.Text,
              --f                     :: Maybe Session,
              --s                     :: Maybe Session,
@@ -68,23 +68,23 @@ data Course =
              name                  :: !T.Text,
              exclusions            :: Maybe T.Text,
              manualTutorialEnrol   :: Maybe Bool,
-             distribution          :: !T.Text,
-             prereqs               :: Maybe [[T.Text]]
+             distribution          :: Maybe T.Text,
+             prereqs               :: Maybe Array
            } deriving Show
 
 instance FromJSON Course where
     parseJSON (Object v) =
-        Course <$> v .:  "breadth"
-               <*> v .:  "description"
-               <*> v .:  "title"
-               <*> v .:  "prereqString"
+        Course <$> v .:? "breadth"
+               <*> v .:? "description"
+               <*> v .:? "title"
+               <*> v .:? "prereqString"
                -- <*> v .:? "F"
                -- <*> v .:? "S"
                -- <*> v .:? "Y"
                <*> v .:  "name"
-               <*> v .:  "exclusions"
+               <*> v .:? "exclusions"
                <*> v .:? "manualTutorialEnrolment"
-               <*> v .:  "distribution"
+               <*> v .:? "distribution"
                <*> v .:? "prereqs"
     parseJSON _ = mzero
 

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -29,32 +29,32 @@ import Control.Applicative
 import Tables
 
 courseDirectory :: String
-courseDirectory = "../../res/courses2/"
+courseDirectory = "../../res/courses/"
 
 -- | A Lecture.
-data Lecture =
-    Lecture { extra      :: Int,
-              section    :: T.Text,
-              cap        :: Int,
-              time_str   :: T.Text,
-              time       :: [[Int]],
-              instructor :: T.Text,
-              enrol      :: Maybe Int,
-              wait       :: Maybe Int
-            } deriving Show
+--data Lecture =
+--    Lecture { extra      :: Int,
+--              section    :: T.Text,
+--              cap        :: Int,
+--              time_str   :: T.Text,
+--              time       :: [[Int]],
+--              instructor :: T.Text,
+--              enrol      :: Maybe Int,
+--              wait       :: Maybe Int
+--            } deriving Show
 
 -- | A Tutorial.
-data Tutorial =
-    Tutorial { tutorialSection :: Maybe T.Text,
-               times       :: [[Int]],
-               timeStr     :: T.Text
-             } deriving Show
+--data Tutorial =
+--    Tutorial { tutorialSection :: Maybe T.Text,
+--               times       :: [[Int]],
+--               timeStr     :: T.Text
+--             } deriving Show
 
 -- | A Session.
-data Session =
-    Session { lectures   :: [Lecture],
-              tutorials  :: [Tutorial]
-            } deriving Show
+--data Session =
+--    Session { lectures   :: [Lecture],
+--              tutorials  :: [Tutorial]
+--            } deriving Show
 
 -- | A Course.
 data Course =
@@ -62,14 +62,14 @@ data Course =
              description           :: !T.Text,
              title                 :: !T.Text,
              prereqString          :: Maybe T.Text,
-             f                     :: Maybe Session,
-             s                     :: Maybe Session,
-             y                     :: Maybe Session,
+             --f                     :: Maybe Session,
+             --s                     :: Maybe Session,
+             --y                     :: Maybe Session,
              name                  :: !T.Text,
              exclusions            :: Maybe T.Text,
              manualTutorialEnrol   :: Maybe Bool,
              distribution          :: !T.Text,
-             prereqs               :: Maybe [T.Text]
+             prereqs               :: Maybe [[T.Text]]
            } deriving Show
 
 instance FromJSON Course where
@@ -78,9 +78,9 @@ instance FromJSON Course where
                <*> v .:  "description"
                <*> v .:  "title"
                <*> v .:  "prereqString"
-               <*> v .:? "F"
-               <*> v .:? "S"
-               <*> v .:? "Y"
+               -- <*> v .:? "F"
+               -- <*> v .:? "S"
+               -- <*> v .:? "Y"
                <*> v .:  "name"
                <*> v .:  "exclusions"
                <*> v .:? "manualTutorialEnrolment"
@@ -88,74 +88,74 @@ instance FromJSON Course where
                <*> v .:? "prereqs"
     parseJSON _ = mzero
 
-instance ToJSON Course where
-  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol distribution prereqs) 
-          = object ["breadth" .= breadth,
-                    "description" .= description,
-                    "title" .= title,
-                    "prereqString" .= prereqString,
-                    "F" .= f,
-                    "S" .= s,
-                    "Y" .= y,
-                    "name" .= name,
-                    "exclusions" .= exclusions,
-                    "manualTutorialEnrolment" .= manualTutorialEnrol,
-                    "distribution" .= distribution,
-                    "prereqs" .= prereqs
-                   ]
+--instance ToJSON Course where
+--  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol distribution prereqs) 
+--          = object ["breadth" .= breadth,
+--                    "description" .= description,
+--                    "title" .= title,
+--                    "prereqString" .= prereqString,
+--                    --"F" .= f,
+--                    --"S" .= s,
+--                    --"Y" .= y,
+--                    "name" .= name,
+--                    "exclusions" .= exclusions,
+--                    "manualTutorialEnrolment" .= manualTutorialEnrol,
+--                    "distribution" .= distribution,
+--                    "prereqs" .= prereqs
+--                   ]
 
-instance FromJSON Session where
-    parseJSON (Object v) =
-        Session <$> v .: "lectures"
-                <*> v .: "tutorials"
-    parseJSON _ = mzero
+--instance FromJSON Session where
+--    parseJSON (Object v) =
+--        Session <$> v .: "lectures"
+--                <*> v .: "tutorials"
+--    parseJSON _ = mzero
 
-instance ToJSON Session where
-  toJSON (Session lectures tutorials) 
-          = object ["lectures" .= lectures,
-                    "tutorials" .= tutorials
-                   ]
+--instance ToJSON Session where
+--  toJSON (Session lectures tutorials) 
+--          = object ["lectures" .= lectures,
+--                    "tutorials" .= tutorials
+--                   ]
 
-instance FromJSON Lecture where
-    parseJSON (Object v) =
-        Lecture <$> v .:  "extra"
-                <*> v .:  "section"
-                <*> v .:  "cap"
-                <*> v .:  "time_str"
-                <*> v .:  "time"
-                <*> v .:  "instructor"
-                <*> v .:? "enrol"
-                <*> v .:? "wait"
-    parseJSON _ = mzero
+--instance FromJSON Lecture where
+--    parseJSON (Object v) =
+--        Lecture <$> v .:  "extra"
+--                <*> v .:  "section"
+--                <*> v .:  "cap"
+--                <*> v .:  "time_str"
+--                <*> v .:  "time"
+--                <*> v .:  "instructor"
+--                <*> v .:? "enrol"
+--                <*> v .:? "wait"
+--    parseJSON _ = mzero
 
-instance ToJSON Lecture where
-  toJSON (Lecture extra section cap time_str time instructor enrol wait) 
-          = object ["extra" .= extra,
-                    "section" .= section,
-                    "cap" .= cap,
-                    "time_str" .= time_str,
-                    "time" .= time,
-                    "instructor" .= instructor,
-                    "enrol" .= enrol,
-                    "wait" .= wait
-                   ]
+--instance ToJSON Lecture where
+--  toJSON (Lecture extra section cap time_str time instructor enrol wait) 
+--          = object ["extra" .= extra,
+--                    "section" .= section,
+--                    "cap" .= cap,
+--                    "time_str" .= time_str,
+--                    "time" .= time,
+--                    "instructor" .= instructor,
+--                    "enrol" .= enrol,
+--                    "wait" .= wait
+--                   ]
 
-instance FromJSON Tutorial where
-    parseJSON (Array v)
-        | V.length v == 2 = do
-            times   <- parseJSON $ v V.! 0
-            timeStr <- parseJSON $ v V.! 1
-            return $ Tutorial Nothing times timeStr
-        | V.length v == 3 = do
-            times   <- parseJSON $ v V.! 1
-            timeStr <- parseJSON $ v V.! 2
-            return $ Tutorial Nothing times timeStr
-        | otherwise = mzero
-    parseJSON _ = mzero
+--instance FromJSON Tutorial where
+--    parseJSON (Array v)
+--        | V.length v == 2 = do
+--            times   <- parseJSON $ v V.! 0
+--            timeStr <- parseJSON $ v V.! 1
+--            return $ Tutorial Nothing times timeStr
+--        | V.length v == 3 = do
+--            times   <- parseJSON $ v V.! 1
+--            timeStr <- parseJSON $ v V.! 2
+--            return $ Tutorial Nothing times timeStr
+--        | otherwise = mzero
+--    parseJSON _ = mzero
 
-instance ToJSON Tutorial where
-  toJSON (Tutorial tutorialSection times timeStr) 
-          = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
+--instance ToJSON Tutorial where
+--  toJSON (Tutorial tutorialSection times timeStr) 
+--          = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.
 processDirectory :: IO ()
@@ -170,9 +170,9 @@ printFile courseFile = do
                          case d of
                            Left err -> print $ courseFile ++ " " ++ err
                            Right course -> do
-                                             insertCourse $ course
-                                             insertLectures $ course
-                                             insertTutorials $ course
+                                             --insertCourse $ course
+                                             --insertLectures $ course
+                                             --insertTutorials $ course
                                              print $ "Inserted " ++ show (name course)
 
 -- | Opens and reads the file contained in `jsonFile`. File contents are returned, surrounded by
@@ -181,85 +181,85 @@ getJSON :: String -> IO B.ByteString
 getJSON jsonFile = (B.readFile jsonFile)
 
 -- | Inserts course into the Courses table.
-insertCourse :: Course -> IO ()
-insertCourse course = runSqlite dbStr $ do
-                        runMigration migrateAll
-                        insert_ $ Courses (name course)
-                                          (title course)
-                                          (description course)
-                                          (manualTutorialEnrol course)
-                                          (prereqString course)
-                                          (exclusions course)
-                                          (breadth course) 
-                                          (distribution course)
-                                          (prereqString course)
+--insertCourse :: Course -> IO ()
+--insertCourse course = runSqlite dbStr $ do
+--                        runMigration migrateAll
+--                        insert_ $ Courses (name course)
+--                                          (title course)
+--                                          (description course)
+--                                          (manualTutorialEnrol course)
+--                                          (prereqString course)
+--                                          (exclusions course)
+--                                          (breadth course) 
+--                                          (distribution course)
+--                                          (prereqString course)
 
--- | Inserts the lectures from course into the Lectures table.
-insertLectures :: Course -> IO ()
-insertLectures course = insertSessionLectures (f course) "F" course >>
-                        insertSessionLectures (s course) "S" course >>
-                        insertSessionLectures (y course) "Y" course
+---- | Inserts the lectures from course into the Lectures table.
+--insertLectures :: Course -> IO ()
+--insertLectures course = insertSessionLectures (f course) "F" course >>
+--                        insertSessionLectures (s course) "S" course >>
+--                        insertSessionLectures (y course) "Y" course
 
--- | Inserts the lectures from a specified section into the Lectures table.
-insertSessionLectures :: Maybe Session -> T.Text -> Course -> IO ()
-insertSessionLectures Nothing sessionStr course = return ()
-insertSessionLectures (Just session) sessionStr course = liftIO $ mapM_ ((insertLecture sessionStr) course) (lectures session)
+---- | Inserts the lectures from a specified section into the Lectures table.
+--insertSessionLectures :: Maybe Session -> T.Text -> Course -> IO ()
+--insertSessionLectures Nothing sessionStr course = return ()
+--insertSessionLectures (Just session) sessionStr course = liftIO $ mapM_ ((insertLecture sessionStr) course) (lectures session)
 
--- | Inserts a lecture into the Lectures table.
-insertLecture :: T.Text -> Course -> Lecture -> IO ()
-insertLecture session course lecture = runSqlite dbStr $ do
-                                       runMigration migrateAll
-                                       insert_ $ Lectures (name course)
-                                                          session
-                                                          (section lecture)
-                                                          (map Time (time lecture))
-                                                          (cap lecture)
-                                                          (instructor lecture)
-                                                          (case enrol lecture of
-                                                                Just value -> value
-                                                                Nothing    -> 0)
-                                                          (case wait lecture of
-                                                                Just value -> value
-                                                                Nothing    -> 0)
-                                                          (extra lecture)
-                                                          (time_str lecture)
+---- | Inserts a lecture into the Lectures table.
+--insertLecture :: T.Text -> Course -> Lecture -> IO ()
+--insertLecture session course lecture = runSqlite dbStr $ do
+--                                       runMigration migrateAll
+--                                       insert_ $ Lectures (name course)
+--                                                          session
+--                                                          (section lecture)
+--                                                          (map Time (time lecture))
+--                                                          (cap lecture)
+--                                                          (instructor lecture)
+--                                                          (case enrol lecture of
+--                                                                Just value -> value
+--                                                                Nothing    -> 0)
+--                                                          (case wait lecture of
+--                                                                Just value -> value
+--                                                                Nothing    -> 0)
+--                                                          (extra lecture)
+--                                                          (time_str lecture)
 
--- | Inserts the tutorials from course into the Tutorials table.
-insertTutorials :: Course -> IO ()
-insertTutorials course =  insertSessionTutorials (f course) "F" course >>
-                          insertSessionTutorials (s course) "S" course >>
-                          insertSessionTutorials (y course) "Y" course
+---- | Inserts the tutorials from course into the Tutorials table.
+--insertTutorials :: Course -> IO ()
+--insertTutorials course =  insertSessionTutorials (f course) "F" course >>
+--                          insertSessionTutorials (s course) "S" course >>
+--                          insertSessionTutorials (y course) "Y" course
 
--- | Inserts the tutorials from a specified section into the Tutorials table.
-insertSessionTutorials :: Maybe Session -> T.Text -> Course -> IO ()
-insertSessionTutorials Nothing sessionStr course = return ()
-insertSessionTutorials (Just session) sessionStr course = when (not $ null (tutorials session)) $ liftIO $ mapM_ ((insertTutorial sessionStr) course) (tutorials session)
+---- | Inserts the tutorials from a specified section into the Tutorials table.
+--insertSessionTutorials :: Maybe Session -> T.Text -> Course -> IO ()
+--insertSessionTutorials Nothing sessionStr course = return ()
+--insertSessionTutorials (Just session) sessionStr course = when (not $ null (tutorials session)) $ liftIO $ mapM_ ((insertTutorial sessionStr) course) (tutorials session)
 
--- | Inserts a tutorial into the Tutorials table.
-insertTutorial :: T.Text -> Course -> Tutorial -> IO ()
-insertTutorial session course tutorial = runSqlite dbStr $ do
-                                       runMigration migrateAll
-                                       insert_ $ Tutorials (name course)
-                                                           session
-                                                           (map Time (times tutorial))
-                                                           (timeStr tutorial)
+---- | Inserts a tutorial into the Tutorials table.
+--insertTutorial :: T.Text -> Course -> Tutorial -> IO ()
+--insertTutorial session course tutorial = runSqlite dbStr $ do
+--                                       runMigration migrateAll
+--                                       insert_ $ Tutorials (name course)
+--                                                           session
+--                                                           (map Time (times tutorial))
+--                                                           (timeStr tutorial)
 
--- | Gets the corresponding numeric requirement from a breadth requirement description.
--- | 6 indicates a parsing error.
-getBreadthRequirement :: T.Text -> Int
-getBreadthRequirement reqString
-    |   (T.isInfixOf "5" reqString) = 5
-    |   (T.isInfixOf "4" reqString) = 4
-    |   (T.isInfixOf "3" reqString) = 3
-    |   (T.isInfixOf "2" reqString) = 2
-    |   (T.isInfixOf "1" reqString) = 1
-    |   otherwise = 6
+---- | Gets the corresponding numeric requirement from a breadth requirement description.
+---- | 6 indicates a parsing error.
+--getBreadthRequirement :: T.Text -> Int
+--getBreadthRequirement reqString
+--    |   (T.isInfixOf "5" reqString) = 5
+--    |   (T.isInfixOf "4" reqString) = 4
+--    |   (T.isInfixOf "3" reqString) = 3
+--    |   (T.isInfixOf "2" reqString) = 2
+--    |   (T.isInfixOf "1" reqString) = 1
+--    |   otherwise = 6
 
--- | Gets the corresponding numeric requirement from a distribution requirement description.
--- | 6 indicates a parsing error.
-getDistributionRequirement :: T.Text -> Int
-getDistributionRequirement reqString
-    |   (T.isInfixOf "This is a Science course" reqString) = 3
-    |   (T.isInfixOf "This is a Social Science course" reqString) = 2
-    |   (T.isInfixOf "This is a Humanities course" reqString) = 1
-    |   otherwise = 6
+---- | Gets the corresponding numeric requirement from a distribution requirement description.
+---- | 6 indicates a parsing error.
+--getDistributionRequirement :: T.Text -> Int
+--getDistributionRequirement reqString
+--    |   (T.isInfixOf "This is a Science course" reqString) = 3
+--    |   (T.isInfixOf "This is a Social Science course" reqString) = 2
+--    |   (T.isInfixOf "This is a Humanities course" reqString) = 1
+--    |   otherwise = 6

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -29,7 +29,7 @@ import Control.Applicative
 import Tables
 
 courseDirectory :: String
-courseDirectory = "../../res/courses/"
+courseDirectory = "../../res/courses2/"
 
 -- | A Lecture.
 data Lecture =
@@ -45,7 +45,8 @@ data Lecture =
 
 -- | A Tutorial.
 data Tutorial =
-    Tutorial { times       :: [[Int]],
+    Tutorial { tutorialSection :: Maybe T.Text,
+               times       :: [[Int]],
                timeStr     :: T.Text
              } deriving Show
 
@@ -142,14 +143,18 @@ instance ToJSON Lecture where
 instance FromJSON Tutorial where
     parseJSON (Array v)
         | V.length v == 2 = do
-            times <- parseJSON $ v V.! 0
+            times   <- parseJSON $ v V.! 0
             timeStr <- parseJSON $ v V.! 1
-            return $ Tutorial times timeStr
+            return $ Tutorial Nothing times timeStr
+        | V.length v == 3 = do
+            times   <- parseJSON $ v V.! 1
+            timeStr <- parseJSON $ v V.! 2
+            return $ Tutorial Nothing times timeStr
         | otherwise = mzero
     parseJSON _ = mzero
 
 instance ToJSON Tutorial where
-  toJSON (Tutorial times timeStr) 
+  toJSON (Tutorial tutorialSection times timeStr) 
           = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.

--- a/hs/database/JsonParser.hs
+++ b/hs/database/JsonParser.hs
@@ -32,29 +32,29 @@ courseDirectory :: String
 courseDirectory = "../../res/courses/"
 
 -- | A Lecture.
---data Lecture =
---    Lecture { extra      :: Int,
---              section    :: T.Text,
---              cap        :: Int,
---              time_str   :: T.Text,
---              time       :: [[Int]],
---              instructor :: T.Text,
---              enrol      :: Maybe Int,
---              wait       :: Maybe Int
---            } deriving Show
+data Lecture =
+    Lecture { extra      :: Int,
+              section    :: T.Text,
+              cap        :: Int,
+              time_str   :: T.Text,
+              time       :: [[Int]],
+              instructor :: T.Text,
+              enrol      :: Maybe Int,
+              wait       :: Maybe Int
+            } deriving Show
 
 -- | A Tutorial.
---data Tutorial =
---    Tutorial { tutorialSection :: Maybe T.Text,
---               times       :: [[Int]],
---               timeStr     :: T.Text
---             } deriving Show
+data Tutorial =
+    Tutorial { tutorialSection :: Maybe T.Text,
+               times       :: [[Int]],
+               timeStr     :: T.Text
+             } deriving Show
 
 -- | A Session.
---data Session =
---    Session { lectures   :: [Lecture],
---              tutorials  :: [Tutorial]
---            } deriving Show
+data Session =
+    Session { lectures   :: [Lecture],
+              tutorials  :: [Tutorial]
+            } deriving Show
 
 -- | A Course.
 data Course =
@@ -62,9 +62,9 @@ data Course =
              description           :: Maybe T.Text,
              title                 :: Maybe T.Text,
              prereqString          :: Maybe T.Text,
-             --f                     :: Maybe Session,
-             --s                     :: Maybe Session,
-             --y                     :: Maybe Session,
+             f                     :: Maybe Session,
+             s                     :: Maybe Session,
+             y                     :: Maybe Session,
              name                  :: !T.Text,
              exclusions            :: Maybe T.Text,
              manualTutorialEnrol   :: Maybe Bool,
@@ -78,9 +78,9 @@ instance FromJSON Course where
                <*> v .:? "description"
                <*> v .:? "title"
                <*> v .:? "prereqString"
-               -- <*> v .:? "F"
-               -- <*> v .:? "S"
-               -- <*> v .:? "Y"
+               <*> v .:? "F"
+               <*> v .:? "S"
+               <*> v .:? "Y"
                <*> v .:  "name"
                <*> v .:? "exclusions"
                <*> v .:? "manualTutorialEnrolment"
@@ -88,74 +88,74 @@ instance FromJSON Course where
                <*> v .:? "prereqs"
     parseJSON _ = mzero
 
---instance ToJSON Course where
---  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol distribution prereqs) 
---          = object ["breadth" .= breadth,
---                    "description" .= description,
---                    "title" .= title,
---                    "prereqString" .= prereqString,
---                    --"F" .= f,
---                    --"S" .= s,
---                    --"Y" .= y,
---                    "name" .= name,
---                    "exclusions" .= exclusions,
---                    "manualTutorialEnrolment" .= manualTutorialEnrol,
---                    "distribution" .= distribution,
---                    "prereqs" .= prereqs
---                   ]
+instance ToJSON Course where
+  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol distribution prereqs) 
+          = object ["breadth" .= breadth,
+                    "description" .= description,
+                    "title" .= title,
+                    "prereqString" .= prereqString,
+                    "F" .= f,
+                    "S" .= s,
+                    "Y" .= y,
+                    "name" .= name,
+                    "exclusions" .= exclusions,
+                    "manualTutorialEnrolment" .= manualTutorialEnrol,
+                    "distribution" .= distribution,
+                    "prereqs" .= prereqs
+                   ]
 
---instance FromJSON Session where
---    parseJSON (Object v) =
---        Session <$> v .: "lectures"
---                <*> v .: "tutorials"
---    parseJSON _ = mzero
+instance FromJSON Session where
+    parseJSON (Object v) =
+        Session <$> v .: "lectures"
+                <*> v .: "tutorials"
+    parseJSON _ = mzero
 
---instance ToJSON Session where
---  toJSON (Session lectures tutorials) 
---          = object ["lectures" .= lectures,
---                    "tutorials" .= tutorials
---                   ]
+instance ToJSON Session where
+  toJSON (Session lectures tutorials) 
+          = object ["lectures" .= lectures,
+                    "tutorials" .= tutorials
+                   ]
 
---instance FromJSON Lecture where
---    parseJSON (Object v) =
---        Lecture <$> v .:  "extra"
---                <*> v .:  "section"
---                <*> v .:  "cap"
---                <*> v .:  "time_str"
---                <*> v .:  "time"
---                <*> v .:  "instructor"
---                <*> v .:? "enrol"
---                <*> v .:? "wait"
---    parseJSON _ = mzero
+instance FromJSON Lecture where
+    parseJSON (Object v) =
+        Lecture <$> v .:  "extra"
+                <*> v .:  "section"
+                <*> v .:  "cap"
+                <*> v .:  "time_str"
+                <*> v .:  "time"
+                <*> v .:  "instructor"
+                <*> v .:? "enrol"
+                <*> v .:? "wait"
+    parseJSON _ = mzero
 
---instance ToJSON Lecture where
---  toJSON (Lecture extra section cap time_str time instructor enrol wait) 
---          = object ["extra" .= extra,
---                    "section" .= section,
---                    "cap" .= cap,
---                    "time_str" .= time_str,
---                    "time" .= time,
---                    "instructor" .= instructor,
---                    "enrol" .= enrol,
---                    "wait" .= wait
---                   ]
+instance ToJSON Lecture where
+  toJSON (Lecture extra section cap time_str time instructor enrol wait) 
+          = object ["extra" .= extra,
+                    "section" .= section,
+                    "cap" .= cap,
+                    "time_str" .= time_str,
+                    "time" .= time,
+                    "instructor" .= instructor,
+                    "enrol" .= enrol,
+                    "wait" .= wait
+                   ]
 
---instance FromJSON Tutorial where
---    parseJSON (Array v)
---        | V.length v == 2 = do
---            times   <- parseJSON $ v V.! 0
---            timeStr <- parseJSON $ v V.! 1
---            return $ Tutorial Nothing times timeStr
---        | V.length v == 3 = do
---            times   <- parseJSON $ v V.! 1
---            timeStr <- parseJSON $ v V.! 2
---            return $ Tutorial Nothing times timeStr
---        | otherwise = mzero
---    parseJSON _ = mzero
+instance FromJSON Tutorial where
+    parseJSON (Array v)
+        | V.length v == 2 = do
+            times   <- parseJSON $ v V.! 0
+            timeStr <- parseJSON $ v V.! 1
+            return $ Tutorial Nothing times timeStr
+        | V.length v == 3 = do
+            times   <- parseJSON $ v V.! 1
+            timeStr <- parseJSON $ v V.! 2
+            return $ Tutorial Nothing times timeStr
+        | otherwise = mzero
+    parseJSON _ = mzero
 
---instance ToJSON Tutorial where
---  toJSON (Tutorial tutorialSection times timeStr) 
---          = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
+instance ToJSON Tutorial where
+  toJSON (Tutorial tutorialSection times timeStr) 
+          = Array (V.fromList (map toJSON times) V.++ (V.singleton $ toJSON timeStr))
 
 -- | Opens a directory contained in dir, and processes every file in that directory.
 processDirectory :: IO ()
@@ -170,9 +170,9 @@ printFile courseFile = do
                          case d of
                            Left err -> print $ courseFile ++ " " ++ err
                            Right course -> do
-                                             --insertCourse $ course
-                                             --insertLectures $ course
-                                             --insertTutorials $ course
+                                             insertCourse $ course
+                                             insertLectures $ course
+                                             insertTutorials $ course
                                              print $ "Inserted " ++ show (name course)
 
 -- | Opens and reads the file contained in `jsonFile`. File contents are returned, surrounded by
@@ -181,85 +181,85 @@ getJSON :: String -> IO B.ByteString
 getJSON jsonFile = (B.readFile jsonFile)
 
 -- | Inserts course into the Courses table.
---insertCourse :: Course -> IO ()
---insertCourse course = runSqlite dbStr $ do
---                        runMigration migrateAll
---                        insert_ $ Courses (name course)
---                                          (title course)
---                                          (description course)
---                                          (manualTutorialEnrol course)
---                                          (prereqString course)
---                                          (exclusions course)
---                                          (breadth course) 
---                                          (distribution course)
---                                          (prereqString course)
+insertCourse :: Course -> IO ()
+insertCourse course = runSqlite dbStr $ do
+                        runMigration migrateAll
+                        insert_ $ Courses (name course)
+                                          (title course)
+                                          (description course)
+                                          (manualTutorialEnrol course)
+                                          (prereqString course)
+                                          (exclusions course)
+                                          (breadth course) 
+                                          (distribution course)
+                                          (prereqString course)
 
----- | Inserts the lectures from course into the Lectures table.
---insertLectures :: Course -> IO ()
---insertLectures course = insertSessionLectures (f course) "F" course >>
---                        insertSessionLectures (s course) "S" course >>
---                        insertSessionLectures (y course) "Y" course
+-- | Inserts the lectures from course into the Lectures table.
+insertLectures :: Course -> IO ()
+insertLectures course = insertSessionLectures (f course) "F" course >>
+                        insertSessionLectures (s course) "S" course >>
+                        insertSessionLectures (y course) "Y" course
 
----- | Inserts the lectures from a specified section into the Lectures table.
---insertSessionLectures :: Maybe Session -> T.Text -> Course -> IO ()
---insertSessionLectures Nothing sessionStr course = return ()
---insertSessionLectures (Just session) sessionStr course = liftIO $ mapM_ ((insertLecture sessionStr) course) (lectures session)
+-- | Inserts the lectures from a specified section into the Lectures table.
+insertSessionLectures :: Maybe Session -> T.Text -> Course -> IO ()
+insertSessionLectures Nothing sessionStr course = return ()
+insertSessionLectures (Just session) sessionStr course = liftIO $ mapM_ ((insertLecture sessionStr) course) (lectures session)
 
----- | Inserts a lecture into the Lectures table.
---insertLecture :: T.Text -> Course -> Lecture -> IO ()
---insertLecture session course lecture = runSqlite dbStr $ do
---                                       runMigration migrateAll
---                                       insert_ $ Lectures (name course)
---                                                          session
---                                                          (section lecture)
---                                                          (map Time (time lecture))
---                                                          (cap lecture)
---                                                          (instructor lecture)
---                                                          (case enrol lecture of
---                                                                Just value -> value
---                                                                Nothing    -> 0)
---                                                          (case wait lecture of
---                                                                Just value -> value
---                                                                Nothing    -> 0)
---                                                          (extra lecture)
---                                                          (time_str lecture)
+-- | Inserts a lecture into the Lectures table.
+insertLecture :: T.Text -> Course -> Lecture -> IO ()
+insertLecture session course lecture = runSqlite dbStr $ do
+                                       runMigration migrateAll
+                                       insert_ $ Lectures (name course)
+                                                          session
+                                                          (section lecture)
+                                                          (map Time (time lecture))
+                                                          (cap lecture)
+                                                          (instructor lecture)
+                                                          (case enrol lecture of
+                                                                Just value -> value
+                                                                Nothing    -> 0)
+                                                          (case wait lecture of
+                                                                Just value -> value
+                                                                Nothing    -> 0)
+                                                          (extra lecture)
+                                                          (time_str lecture)
 
----- | Inserts the tutorials from course into the Tutorials table.
---insertTutorials :: Course -> IO ()
---insertTutorials course =  insertSessionTutorials (f course) "F" course >>
---                          insertSessionTutorials (s course) "S" course >>
---                          insertSessionTutorials (y course) "Y" course
+-- | Inserts the tutorials from course into the Tutorials table.
+insertTutorials :: Course -> IO ()
+insertTutorials course =  insertSessionTutorials (f course) "F" course >>
+                          insertSessionTutorials (s course) "S" course >>
+                          insertSessionTutorials (y course) "Y" course
 
----- | Inserts the tutorials from a specified section into the Tutorials table.
---insertSessionTutorials :: Maybe Session -> T.Text -> Course -> IO ()
---insertSessionTutorials Nothing sessionStr course = return ()
---insertSessionTutorials (Just session) sessionStr course = when (not $ null (tutorials session)) $ liftIO $ mapM_ ((insertTutorial sessionStr) course) (tutorials session)
+-- | Inserts the tutorials from a specified section into the Tutorials table.
+insertSessionTutorials :: Maybe Session -> T.Text -> Course -> IO ()
+insertSessionTutorials Nothing sessionStr course = return ()
+insertSessionTutorials (Just session) sessionStr course = when (not $ null (tutorials session)) $ liftIO $ mapM_ ((insertTutorial sessionStr) course) (tutorials session)
 
----- | Inserts a tutorial into the Tutorials table.
---insertTutorial :: T.Text -> Course -> Tutorial -> IO ()
---insertTutorial session course tutorial = runSqlite dbStr $ do
---                                       runMigration migrateAll
---                                       insert_ $ Tutorials (name course)
---                                                           session
---                                                           (map Time (times tutorial))
---                                                           (timeStr tutorial)
+-- | Inserts a tutorial into the Tutorials table.
+insertTutorial :: T.Text -> Course -> Tutorial -> IO ()
+insertTutorial session course tutorial = runSqlite dbStr $ do
+                                       runMigration migrateAll
+                                       insert_ $ Tutorials (name course)
+                                                           session
+                                                           (map Time (times tutorial))
+                                                           (timeStr tutorial)
 
----- | Gets the corresponding numeric requirement from a breadth requirement description.
----- | 6 indicates a parsing error.
---getBreadthRequirement :: T.Text -> Int
---getBreadthRequirement reqString
---    |   (T.isInfixOf "5" reqString) = 5
---    |   (T.isInfixOf "4" reqString) = 4
---    |   (T.isInfixOf "3" reqString) = 3
---    |   (T.isInfixOf "2" reqString) = 2
---    |   (T.isInfixOf "1" reqString) = 1
---    |   otherwise = 6
+-- | Gets the corresponding numeric requirement from a breadth requirement description.
+-- | 6 indicates a parsing error.
+getBreadthRequirement :: T.Text -> Int
+getBreadthRequirement reqString
+    |   (T.isInfixOf "5" reqString) = 5
+    |   (T.isInfixOf "4" reqString) = 4
+    |   (T.isInfixOf "3" reqString) = 3
+    |   (T.isInfixOf "2" reqString) = 2
+    |   (T.isInfixOf "1" reqString) = 1
+    |   otherwise = 6
 
----- | Gets the corresponding numeric requirement from a distribution requirement description.
----- | 6 indicates a parsing error.
---getDistributionRequirement :: T.Text -> Int
---getDistributionRequirement reqString
---    |   (T.isInfixOf "This is a Science course" reqString) = 3
---    |   (T.isInfixOf "This is a Social Science course" reqString) = 2
---    |   (T.isInfixOf "This is a Humanities course" reqString) = 1
---    |   otherwise = 6
+-- | Gets the corresponding numeric requirement from a distribution requirement description.
+-- | 6 indicates a parsing error.
+getDistributionRequirement :: T.Text -> Int
+getDistributionRequirement reqString
+    |   (T.isInfixOf "This is a Science course" reqString) = 3
+    |   (T.isInfixOf "This is a Social Science course" reqString) = 2
+    |   (T.isInfixOf "This is a Humanities course" reqString) = 1
+    |   otherwise = 6

--- a/hs/database/Tables.hs
+++ b/hs/database/Tables.hs
@@ -21,14 +21,14 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 Courses json
     --department String
     code Text
-    title Text
-    description Text
+    title Text Maybe
+    description Text Maybe
     manualTutorialEnrolment Bool Maybe
     --manualPracticalEnrolment Bool
     prereqs Text Maybe
     exclusions Text Maybe
-    breadth Text
-    distribution Text
+    breadth Text Maybe
+    distribution Text Maybe
     prereqString Text Maybe
     deriving Show
 
@@ -67,4 +67,4 @@ Distribution
 |]
 
 dbStr :: Text
-dbStr = "data63.sqlite3"
+dbStr = "data78.sqlite3"

--- a/hs/database/Tables.hs
+++ b/hs/database/Tables.hs
@@ -50,6 +50,7 @@ Lectures
 Tutorials
     --department String
     code Text
+    section Text Maybe
     session Text
     times [Time]
     timeStr Text
@@ -67,4 +68,4 @@ Distribution
 |]
 
 dbStr :: Text
-dbStr = "data78.sqlite3"
+dbStr = "data80.sqlite3"

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -110,7 +110,7 @@ buildLecture entity = Lecture (lecturesExtra entity)
 
 -- | Builds a Tutorial structure from a tuple from the Tutorials table.
 buildTutorial :: Tutorials -> Tutorial
-buildTutorial entity = Tutorial Nothing
+buildTutorial entity = Tutorial (tutorialsSection entity)
                                 (map timeField (tutorialsTimes entity))
                                 (tutorialsTimeStr entity)
 

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -74,7 +74,7 @@ queryCourse courseStr = runSqlite (T.pack ("database/" ++ T.unpack dbStr)) $ do
         let course = entityVal $ head sqlCourse
 
         let fallSession   = buildSession sqlLecturesFall sqlTutorialsFall
-        let springSession = buildSession sqlLecturesYear sqlTutorialsSpring
+        let springSession = buildSession sqlLecturesSpring sqlTutorialsSpring
         let yearSession = buildSession sqlLecturesYear sqlTutorialsYear
 
         let courseJSON = buildCourse fallSession springSession yearSession course
@@ -93,7 +93,7 @@ buildCourse fallSession springSession yearSession course = Course (coursesBreadt
                                                                   yearSession
                                                                   (coursesCode course)        --name
                                                                   (coursesExclusions course)  --exclusions
-                                                                   Nothing               -- manualTutorialEnrolment
+                                                                  (coursesManualTutorialEnrolment course)               -- manualTutorialEnrolment
                                                                   (coursesDistribution course)
                                                                    Nothing               -- prereqs
 
@@ -110,7 +110,8 @@ buildLecture entity = Lecture (lecturesExtra entity)
 
 -- | Builds a Tutorial structure from a tuple from the Tutorials table.
 buildTutorial :: Tutorials -> Tutorial
-buildTutorial entity = Tutorial (map timeField (tutorialsTimes entity))
+buildTutorial entity = Tutorial Nothing
+                                (map timeField (tutorialsTimes entity))
                                 (tutorialsTimeStr entity)
 
 -- | Encodes an Aeson Value into a ByteString.

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -50,7 +50,6 @@ main = simpleHTTP nullConf $
 queryCourse :: String -> IO Response
 queryCourse courseStr = runSqlite (T.pack ("database/" ++ T.unpack dbStr)) $ do
 
-
         sqlCourse :: [Entity Courses] <- selectList [CoursesCode ==. (T.pack courseStr)] []
 
         sqlLecturesFall :: [Entity Lectures]  <- selectList [LecturesCode  ==. (T.pack courseStr),
@@ -87,7 +86,7 @@ buildCourse :: Maybe Session -> Maybe Session -> Maybe Session -> Courses -> Cou
 buildCourse fallSession springSession yearSession course = Course (coursesBreadth course)
                                                                   (coursesDescription course)
                                                                   (coursesTitle course)
-                                                                   Nothing               --prereqString
+                                                                  Nothing               --prereqString
                                                                   fallSession
                                                                   springSession
                                                                   yearSession
@@ -95,7 +94,7 @@ buildCourse fallSession springSession yearSession course = Course (coursesBreadt
                                                                   (coursesExclusions course)  --exclusions
                                                                   (coursesManualTutorialEnrolment course)               -- manualTutorialEnrolment
                                                                   (coursesDistribution course)
-                                                                   Nothing               -- prereqs
+                                                                  Nothing               -- prereqs
 
 -- | Builds a Lecture structure from a tuple from the Lectures table.
 buildLecture :: Lectures -> Lecture


### PR DESCRIPTION
Courses can now be successfully rebuilt.

Some courses, such as CSC209, have tutorial sections listed in their `tutorials` array. As such, the `Tutorial` structure and `Tutorials` table has been modified to store this data. The fromJSON declaration has also been modified to account for variable JSON tutorials array lengths.