### PR TITLE
issue-217: Change opacity of regions to 0.7, add class for regions in pa...

### DIFF
--- a/hs/CssGen.hs
+++ b/hs/CssGen.hs
@@ -113,6 +113,7 @@ graphStyles = do
     titleCSS
     modalCSS
     regionCSS
+    regionLabelCSS
 
 alignCenter = textAlign $ alignSide sideCenter
 
@@ -302,10 +303,12 @@ titleCSS = "#svgTitle" ? do
     fontStyle italic
     fill titleColour
 
-
-regionCSS = ".region-label" ? do
+regionLabelCSS = ".region-label" ? do
     fontSize (em 0.65)
     "text-anchor" -: "start"
+
+regionCSS = ".region" ? do
+    opacity 0.7
 
 -- Course Modal
 modalColor = parse "#374AA1"

--- a/utilities/svg_parsing/region.py
+++ b/utilities/svg_parsing/region.py
@@ -6,7 +6,7 @@ class Region:
         self.style = style
 
     def output_haskell(self):
-        print('S.path ! A.style "' +
+        print('S.path ! A.class_ "region" ! A.style "' +
               self.style +
               '" ! A.d "' +
               self.d +


### PR DESCRIPTION
...rser.

I have changed the `opacity` of the regions to 0.7 and added in a `'region'` class in the parser.

The regions are still affected by the native graph's `fill-opacity`.

We should get Karen Reid's feedback, as she was the one who first suggested it.

Ref #217.