### PR TITLE
Issue 233: Missing prereqs

### DIFF
--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -34,6 +34,11 @@ class Rect:
         self.colour = '#fff'
         self.class_ = 'hybrid' if self.hybrid else 'node'
 
+        self.input_text_y = 0 # The y value of the first text value seen by the parser.
+                              # When a second text value for a node is seen, we want
+                              # to be able to identify which text element goes above,
+                              # and which goes below.
+
     def output_haskell(self):
         if self.hybrid:
             self.colour = "#bbb"
@@ -53,8 +58,10 @@ class Rect:
                 self.area = area
                 break
 
-        
-
+        # Certain nodes have multiple lines of text. SVG text elements do not support
+        # line wrapping or newlines, so two text elements need to be created.
+        # Since there are now two text elements fitting into the node, the y positions
+        # of the text elements need to be recalculated to account for this.
         if len(self.extra_text) == 0:
             text = ("             S.text_ " +
                    " ! A.x \"" + str(self.text_x) +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -80,7 +80,6 @@ class Rect:
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
               " ! A.id_ \"" + code + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
-              " ! S.customAttribute \"text-rendering\" \"geometricPrecision\"" +
               " ! A.style \"" + "\" $ do \n"  +
               "             S.rect ! A.width \"" + self.width +
               "\" ! A.height \"" + self.height +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -27,7 +27,7 @@ class Rect:
         self.text_y = float(self.y) + (float(height)/2)
         self.parent_transform_x = float(transform[transform.find('(') + 1: transform.find(',')])
         self.parent_transform_y = float(transform[transform.find(',') + 1: transform.find(')')])
-        self.text = {} # This is a dictionary, whose keys are y coordinates and values are strings.
+        self.text = {} # This is a dictionary whose keys are y coordinates and values are strings.
                        # (text element text).
                        # Some hybrids require two lines of text, and SVG text elements do not
                        # wrap around, nor do they respect the newline character.

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -27,9 +27,9 @@ class Rect:
         self.text_y = float(self.y) + (float(height)/2)
         self.parent_transform_x = float(transform[transform.find('(') + 1: transform.find(',')])
         self.parent_transform_y = float(transform[transform.find(',') + 1: transform.find(')')])
-        self.text = '' # Text is set later.
-        self.extra_text = '' # Some hybrids require two lines of text, and SVG text elements do not
-                             # wrap around, nor do they respect the newline character.
+        self.text = [] # Text is set later.
+                       # Some hybrids require two lines of text, and SVG text elements do not
+                       # wrap around, nor do they respect the newline character.
         self.hybrid = hybrid
         self.colour = '#fff'
         self.class_ = 'hybrid' if self.hybrid else 'node'
@@ -43,15 +43,13 @@ class Rect:
         if self.hybrid:
             self.colour = "#bbb"
         prefix = ""
-        if self.text == '385' or self.text == '489':
-            prefix = 'ECE'
-        elif not self.text[0].isalpha():
+        if not self.text[0][0].isalpha():
             prefix = "CSC"
         if self.hybrid:
             prefix = "hCSC"
 
         #Figure out the research area
-        code = (prefix + self.text + self.extra_text)[:6]
+        code = (prefix + self.text[0] + (self.text[1] if len(self.text) > 1 else ""))[:6]
         self.area = 'core'
         for area, courses in AREAS.items():
             if code in courses:
@@ -62,29 +60,29 @@ class Rect:
         # line wrapping or newlines, so two text elements need to be created.
         # Since there are now two text elements fitting into the node, the y positions
         # of the text elements need to be recalculated to account for this.
-        if len(self.extra_text) == 0:
+        if len(self.text) == 1:
             text = ("             S.text_ " +
                    " ! A.x \"" + str(self.text_x) +
                    "\" ! A.y \"" + str(self.text_y) +
                    '" $ "' +
-                   self.text +
+                   self.text[0] +
                    '"')
         else:
             text = ("             S.text_ " +
                    " ! A.x \"" + str(self.text_x) +
                    "\" ! A.y \"" + str(self.text_y - float(self.height)/4) +
                    '" $ "' +
-                   self.text +
+                   self.text[0] +
                    '"\n'
                    "             S.text_ " +
                    " ! A.x \"" + str(self.text_x) +
                    "\" ! A.y \"" + str(self.text_y + float(self.height)/4) +
                    '" $ "' +
-                   self.extra_text +
+                   self.text[1] +
                    '"')
 
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
-              " ! A.id_ \"" + prefix + self.text + self.extra_text + "\""
+              " ! A.id_ \"" + prefix + self.text[0] + (self.text[1] if len(self.text) > 1 else "") + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
               " ! A.style \"" + "\" $ do \n"  +
               "             S.rect ! A.width \"" + self.width +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -45,10 +45,10 @@ class Rect:
         prefix = ""
         sorted_text = sorted(self.text.items()) 
 
-        if not sorted_text[0][1][0].isalpha():
-            prefix = "CSC"
         if self.hybrid:
             prefix = "hCSC"
+        elif not sorted_text[0][1][0].isalpha():
+            prefix = "CSC"
 
 
         # Figure out the research area
@@ -80,6 +80,7 @@ class Rect:
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
               " ! A.id_ \"" + code + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
+              " ! S.customAttribute \"text-rendering\" \"geometricPrecision\"" +
               " ! A.style \"" + "\" $ do \n"  +
               "             S.rect ! A.width \"" + self.width +
               "\" ! A.height \"" + self.height +
@@ -99,7 +100,7 @@ class Rect:
 			    -1 * offset <= dy <= float(self.height) + offset)
 
     def create_output_text(self, dict_entry):
