### PR TITLE
CSC465 missing from create-data.js fix

### DIFF
--- a/js/graph/create_data.js
+++ b/js/graph/create_data.js
@@ -10,7 +10,7 @@ var areas = {
                'CSC463'],
     'core': ['CSC108', 'CSC148', 'CSC104', 'CSC120', 'CSC490',
              'CSC491', 'CSC494', 'CSC495'],
-    'se': ['CSC207', 'CSC301', 'CSC302', 'CSC410'],
+    'se': ['CSC207', 'CSC301', 'CSC302', 'CSC410', 'CSC465'],
     'systems': ['CSC209', 'CSC258', 'CSC358', 'CSC369', 'CSC372',
                 'CSC458', 'CSC469', 'CSC488', 'ECE385', 'ECE489'],
     'hci': ['CSC200', 'CSC300',  'CSC318', 'CSC404', 'CSC428',


### PR DESCRIPTION
I noticed, while looking through the javascript files, that - just like in what I fixed for PR #250 - CSC465 was missing in the 'se' array in create-data.js. I've just added it back in as I did with the previously referenced pull request.