### PR TITLE
Add fb login button

### DIFF
--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -32,6 +32,7 @@ header page = createTag H.nav "" "row header" $ do
     H.li ! A.class_ "fb-login-button" 
          ! H.customAttribute "data-max-rows" "1" 
          ! H.customAttribute "data-size" "medium"
+         ! H.customAttribute "autologoutlink" "true"
          ! H.customAttribute "data-show-faces" "false"
          ! H.customAttribute "data-auto-logout-link" "false" $ ""
 

--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -29,6 +29,7 @@ header page = createTag H.nav "" "row header" $ do
     H.li $ makeA "" "" "grid" "" $ "Grid"
     H.li $ makeA "" "" "" "" $ "Check My POSt!"
     H.li $ makeA "" "" "about" "" $ "About"
+    H.li ! A.id "facebook-name" $ ""
     H.li ! A.class_ "fb-login-button" 
          ! H.customAttribute "data-max-rows" "1" 
          ! H.customAttribute "data-size" "medium"

--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -29,6 +29,11 @@ header page = createTag H.nav "" "row header" $ do
     H.li $ makeA "" "" "grid" "" $ "Grid"
     H.li $ makeA "" "" "" "" $ "Check My POSt!"
     H.li $ makeA "" "" "about" "" $ "About"
+    H.li ! A.class_ "fb-login-button" 
+         ! H.customAttribute "data-max-rows" "1" 
+         ! H.customAttribute "data-size" "medium"
+         ! H.customAttribute "data-show-faces" "false"
+         ! H.customAttribute "data-auto-logout-link" "false" $ ""
 
 -- Disclaimer. This will be the same for both pages, I guess?
 disclaimer :: H.Html

--- a/hs/Scripts.hs
+++ b/hs/Scripts.hs
@@ -16,6 +16,7 @@ plannerScripts = concatHtml (map makeScript["http://code.jquery.com/jquery-1.10.
                                            "static/js/graph/objects/edge.js",
                                            "static/js/graph/objects/node.js",
                                            "static/js/common/objects/course.js",
+                                           "static/js/common/facebook_login.js",
                                            "static/js/common/cookieHandler.js",
                                            "static/js/graph/tabs/setup_tabs.js",
                                            "static/js/graph/utilities/course_description.js",
@@ -44,4 +45,5 @@ timetableScripts = do jQuery
                                                 "static/js/grid/generate_grid.js",
                                                 "static/js/common/objects/course.js",
                                                 "static/js/common/objects/section.js",
+                                                "static/js/common/facebook_login.js",
                                                 "static/js/common/utilities/util.js"])

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -22,6 +22,17 @@ $(document).ready(function() {
             } else {
                 console.log('Not logged in.');
             }
+
+        
         });