-        y_pos = str(float(dict_entry[0]) + self.parent_transform_y - 4)
+        y_pos = str(float(dict_entry[0]) + self.parent_transform_y)
         text_fragment = dict_entry[1]
 
         return ("             S.text_ " +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -28,6 +28,8 @@ class Rect:
         self.parent_transform_x = float(transform[transform.find('(') + 1: transform.find(',')])
         self.parent_transform_y = float(transform[transform.find(',') + 1: transform.find(')')])
         self.text = '' # Text is set later.
+        self.extra_text = '' # Some hybrids require two lines of text, and SVG text elements do not
+                             # wrap around, nor do they respect the newline character.
         self.hybrid = hybrid
         self.colour = '#fff'
         self.class_ = 'hybrid' if self.hybrid else 'node'

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -35,7 +35,6 @@ class Rect:
                        # When a second text value for a node is seen, we want
                        # to be able to identify which text element goes above,
                        # and which goes below.
-                       # 
         self.hybrid = hybrid
         self.colour = '#fff'
         self.class_ = 'hybrid' if self.hybrid else 'node'
@@ -49,10 +48,9 @@ class Rect:
         if self.hybrid:
             prefix = "hCSC"
 
+        #Figure out the research area
         code = (prefix + self.text[sorted(self.text.keys())[0]] +
                (self.text[sorted(self.text.keys())[1]] if len(self.text) > 1 else ""))[:6]
-
-        #Figure out the research area
         self.area = 'core'
         for area, courses in AREAS.items():
             if code in courses:

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -43,14 +43,17 @@ class Rect:
         if self.hybrid:
             self.colour = "#bbb"
         prefix = ""
-        if not self.text[min(self.text.keys())][0].isalpha():
+        sorted_text = sorted(self.text.items()) 
+
+        if not sorted_text[0][1][0].isalpha():
             prefix = "CSC"
         if self.hybrid:
             prefix = "hCSC"
 
-        #Figure out the research area
-        code = (prefix + self.text[sorted(self.text.keys())[0]] +
-               (self.text[sorted(self.text.keys())[1]] if len(self.text) > 1 else ""))[:6]
+
+        # Figure out the research area
+        code = (prefix + sorted_text[0][1] +
+               (sorted_text[1][1] if len(self.text) > 1 else ""))[:6]
         self.area = 'core'
         for area, courses in AREAS.items():
             if code in courses:
@@ -66,25 +69,14 @@ class Rect:
                    " ! A.x \"" + str(self.text_x) +
                    "\" ! A.y \"" + str(self.text_y) +
                    '" $ "' +
-                   self.text[min(self.text.keys())] +
+                   sorted_text[0][1] +
                    '"')
         else:
-            text = ""
-            for t in range(len(self.text)):
-                d = {k:v for (k,v) in self.text.items() if v != None}
-                text_fragment = self.text[min(d.keys())]
-                offset = float(self.height)/(len(self.text)*2)
-                offset = -offset if t < len(self.text)/2 else offset
+            text = list(map(self.create_output_text, sorted_text))
+            text = "".join(text)
 
