### PR TITLE
Fix for issue 217: Made region class in region.py and decreased opacity ...

### DIFF
--- a/hs/CssGen.hs
+++ b/hs/CssGen.hs
@@ -115,6 +115,7 @@ graphStyles = do
     titleCSS
     modalCSS
     regionCSS
+    regionShapeCSS
 
 alignCenter = textAlign $ alignSide sideCenter
 
@@ -308,6 +309,9 @@ titleCSS = "#svgTitle" ? do
 regionCSS = ".region-label" ? do
     fontSize (em 0.65)
     "text-anchor" -: "start"
+
+regionShapeCSS = ".region" ? do
+    faded
 
 -- Course Modal
 modalColor = parse "#374AA1"

--- a/utilities/svg_parsing/region.py
+++ b/utilities/svg_parsing/region.py
@@ -6,7 +6,8 @@ class Region:
         self.style = style
 
     def output_haskell(self):
-        print('S.path ! A.style "' +
+        print('S.path ! A.class_ "region"' +
+              ' ! A.style "' +
               self.style +
               '" ! A.d "' +
               self.d +


### PR DESCRIPTION
...in CssGen.hs

Fix for issue #217, added a class for regions in region.py (utilities/svg_parsing/region.py) and added a faded style for the region class in CssGen.hs.

This means that the setup.py must be executed again to regenerate the CSS files.

BEFORE: 
![image](https://cloud.githubusercontent.com/assets/9491656/5846310/b7f2e502-a190-11e4-94e2-d61f49deb781.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/9491656/5846340/e6b6e622-a190-11e4-974c-3c3a1169273f.png)

Due to this change, the colours of the nodes are more apparent and I am not sure if is a pleasant change for some of them (web and databases courses look orange, and numerical computing courses look grey).
