### PR TITLE
Issue 285: Parse About page from README.md

### DIFF
--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -26,4 +26,9 @@ aboutResponse aboutContents =
 -- | AboutHtml takes in the contents of the README.md file (the GitHub README file) and translates
 -- the markdown to blaze-HTML.
 aboutHtml :: String -> H.Html
-aboutHtml contents = H.div ! A.id "aboutDiv" $ writeHtml def $ readMarkdown def contents
+aboutHtml contents = H.div ! A.id "aboutDiv" $ mdToHTML contents
+
+-- | mdToHTML takes in the contents of a file written in Mark Down and converts it to 
+-- blaze-HTML.
+mdToHTML :: String -> H.Html
+mdToHTML contents = writeHtml def $ readMarkdown def contents

--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -23,5 +23,7 @@ aboutResponse aboutContents =
                 )
                 ""
 
+-- | AboutHtml takes in the contents of the README.md file (the GitHub README file) and translates
+-- the markdown to blaze-HTML.
 aboutHtml :: String -> H.Html
 aboutHtml contents = H.div ! A.id "aboutDiv" $ writeHtml def $ readMarkdown def $ contents

--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -24,4 +24,4 @@ aboutResponse aboutContents =
                 ""
 
 aboutHtml :: String -> H.Html
-aboutHtml contents = writeHtml def $ readMarkdown def $ contents
+aboutHtml contents = H.div ! A.id "aboutDiv" $ writeHtml def $ readMarkdown def $ contents

--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -6,7 +6,6 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 import Happstack.Server
 import MakeElements
-import Control.Monad.IO.Class  (liftIO)
 import Text.Pandoc
 import MasterTemplate
 
@@ -26,59 +25,3 @@ aboutResponse aboutContents =
 
 aboutHtml :: String -> H.Html
 aboutHtml contents = writeHtml def $ readMarkdown def $ contents
-
---aboutHtml :: H.Html
---aboutHtml = H.div ! A.id "aboutDiv" $ do
---  H.h1 "About Courseography"
---  H.p $ do
---    "Here at the University of Toronto, we have hundreds of courses to choose from, "
---    "and it can be hard to navigate prerequisite chains, program requirements, "
---    "and term-by-term offerings all at once. "
---    "That's where Courseography comes in: by presenting course and scheduling "
---    "information in a set of graphical interactive tools, "
---    H.strong "we make it easier to choose the right courses for your academic career"
---    ". Whether it's making sure you'll satisfy all the "
---    "prerequities for that 4th year course you really want to take, "
---    "or fitting together fragments of your schedule for next term, "
---    "we hope Courseography makes your life easier!"
---  H.p $ do
---    "Courseography was envisioned in late 2013 by "
---    H.a ! A.href "http://www.cs.toronto.edu/~liudavid/" $ "David Liu"
---    ", then a PhD student in the Department of Computer Science. "
---    "However, it wasn't until he recruited Ian Stewart-Binks to "
---    "the project that things really got rolling. Though the past year "
---    "has really seen our tools take off within the CS student body, "
---    "there's still a long way for us to go. Check out our "
---    H.a ! A.href "projects" $ "Projects"
---    " page to find out more about our plans for expanding to new "
---    H.strong "departments, faculties, and campuses"
---    ", and adding new services like "
---    H.strong "POSt checking"
---    " and "
---    H.strong "importing/exporting data"
---    "."
---  H.h2 "Get Involved"
---  H.p $ do
---    "One of our main goals for Courseography is to keep it a "
---    H.strong "student-driven project"
---    ". This means that if you want to get involved, you can! "
---    "The best way to get started is by "
---    H.a ! A.href "" $ "shooting us an email"
---    ", but you should also feel free to check out all of the source code"
---    " on "
---    H.a ! A.href "" $ "Github"
---    " and the accompanying "
---    H.a ! A.href "https://github.com/Courseography/courseography/wiki/Courseography-Projects" $ "Projects"
---    " page."
---  H.p $ do
---    "If you're coming from outside of the Department of Computer Science, "
---    "we'd love to hear from you! We welcome help on making new graphs, "
---    "understanding department- or program-specific policies, "
---    "pointing out bugs or incorrect information, "
---    "and general thoughts on the design of our tools. "
---    H.strong "You don't need to be a programmer to get involved."
---  H.p $ do
---    "We can be reached at "
---    H.a ! A.href "mailto:courseography@cs.toronto.edu" ! A.target "_blank"
---        $ "courseography@cs.toronto.edu"
---    ", and look forward to hearing from you!"

