### PR TITLE
Issue 243: Style, bool node opacity when inactive

### DIFF
--- a/hs/cssGen.hs
+++ b/hs/cssGen.hs
@@ -221,6 +221,7 @@ nodeCSS = "g" ? do
         "data-active" @= "inactive" & do
             "ellipse" <? do
                 fill lightGrey
+                faded
                 strokeDashed
         "data-active" @= "takeable" & do
             "ellipse" <? do


### PR DESCRIPTION
Fixed Issue #243: The boolean nodes had high opacity when they were not satisfied. To fix it I added the faded characteristic to the inactive bool nodes in cssGen.hs. setup.py should be run again in order to regenerate the css files. 