### PR TITLE
Issue 214: 465 Displays Wrong Colour Fix

### DIFF
--- a/utilities/svg_parsing/rect.py
+++ b/utilities/svg_parsing/rect.py
@@ -4,7 +4,7 @@ AREAS = {
                'CSC463'],
     'core': ['CSC108', 'CSC148', 'CSC104', 'CSC120', 'CSC490',
              'CSC491', 'CSC494', 'CSC495'],
-    'se': ['CSC207', 'CSC301', 'CSC302', 'CSC410'],
+    'se': ['CSC207', 'CSC301', 'CSC302', 'CSC410', 'CSC465'],
     'systems': ['CSC209', 'CSC258', 'CSC358', 'CSC369', 'CSC372',
                 'CSC458', 'CSC469', 'CSC488', 'ECE385', 'ECE489'],
     'hci': ['CSC200', 'CSC300',  'CSC318', 'CSC404', 'CSC428',


### PR DESCRIPTION
This fixes Issue #214. Turns out CSC465 was not in the 'se' array in rect.py, so it was being interpreted as 'core'  when outputted to SVGGen.hs. 