-                text +=  ("             S.text_ " +
-                         " ! A.x \"" + str(self.text_x) +
-                         "\" ! A.y \"" + str(self.text_y + offset) +
-                         '" $ "' +
-                         text_fragment +
-                         '"\n')
-
-                self.text[min(d.keys())] = None
-
+        # Some hybrids may have identical IDs. 
+        # This may cause problems when building the graph.
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
               " ! A.id_ \"" + code + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
@@ -105,3 +97,15 @@ class Rect:
         offset = 9
         return (-1 * offset <= dx <= float(self.width) + offset and
 			    -1 * offset <= dy <= float(self.height) + offset)
+
+    def create_output_text(self, dict_entry):
+        y_pos = str(float(dict_entry[0]) + self.parent_transform_y - 4)
+        text_fragment = dict_entry[1]
+
+        return ("             S.text_ " +
+                " ! A.x \"" + str(self.text_x) +
+                "\" ! A.y \"" + 
+                y_pos +
+                '" $ "' +
+                text_fragment +
+                '"\n')

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -99,7 +99,7 @@ class Rect:
 			    -1 * offset <= dy <= float(self.height) + offset)
 
     def create_output_text(self, dict_entry):
-        y_pos = str(float(dict_entry[0]) + self.parent_transform_y)
+        y_pos = str(float(dict_entry[0]) + self.parent_transform_y - 4)
         text_fragment = dict_entry[1]
 
         return ("             S.text_ " +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -50,10 +50,12 @@ class Rect:
         elif not sorted_text[0][1][0].isalpha():
             prefix = "CSC"
 
-
         # Figure out the research area
         code = (prefix + sorted_text[0][1] +
-               (sorted_text[1][1] if len(self.text) > 1 else ""))[:6]
+               (sorted_text[1][1] if len(self.text) > 1 else ""))
+        if prefix == "CSC":
+            code = code[:6]
+            
         self.area = 'core'
         for area, courses in AREAS.items():
             if code in courses:

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -46,7 +46,7 @@ class Rect:
             prefix = "hCSC"
 
         #Figure out the research area
-        code = (prefix + self.text)[:6]
+        code = (prefix + self.text + self.extra_text)[:6]
         self.area = 'core'
         for area, courses in AREAS.items():
             if code in courses:
@@ -77,7 +77,7 @@ class Rect:
                    '"')
 
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
-              " ! A.id_ \"" + prefix + self.text + "\""
+              " ! A.id_ \"" + prefix + self.text + self.extra_text + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
               " ! A.style \"" + "\" $ do \n"  +
               "             S.rect ! A.width \"" + self.width +

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -99,6 +99,10 @@ class Rect:
 			    -1 * offset <= dy <= float(self.height) + offset)
 
     def create_output_text(self, dict_entry):
+
+        # The Y coordinate of the text is identical to the input graph,
+        # but for some reason the 4 position needs an offest of 4 to display
+        # correctly with their parent rects.
         y_pos = str(float(dict_entry[0]) + self.parent_transform_y - 4)
         text_fragment = dict_entry[1]
 

--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -53,6 +53,29 @@ class Rect:
                 self.area = area
                 break
 
+        
+
+        if len(self.extra_text) == 0:
+            text = ("             S.text_ " +
+                   " ! A.x \"" + str(self.text_x) +
+                   "\" ! A.y \"" + str(self.text_y) +
+                   '" $ "' +
+                   self.text +
+                   '"')
+        else:
+            text = ("             S.text_ " +
+                   " ! A.x \"" + str(self.text_x) +
+                   "\" ! A.y \"" + str(self.text_y - float(self.height)/4) +
+                   '" $ "' +
+                   self.text +
+                   '"\n'
+                   "             S.text_ " +
+                   " ! A.x \"" + str(self.text_x) +
+                   "\" ! A.y \"" + str(self.text_y + float(self.height)/4) +
+                   '" $ "' +
+                   self.extra_text +
+                   '"')
+
         print("S.g ! A.class_ \"" + self.class_ + "\" " +
               " ! A.id_ \"" + prefix + self.text + "\""
               " ! S.dataAttribute \"group\" \"" + self.area + "\""
@@ -64,12 +87,8 @@ class Rect:
               "\" ! A.x \"" + str(self.x) +
               "\" ! A.y \"" + str(self.y) +
               "\" ! A.fill \"" + self.colour + "\" \n" +
-              "             S.text_ " +
-              " ! A.x \"" + str(self.text_x) +
-              "\" ! A.y \"" + str(self.text_y) +
-              '" $ "' +
-              self.text +
-              '"')
+              text
+              )
 
     def __contains__(self, coords):
         dx = float(coords[0]) - float(self.x) + (float(self.parent_transform_x) * coords[2]) # Coords[2] is 0 if translation should not be applied, 1 if it should. Very hacky.

