### PR TITLE
Timetable - Hide half hours and non-mainstream hours

### DIFF
--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -109,7 +109,7 @@ function appendTableRows(timetableTableFall, timetableTableSpring) {
 function appendTableData(trFall, trSpring, time) {
     'use strict';
 
-    var weekPrefixArray = ["M", "T", "W", "R", "F"];
+    var weekPrefixArray = ['M', 'T', 'W', 'R', 'F'];
 
     if (time % 1 === 0) {
         var adjustedTime = (time === 12 ? 12 : time % 12) + ':00';
@@ -118,12 +118,12 @@ function appendTableData(trFall, trSpring, time) {
     }
 
     if (time < 9 || time >= 17) {
-        trFall.append($("<td></td>")
-            .attr("hidden", "true")
-            .addClass("timetable-time")
+        trFall.append($('<td></td>')
+            .attr('hidden', 'true')
+            .addClass('timetable-time')
             .html(adjustedTime));
     } else {
-        trFall.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
+        trFall.append($('<td></td>').addClass('timetable-time').html(adjustedTime));
     }
 
     if (time % 1 === 0) {
@@ -131,34 +131,34 @@ function appendTableData(trFall, trSpring, time) {
         for (var k = 0; k < 5; k++) {
 
             if (time < 9 || time >= 17) {
-                trFall.append($("<td></td>")
-                    .attr("id", weekPrefixArray[k] + time + "F")
+                trFall.append($('<td></td>')
+                    .attr('id', weekPrefixArray[k] + time + 'F')
                     .attr('in-conflict', 'false')
-                    .attr("satisfied", "true")
-                    .attr("rowspan", "2")
-                    .attr("hidden", "true")
-                    .addClass("timetable-cell"));
-                trSpring.append($("<td></td>")
-                    .attr("id", weekPrefixArray[k] + time + "S")
+                    .attr('satisfied', 'true')
+                    .attr('rowspan', '2')
+                    .attr('hidden', 'true')
+                    .addClass('timetable-cell'));
+                trSpring.append($('<td></td>')
+                    .attr('id', weekPrefixArray[k] + time + 'S')
                     .attr('in-conflict', 'false')
-                    .attr("satisfied", "true")
-                    .attr("rowspan", "2")
-                    .attr("hidden", "true")
-                    .addClass("timetable-cell"));
+                    .attr('satisfied', 'true')
+                    .attr('rowspan', '2')
+                    .attr('hidden', 'true')
+                    .addClass('timetable-cell'));
 
             } else {
-                trFall.append($("<td></td>")
-                    .attr("id", weekPrefixArray[k] + time + "F")
+                trFall.append($('<td></td>')
+                    .attr('id', weekPrefixArray[k] + time + 'F')
                     .attr('in-conflict', 'false')
-                    .attr("satisfied", "true")
-                    .attr("rowspan", "2")
-                    .addClass("timetable-cell"));
-                trSpring.append($("<td></td>")
-                    .attr("id", weekPrefixArray[k] + time + "S")
+                    .attr('satisfied', 'true')
+                    .attr('rowspan', '2')
+                    .addClass('timetable-cell'));
+                trSpring.append($('<td></td>')
+                    .attr('id', weekPrefixArray[k] + time + 'S')
                     .attr('in-conflict', 'false')
-                    .attr("satisfied", "true")
-                    .attr("rowspan", "2")
-                    .addClass("timetable-cell"));
+                    .attr('satisfied', 'true')
+                    .attr('rowspan', '2')
+                    .addClass('timetable-cell'));
             }
 
         }
@@ -166,29 +166,29 @@ function appendTableData(trFall, trSpring, time) {
     } else {
 
         for (var k = 0; k < 5; k++) {
-            trFall.append($("<td></td>")
-                .attr("id", weekPrefixArray[k] + time + "F")
+            trFall.append($('<td></td>')
+                .attr('id', weekPrefixArray[k] + time + 'F')
                 .attr('in-conflict', 'false')
-                .attr("satisfied", "true")
-                .attr("hidden", "true")
-                .addClass("timetable-cell"));
-            trSpring.append($("<td></td>")
-                .attr("id", weekPrefixArray[k] + time + "S")
+                .attr('satisfied', 'true')
+                .attr('hidden', 'true')
+                .addClass('timetable-cell'));
+            trSpring.append($('<td></td>')
+                .attr('id', weekPrefixArray[k] + time + 'S')
                 .attr('in-conflict', 'false')
-                .attr("satisfied", "true")
-                .attr("hidden", "true")
-                .addClass("timetable-cell"));
+                .attr('satisfied', 'true')
+                .attr('hidden', 'true')
+                .addClass('timetable-cell'));
         }
         
     }
 
     if (time < 9 || time >= 17) {
-        trSpring.append($("<td></td>")
-            .attr("hidden", "true")
-            .addClass("timetable-time")
+        trSpring.append($('<td></td>')
+            .attr('hidden', 'true')
+            .addClass('timetable-time')
             .html(adjustedTime));
     } else {
-        trSpring.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
+        trSpring.append($('<td></td>').addClass('timetable-time').html(adjustedTime));
     }
     
 }

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -113,57 +113,39 @@ function appendTableData(trFall, trSpring, time) {
 
     if (time % 1 === 0) {
         var adjustedTime = (time === 12 ? 12 : time % 12) + ':00';
+        
+        trFall.append($('<td></td>')
+           .attr('rowspan', '2')
+           .addClass('timetable-time')
+           .html(adjustedTime));
+
+        for (var k = 0; k < 5; k++) {
+            trFall.append($('<td></td>')
+                .attr('id', weekPrefixArray[k] + time + 'F')
+                .attr('in-conflict', 'false')
+                .attr('satisfied', 'true')
+                .attr('rowspan', '2')
+                .addClass('timetable-cell'));
+            trSpring.append($('<td></td>')
+                .attr('id', weekPrefixArray[k] + time + 'S')
+                .attr('in-conflict', 'false')
+                .attr('satisfied', 'true')
+                .attr('rowspan', '2')
+                .addClass('timetable-cell'));
+        }
+        
+        trSpring.append($('<td></td>')
+            .attr('rowspan', '2')
+            .addClass('timetable-time')
+            .html(adjustedTime));
+
     } else {
         var adjustedTime = '';
-    }
 
-    if (time < 9 || time >= 17) {
         trFall.append($('<td></td>')
             .attr('hidden', 'true')
             .addClass('timetable-time')
             .html(adjustedTime));
-    } else {
-        trFall.append($('<td></td>').addClass('timetable-time').html(adjustedTime));
-    }
-
-    if (time % 1 === 0) {
-
-        for (var k = 0; k < 5; k++) {
-
-            if (time < 9 || time >= 17) {
-                trFall.append($('<td></td>')
-                    .attr('id', weekPrefixArray[k] + time + 'F')
-                    .attr('in-conflict', 'false')
-                    .attr('satisfied', 'true')
-                    .attr('rowspan', '2')
-                    .attr('hidden', 'true')
-                    .addClass('timetable-cell'));
-                trSpring.append($('<td></td>')
-                    .attr('id', weekPrefixArray[k] + time + 'S')
-                    .attr('in-conflict', 'false')
-                    .attr('satisfied', 'true')
-                    .attr('rowspan', '2')
-                    .attr('hidden', 'true')
-                    .addClass('timetable-cell'));
-
-            } else {
-                trFall.append($('<td></td>')
-                    .attr('id', weekPrefixArray[k] + time + 'F')
-                    .attr('in-conflict', 'false')
-                    .attr('satisfied', 'true')
-                    .attr('rowspan', '2')
-                    .addClass('timetable-cell'));
-                trSpring.append($('<td></td>')
-                    .attr('id', weekPrefixArray[k] + time + 'S')
-                    .attr('in-conflict', 'false')
-                    .attr('satisfied', 'true')
-                    .attr('rowspan', '2')
-                    .addClass('timetable-cell'));
-            }
-
-        }
-
-    } else {
 
         for (var k = 0; k < 5; k++) {
             trFall.append($('<td></td>')
@@ -180,15 +162,11 @@ function appendTableData(trFall, trSpring, time) {
                 .addClass('timetable-cell'));
         }
         
-    }
-
-    if (time < 9 || time >= 17) {
         trSpring.append($('<td></td>')
             .attr('hidden', 'true')
             .addClass('timetable-time')
             .html(adjustedTime));
-    } else {
-        trSpring.append($('<td></td>').addClass('timetable-time').html(adjustedTime));
+        
     }
-    
+
 }

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -124,12 +124,6 @@ function appendTableData(trFall, trSpring, time) {
             .attr("id", weekPrefixArray[k] + time + "F")
             .attr('in-conflict', 'false')
             .attr("satisfied", "true")
-            if (adjustedTime === '') {
-                .attr("hidden", "true")
-            } else {
-                .attr("rowspan", "2")
-                .attr("hidden", "false")
-            }
             .addClass("timetable-cell"));
         trSpring.append($("<td></td>")
             .attr("id", weekPrefixArray[k] + time + "S")

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -124,11 +124,21 @@ function appendTableData(trFall, trSpring, time) {
             .attr("id", weekPrefixArray[k] + time + "F")
             .attr('in-conflict', 'false')
             .attr("satisfied", "true")
+            if (adjustedTime === '') {
+                .attr("hidden", "hidden")
+            } else {
+                .attr("rowspan", "2")
+            }
             .addClass("timetable-cell"));
         trSpring.append($("<td></td>")
             .attr("id", weekPrefixArray[k] + time + "S")
             .attr('in-conflict', 'false')
             .attr("satisfied", "true")
+            if (adjustedTime === '') {
+                .attr("hidden", "hidden")
+            } else {
+                .attr("rowspan", "2")
+            }
             .addClass("timetable-cell"));
     }
 

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -117,20 +117,78 @@ function appendTableData(trFall, trSpring, time) {
         var adjustedTime = '';
     }
 
-    trFall.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
-
-    for (var k = 0; k < 5; k++) {
+    if (time < 9 || time >= 17) {
         trFall.append($("<td></td>")
-            .attr("id", weekPrefixArray[k] + time + "F")
-            .attr('in-conflict', 'false')
-            .attr("satisfied", "true")
-            .addClass("timetable-cell"));
-        trSpring.append($("<td></td>")
-            .attr("id", weekPrefixArray[k] + time + "S")
-            .attr('in-conflict', 'false')
-            .attr("satisfied", "true")
-            .addClass("timetable-cell"));
+            .attr("hidden", "true")
+            .addClass("timetable-time")
+            .html(adjustedTime));
+    } else {
+        trFall.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
     }
 
-    trSpring.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
+    if (time % 1 === 0) {
+
+        for (var k = 0; k < 5; k++) {
+
+            if (time < 9 || time >= 17) {
+                trFall.append($("<td></td>")
+                    .attr("id", weekPrefixArray[k] + time + "F")
+                    .attr('in-conflict', 'false')
+                    .attr("satisfied", "true")
+                    .attr("rowspan", "2")
+                    .attr("hidden", "true")
+                    .addClass("timetable-cell"));
+                trSpring.append($("<td></td>")
+                    .attr("id", weekPrefixArray[k] + time + "S")
+                    .attr('in-conflict', 'false')
+                    .attr("satisfied", "true")
+                    .attr("rowspan", "2")
+                    .attr("hidden", "true")
+                    .addClass("timetable-cell"));
+
+            } else {
+                trFall.append($("<td></td>")
+                    .attr("id", weekPrefixArray[k] + time + "F")
+                    .attr('in-conflict', 'false')
+                    .attr("satisfied", "true")
+                    .attr("rowspan", "2")
+                    .addClass("timetable-cell"));
+                trSpring.append($("<td></td>")
+                    .attr("id", weekPrefixArray[k] + time + "S")
+                    .attr('in-conflict', 'false')
+                    .attr("satisfied", "true")
+                    .attr("rowspan", "2")
+                    .addClass("timetable-cell"));
+            }
+
+        }
+
+    } else {
+
+        for (var k = 0; k < 5; k++) {
+            trFall.append($("<td></td>")
+                .attr("id", weekPrefixArray[k] + time + "F")
+                .attr('in-conflict', 'false')
+                .attr("satisfied", "true")
+                .attr("hidden", "true")
+                .addClass("timetable-cell"));
+            trSpring.append($("<td></td>")
+                .attr("id", weekPrefixArray[k] + time + "S")
+                .attr('in-conflict', 'false')
+                .attr("satisfied", "true")
+                .attr("hidden", "true")
+                .addClass("timetable-cell"));
+        }
+        
+    }
+
+    if (time < 9 || time >= 17) {
+        trSpring.append($("<td></td>")
+            .attr("hidden", "true")
+            .addClass("timetable-time")
+            .html(adjustedTime));
+    } else {
+        trSpring.append($("<td></td>").addClass("timetable-time").html(adjustedTime));
+    }
+    
 }

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -125,20 +125,16 @@ function appendTableData(trFall, trSpring, time) {
             .attr('in-conflict', 'false')
             .attr("satisfied", "true")
             if (adjustedTime === '') {
-                .attr("hidden", "hidden")
+                .attr("hidden", "true")
             } else {
                 .attr("rowspan", "2")
+                .attr("hidden", "false")
             }
             .addClass("timetable-cell"));
         trSpring.append($("<td></td>")
             .attr("id", weekPrefixArray[k] + time + "S")
             .attr('in-conflict', 'false')
             .attr("satisfied", "true")
-            if (adjustedTime === '') {
-                .attr("hidden", "hidden")
-            } else {
-                .attr("rowspan", "2")
-            }
             .addClass("timetable-cell"));
     }
 


### PR DESCRIPTION
Updated generate_grid so that now all of the full hour time blocks have row span of 2, and all of the half hour blocks are created but set to hidden.

Also took Ian's suggestion to make the time slots after 5pm hidden initially, and also the 8am time slot.

The only problem is that I don't know how to change the "hidden" attribute, setting it to "false" doesn't seem to do anything...