### PR TITLE
AboutResponse.hs wrong title fix

### DIFF
--- a/hs/AboutResponse.hs
+++ b/hs/AboutResponse.hs
@@ -11,7 +11,7 @@ import MasterTemplate
 aboutResponse :: ServerPart Response
 aboutResponse =
    ok $ toResponse $
-    masterTemplate "Courseography - SVG serving test!"
+    masterTemplate "Courseography - About"
                 [H.meta ! A.name "keywords"
                         ! A.content "",
                  aboutLinks


### PR DESCRIPTION
Related to Issue #213, this Pull Request just changes the title of the About page from "SVG Serving Test!" to "Courseography - About".