### PR TITLE
Issue-241: CSS Error

### DIFF
--- a/utilities/svg_parsing/svg_parser.py
+++ b/utilities/svg_parsing/svg_parser.py
@@ -57,7 +57,7 @@ def output_svg():
     print("    S.defs $ do")
     print("        S.marker ! A.id_ \"arrow\" ! " +
           "A.viewbox \"0 0 10 10\" ! "
-          "A.refx \"1\" ! A.refy \"5\" ! A.markerunits \"strokewidth\" ! " +
+          "A.refx \"1\" ! A.refy \"5\" ! A.markerunits \"strokeWidth\" ! " +
           "A.orient \"auto\" ! A.markerwidth \"4.5\" ! A.markerheight \"4.5\" $ do"
     )
     print("            S.polyline ! A.points \"0,1 10,5 0,9\" ! A.fill \"black\"")


### PR DESCRIPTION
Resolved issue #241 : Unexpected value strokewidth parsing markerUnits attribute." It is unexpected because markerUnits expects "strokeWidth", not "strokewidth." Thanks for pointing me in the right direction, @Ian-Stewart-Binks.

setup.py should be run once again to reflect the changes in svg_parser.py.