--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -26,4 +26,4 @@ aboutResponse aboutContents =
 -- | AboutHtml takes in the contents of the README.md file (the GitHub README file) and translates
 -- the markdown to blaze-HTML.
 aboutHtml :: String -> H.Html
-aboutHtml contents = H.div ! A.id "aboutDiv" $ writeHtml def $ readMarkdown def $ contents
+aboutHtml contents = H.div ! A.id "aboutDiv" $ writeHtml def $ readMarkdown def contents

--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -6,10 +6,12 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 import Happstack.Server
 import MakeElements
+import Control.Monad.IO.Class  (liftIO)
+import Text.Pandoc
 import MasterTemplate
 
-aboutResponse :: ServerPart Response
-aboutResponse =
+aboutResponse :: String -> ServerPart Response
+aboutResponse aboutContents =
    ok $ toResponse $
     masterTemplate "Courseography - SVG serving test!"
                 [H.meta ! A.name "keywords"
@@ -18,63 +20,65 @@ aboutResponse =
                 ]
                 (do
                     header "about"
-                    aboutHtml
+                    aboutHtml aboutContents
                 )
                 ""
 
+aboutHtml :: String -> H.Html
+aboutHtml contents = writeHtml def $ readMarkdown def $ contents
 
-aboutHtml :: H.Html
-aboutHtml = H.div ! A.id "aboutDiv" $ do
-  H.h1 "About Courseography"
-  H.p $ do
-    "Here at the University of Toronto, we have hundreds of courses to choose from, "
-    "and it can be hard to navigate prerequisite chains, program requirements, "
-    "and term-by-term offerings all at once. "
-    "That's where Courseography comes in: by presenting course and scheduling "
-    "information in a set of graphical interactive tools, "
-    H.strong "we make it easier to choose the right courses for your academic career"
-    ". Whether it's making sure you'll satisfy all the "
-    "prerequities for that 4th year course you really want to take, "
-    "or fitting together fragments of your schedule for next term, "
-    "we hope Courseography makes your life easier!"
-  H.p $ do
-    "Courseography was envisioned in late 2013 by "
-    H.a ! A.href "http://www.cs.toronto.edu/~liudavid/" $ "David Liu"
-    ", then a PhD student in the Department of Computer Science. "
-    "However, it wasn't until he recruited Ian Stewart-Binks to "
-    "the project that things really got rolling. Though the past year "
-    "has really seen our tools take off within the CS student body, "
-    "there's still a long way for us to go. Check out our "
-    H.a ! A.href "projects" $ "Projects"
-    " page to find out more about our plans for expanding to new "
-    H.strong "departments, faculties, and campuses"
-    ", and adding new services like "
-    H.strong "POSt checking"
-    " and "
-    H.strong "importing/exporting data"
-    "."
-  H.h2 "Get Involved"
-  H.p $ do
-    "One of our main goals for Courseography is to keep it a "
-    H.strong "student-driven project"
-    ". This means that if you want to get involved, you can! "
-    "The best way to get started is by "
-    H.a ! A.href "" $ "shooting us an email"
-    ", but you should also feel free to check out all of the source code"
-    " on "
-    H.a ! A.href "" $ "Github"
-    " and the accompanying "
-    H.a ! A.href "https://github.com/Courseography/courseography/wiki/Courseography-Projects" $ "Projects"
-    " page."
-  H.p $ do
-    "If you're coming from outside of the Department of Computer Science, "
-    "we'd love to hear from you! We welcome help on making new graphs, "
-    "understanding department- or program-specific policies, "
-    "pointing out bugs or incorrect information, "
-    "and general thoughts on the design of our tools. "
-    H.strong "You don't need to be a programmer to get involved."
-  H.p $ do
-    "We can be reached at "
-    H.a ! A.href "mailto:courseography@cs.toronto.edu" ! A.target "_blank"
-        $ "courseography@cs.toronto.edu"
-    ", and look forward to hearing from you!"
+--aboutHtml :: H.Html
+--aboutHtml = H.div ! A.id "aboutDiv" $ do
+--  H.h1 "About Courseography"
+--  H.p $ do
+--    "Here at the University of Toronto, we have hundreds of courses to choose from, "
+--    "and it can be hard to navigate prerequisite chains, program requirements, "
+--    "and term-by-term offerings all at once. "
+--    "That's where Courseography comes in: by presenting course and scheduling "
+--    "information in a set of graphical interactive tools, "
+--    H.strong "we make it easier to choose the right courses for your academic career"
+--    ". Whether it's making sure you'll satisfy all the "
+--    "prerequities for that 4th year course you really want to take, "
+--    "or fitting together fragments of your schedule for next term, "
+--    "we hope Courseography makes your life easier!"
+--  H.p $ do
+--    "Courseography was envisioned in late 2013 by "
+--    H.a ! A.href "http://www.cs.toronto.edu/~liudavid/" $ "David Liu"
+--    ", then a PhD student in the Department of Computer Science. "
+--    "However, it wasn't until he recruited Ian Stewart-Binks to "
+--    "the project that things really got rolling. Though the past year "
+--    "has really seen our tools take off within the CS student body, "
+--    "there's still a long way for us to go. Check out our "
+--    H.a ! A.href "projects" $ "Projects"
+--    " page to find out more about our plans for expanding to new "
+--    H.strong "departments, faculties, and campuses"
+--    ", and adding new services like "
+--    H.strong "POSt checking"
+--    " and "
+--    H.strong "importing/exporting data"
+--    "."
+--  H.h2 "Get Involved"
+--  H.p $ do
+--    "One of our main goals for Courseography is to keep it a "
+--    H.strong "student-driven project"
+--    ". This means that if you want to get involved, you can! "
+--    "The best way to get started is by "
+--    H.a ! A.href "" $ "shooting us an email"
+--    ", but you should also feel free to check out all of the source code"
+--    " on "
+--    H.a ! A.href "" $ "Github"
+--    " and the accompanying "
+--    H.a ! A.href "https://github.com/Courseography/courseography/wiki/Courseography-Projects" $ "Projects"
+--    " page."
+--  H.p $ do
+--    "If you're coming from outside of the Department of Computer Science, "
+--    "we'd love to hear from you! We welcome help on making new graphs, "
+--    "understanding department- or program-specific policies, "
+--    "pointing out bugs or incorrect information, "
+--    "and general thoughts on the design of our tools. "
+--    H.strong "You don't need to be a programmer to get involved."
+--  H.p $ do
+--    "We can be reached at "
+--    H.a ! A.href "mailto:courseography@cs.toronto.edu" ! A.target "_blank"
+--        $ "courseography@cs.toronto.edu"
+--    ", and look forward to hearing from you!"

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -42,10 +42,11 @@ main = do
     generateCSS
     cwd <- getCurrentDirectory
     let staticDir = encodeString $ parent $ decodeString cwd
+    contents <- readFile "../README.md"
     simpleHTTP nullConf $
       msum [ dir grid $ gridResponse,
              dir graph $ graphResponse,
-             dir about $ aboutResponse,
+             dir about $ aboutResponse contents,
              dir static $ serveDirectory EnableBrowsing [] staticDir,
              dir course $ path (\s -> liftIO $ queryCourse s)
            ]


### PR DESCRIPTION
This pull request reads in the README.md file, uses Pandoc to convert the content from Markdown to Blaze HTML and adds the result to AboutResponse.hs.

Fixes: #285