+
+	    FB.Event.subscribe('auth.statusChange', function (response) {
+	        FB.getLoginStatus(function (response) {
+	            if (response.status !== 'connected') {
+	                $('#facebook-name').empty();
+	            }
+	        });
+	    });
+
     });
 });

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,4 +1,3 @@
-// Includes the Facebook JavaScript SDK
 $(document).ready(function() {
 	$.ajaxSetup({ cache: true });
 	$.getScript('//connect.facebook.net/en_UK/all.js', function() {
@@ -9,6 +8,7 @@ $(document).ready(function() {
 	        version    : 'v2.1'
 	    });
 
+	    // Add the user's name to the navigation bar.
 	    FB.getLoginStatus(function(response) {
 		    if (response.status === 'connected') {
 		        console.log('Logged in.');

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,24 +1,27 @@
 window.fbAsyncInit = function() {
-        FB.init({
-          appId      : '442286309258193',
-          xfbml      : true,
-          version    : 'v2.1'
-        });
-        FB.getLoginStatus(function(response) {
-		  if (response.status === 'connected') {
-		    console.log('Logged in.');
 
-		    console.log('Welcome!  Fetching your information.... ');
-		    FB.api('/me', function(response) {
-		      console.log('Successful login for: ' + response.name);
-		      document.getElementById('facebook-name').innerHTML = response.name;
-		    });
-		  }
-		  else {
-		    console.log('Logged in.');
-		  }
-		});
-      };
+    FB.init({
+        appId      : '442286309258193',
+        xfbml      : true,
+        version    : 'v2.1'
+    });
+
+    FB.getLoginStatus(function(response) {
+	    if (response.status === 'connected') {
+	        console.log('Logged in.');
+	        console.log('Welcome!  Fetching your information.... ');
+
+	        FB.api('/me', function(response) {
+	            console.log('Successful login for: ' + response.name);
+	            $('#facebook-name').html(response.name);
+	        });
+	        
+	    }
+	    else {
+	        console.log('Logged in.');
+	    }
+	});
+};
 
 // Includes the Facebook JavaScript SDK
 (function(d, s, id) {

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,27 +1,27 @@
 $(document).ready(function() {
-	$.ajaxSetup({ cache: true });
-	$.getScript('//connect.facebook.net/en_UK/all.js', function() {
+    $.ajaxSetup({ cache: true });
+    $.getScript('//connect.facebook.net/en_UK/all.js', function() {
 
-	    FB.init({
-	      appId: '442286309258193',
-	        xfbml      : true,
-	        version    : 'v2.1'
-	    });
+        FB.init({
+          appId: '442286309258193',
+            xfbml      : true,
+            version    : 'v2.1'
+        });
 
-	    FB.getLoginStatus(function (response) {
-		    if (response.status === 'connected') {
-		        console.log('Logged in.');
-		        console.log('Welcome!  Fetching your information.... ');
+        FB.getLoginStatus(function (response) {
+            if (response.status === 'connected') {
+                console.log('Logged in.');
+                console.log('Welcome!  Fetching your information.... ');
 
                 // Add the user's name to the navigation bar.
-		        FB.api('/me', function (response) {
-		            console.log('Successful login for: ' + response.name);
-		            $('#facebook-name').html(response.name);
-		        });
+                FB.api('/me', function (response) {
+                    console.log('Successful login for: ' + response.name);
+                    $('#facebook-name').html(response.name);
+                });
 
-		    } else {
-		        console.log('Not logged in.');
-		    }
-		});
-	});
+            } else {
+                console.log('Not logged in.');
+            }
+        });
+    });
 });

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -10,29 +10,39 @@ $(document).ready(function() {
 
         FB.getLoginStatus(function (response) {
             if (response.status === 'connected') {
-                console.log('Logged in.');
-                console.log('Welcome!  Fetching your information.... ');
-
-                // Add the user's name to the navigation bar.
-                FB.api('/me', function (response) {
-                    console.log('Successful login for: ' + response.name);
-                    $('#facebook-name').html(response.name);
-                });
-
-            } else {
-                console.log('Not logged in.');
+	            addNameToNavBar();
             }
-
         
         });
 
 	    FB.Event.subscribe('auth.statusChange', function (response) {
 	        FB.getLoginStatus(function (response) {
-	            if (response.status !== 'connected') {
-	                $('#facebook-name').empty();
+	            if (response.status === 'connected') {
+	                addNameToNavBar();
+	            } else {
+	            	removeNameFromNavBar();
 	            }
 	        });
 	    });
 
     });
 });
+
+
+/**
+ * Adds the user's name to the navigation bar.
+ */
+function addNameToNavBar() {
+	FB.api('/me', function (response) {
+        console.log('Successful login for: ' + response.name);
+        $('#facebook-name').html(response.name);
+    });
+}
+
+
+/**
+ * Removes the name from the navigation bar.
+ */
+function removeNameFromNavBar() {
+	$('#facebook-name').empty();
+}

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -8,13 +8,13 @@ $(document).ready(function() {
 	        version    : 'v2.1'
 	    });
 
-	    // Add the user's name to the navigation bar.
-	    FB.getLoginStatus(function(response) {
+	    FB.getLoginStatus(function (response) {
 		    if (response.status === 'connected') {
 		        console.log('Logged in.');
 		        console.log('Welcome!  Fetching your information.... ');
 
-		        FB.api('/me', function(response) {
+	            // Add the user's name to the navigation bar.
+		        FB.api('/me', function (response) {
 		            console.log('Successful login for: ' + response.name);
 		            $('#facebook-name').html(response.name);
 		        });

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
     $.getScript('//connect.facebook.net/en_UK/all.js', function() {
 
         FB.init({
-          appId: '442286309258193',
+            appId: '442286309258193',
             xfbml      : true,
             version    : 'v2.1'
         });

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -27,7 +27,6 @@ $(document).ready(function() {
  */
 function addNameToNavBar() {
     FB.api('/me', function (response) {
-        console.log('Successful login for: ' + response.name);
         $('#facebook-name').html(response.name);
     });
 }

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -10,20 +10,20 @@ $(document).ready(function() {
 
         FB.getLoginStatus(function (response) {
             if (response.status === 'connected') {
-	            addNameToNavBar();
+                addNameToNavBar();
             }
         
         });
 
-	    FB.Event.subscribe('auth.statusChange', function (response) {
-	        FB.getLoginStatus(function (response) {
-	            if (response.status === 'connected') {
-	                addNameToNavBar();
-	            } else {
-	            	removeNameFromNavBar();
-	            }
-	        });
-	    });
+        FB.Event.subscribe('auth.statusChange', function (response) {
+            FB.getLoginStatus(function (response) {
+                if (response.status === 'connected') {
+                    addNameToNavBar();
+                } else {
+                    removeNameFromNavBar();
+                }
+            });
+        });
 
     });
 });
@@ -33,7 +33,7 @@ $(document).ready(function() {
  * Adds the user's name to the navigation bar.
  */
 function addNameToNavBar() {
-	FB.api('/me', function (response) {
+    FB.api('/me', function (response) {
         console.log('Successful login for: ' + response.name);
         $('#facebook-name').html(response.name);
     });
@@ -44,5 +44,5 @@ function addNameToNavBar() {
  * Removes the name from the navigation bar.
  */
 function removeNameFromNavBar() {
-	$('#facebook-name').empty();
+    $('#facebook-name').empty();
 }

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,34 +1,27 @@
-window.fbAsyncInit = function() {
-
-    FB.init({
-        appId      : '442286309258193',
-        xfbml      : true,
-        version    : 'v2.1'
-    });
-
-    FB.getLoginStatus(function(response) {
-	    if (response.status === 'connected') {
-	        console.log('Logged in.');
-	        console.log('Welcome!  Fetching your information.... ');
-
-	        FB.api('/me', function(response) {
-	            console.log('Successful login for: ' + response.name);
-	            $('#facebook-name').html(response.name);
-	        });
-	        
-	    }
-	    else {
-	        console.log('Logged in.');
-	    }
-	});
-};
-
 // Includes the Facebook JavaScript SDK
-(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) return;
-  js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/sdk.js";
-  fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));
+$(document).ready(function() {
+	$.ajaxSetup({ cache: true });
+	$.getScript('//connect.facebook.net/en_UK/all.js', function() {
 
+	    FB.init({
+	      appId: '442286309258193',
+	        xfbml      : true,
+	        version    : 'v2.1'
+	    });
+
+	    FB.getLoginStatus(function(response) {
+		    if (response.status === 'connected') {
+		        console.log('Logged in.');
+		        console.log('Welcome!  Fetching your information.... ');
+
+		        FB.api('/me', function(response) {
+		            console.log('Successful login for: ' + response.name);
+		            $('#facebook-name').html(response.name);
+		        });
+
+		    } else {
+		        console.log('Not logged in.');
+		    }
+		});
+	});
+});

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,8 +1,31 @@
+window.fbAsyncInit = function() {
+        FB.init({
+          appId      : '442286309258193',
+          xfbml      : true,
+          version    : 'v2.1'
+        });
+        FB.getLoginStatus(function(response) {
+		  if (response.status === 'connected') {
+		    console.log('Logged in.');
+
+		    console.log('Welcome!  Fetching your information.... ');
+		    FB.api('/me', function(response) {
+		      console.log('Successful login for: ' + response.name);
+		      document.getElementById('facebook-name').innerHTML = response.name;
+		    });
+		  }
+		  else {
+		    console.log('Logged in.');
+		  }
+		});
+      };
+
 // Includes the Facebook JavaScript SDK
 (function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&appId=442286309258193&version=v2.0";
+  js.src = "//connect.facebook.net/en_US/sdk.js";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));
+

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -1,0 +1,8 @@
+// Includes the Facebook JavaScript SDK
+(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&appId=432140593606098&version=v2.0";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -3,6 +3,6 @@
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&appId=432140593606098&version=v2.0";
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&appId=442286309258193&version=v2.0";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -3,16 +3,9 @@ $(document).ready(function() {
     $.getScript('//connect.facebook.net/en_UK/all.js', function() {
 
         FB.init({
-            appId: '442286309258193',
+            appId      : '442286309258193',
             xfbml      : true,
             version    : 'v2.1'
-        });
-
-        FB.getLoginStatus(function (response) {
-            if (response.status === 'connected') {
-                addNameToNavBar();
-            }
-        
         });
 
         FB.Event.subscribe('auth.statusChange', function (response) {

--- a/js/common/facebook_login.js
+++ b/js/common/facebook_login.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
 		        console.log('Logged in.');
 		        console.log('Welcome!  Fetching your information.... ');
 
-	            // Add the user's name to the navigation bar.
+                // Add the user's name to the navigation bar.
 		        FB.api('/me', function (response) {
 		            console.log('Successful login for: ' + response.name);
 		            $('#facebook-name').html(response.name);


### PR DESCRIPTION
This pull request adds in the Facebook 'login' button. The button is added in `MasterTemplate.hs`, so it can be accessed in both the Grid and in the Graph.

When a user is logged in, there name is retrieved from Facebook and added to the navigation bar. This is just meant to be an exercise in using the API through JavaScript.

When a user is logged in, they then are given the option to 'log out'.

I have also been playing around with the `fb` Haskell bindings. I can't find a good way to implement the 'log in' button with `fb` yet, there might not be one. I am still playing around with it, though.

Please try this out on your own machine, and let me know if it works.

Note that the App ID is fine to publish on GitHub. The App Secret is what we need to lock up.