--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -132,12 +132,7 @@ def process_text(elem):
     found = False
     for rect in rects:
         if (elem.get('x'), elem.get('y'), 1) in rect:
-            text = elem.text
-            if '/' in text:
-                text = text[:text.index('/')]
-            if "," in text:
-                text = text[:text.index(',')]
-            rect.text = text
+            rect.text = elem.text
             found = True
 
     for boolean in bools:

--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -134,9 +134,10 @@ def process_text(elem):
         if (elem.get('x'), elem.get('y'), 1) in rect:
             if len(rect.text) == 0:
                 rect.text = elem.text
+                rect.input_text_y = float(elem.get('y'))
             else:
-                if len(elem.text) > len(rect.text) or elem.text == "ECE":
-                    rect.extra_text = rect.text[:]
+                if float(elem.get('y')) < rect.input_text_y:
+                    rect.extra_text = elem.get('y')
                     rect.text = elem.text
                 else:
                     rect.extra_text = elem.text

--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -132,15 +132,7 @@ def process_text(elem):
     found = False
     for rect in rects:
         if (elem.get('x'), elem.get('y'), 1) in rect:
-            if len(rect.text) == 0:
-                rect.text.append(elem.text)
-                rect.input_text_y = float(elem.get('y'))
-            else:
-                if float(elem.get('y')) < rect.input_text_y:
-                    rect.text.append(rect.text[0])
-                    rect.text[0] = elem.text
-                else:
-                    rect.text.append(elem.text)
+            rect.text[elem.get('y')] = (elem.text)
             found = True
 
     for boolean in bools:

--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -133,14 +133,14 @@ def process_text(elem):
     for rect in rects:
         if (elem.get('x'), elem.get('y'), 1) in rect:
             if len(rect.text) == 0:
-                rect.text = elem.text
+                rect.text.append(elem.text)
                 rect.input_text_y = float(elem.get('y'))
             else:
                 if float(elem.get('y')) < rect.input_text_y:
-                    rect.extra_text = elem.get('y')
-                    rect.text = elem.text
+                    rect.text.append(rect.text[0])
+                    rect.text[0] = elem.text
                 else:
-                    rect.extra_text = elem.text
+                    rect.text.append(elem.text)
             found = True
 
     for boolean in bools:

--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -132,7 +132,14 @@ def process_text(elem):
     found = False
     for rect in rects:
         if (elem.get('x'), elem.get('y'), 1) in rect:
-            rect.text = elem.text
+            if len(rect.text) == 0:
+                rect.text = elem.text
+            else:
+                if len(elem.text) > len(rect.text) or elem.text == "ECE":
+                    rect.extra_text = rect.text[:]
+                    rect.text = elem.text
+                else:
+                    rect.extra_text = elem.text
             found = True
 
     for boolean in bools:


### PR DESCRIPTION
This pull request fixes issue #233, where some hybrid nodes would not show the entire prerequisite list for a course. This also adds in the ECE prefix for ECE courses.

The problem was that the parser was discarding any text after the first `,` or `/` it saw, and it would also only account for one text element. In the input graph, text elements spanning multiple lines are actually multiple text elements. This is fixed within the `Rect` object by converting `rect.text` to a list. The alternative was to store an extra variable (which I had initially called `extra_text` in some of the previous commits) that stores the second text element text. The original approach was bad for extensibility, it would be cumbersome to account for more than 2 text elements.

The text elements are also ordered based on their y position in the original graph, so a text element that appears above another in the original graph will appear above the other in SVGGen.hs (the output graph).

Note: Now that the ECE prefix is contained within the node, and the element IDs account for all node text, I have removed the ECE prefix addition on line 39 of `rect.py`.