### PR TITLE
Issue 290: Change course names

### DIFF
--- a/js/common/objects/section.js
+++ b/js/common/objects/section.js
@@ -9,7 +9,7 @@ function Section(times, course, id) {
     'use strict';
 
     this.id = id;
-    this.courseName = this.id.substring(0, 8);
+    this.courseName = this.id.substring(0, 6);
     this.name = this.id.substring(9, 14);
     this.session = this.id.substring(15, 16);
     this.type = this.name.charAt(0);

--- a/js/common/objects/section.js
+++ b/js/common/objects/section.js
@@ -11,7 +11,7 @@ function Section(times, course, id) {
     this.id = id;
     this.name = this.id.substring(9, 14);
     this.type = this.name.charAt(0);
-    this.courseName = this.id.substring(0, 6) + " (" + this.type + ")";
+    this.courseName = this.id.substring(0, 6) + ' (' + this.type + ')';
     this.session = this.id.substring(15, 16);
     this.course = course;
     this.times = times;

--- a/js/common/objects/section.js
+++ b/js/common/objects/section.js
@@ -9,10 +9,10 @@ function Section(times, course, id) {
     'use strict';
 
     this.id = id;
-    this.courseName = this.id.substring(0, 6);
     this.name = this.id.substring(9, 14);
-    this.session = this.id.substring(15, 16);
     this.type = this.name.charAt(0);
+    this.courseName = this.id.substring(0, 6) + " (" + this.type + ")";
+    this.session = this.id.substring(15, 16);
     this.course = course;
     this.times = times;
     this.clicked = false;

--- a/js/common/objects/section.js
+++ b/js/common/objects/section.js
@@ -101,7 +101,7 @@ Section.prototype.onclick = function () {
 Section.prototype.setTime = function (time) {
     'use strict';
 
-    $(time).html(this.courseName.substring(0,6) + ' (' + this.type + ')')
+    $(time).html(this.courseName.substring(0, 6) + ' (' + this.type + ')')
            .attr("clicked", "true")
            .attr("type", this.type);
 };

--- a/js/common/objects/section.js
+++ b/js/common/objects/section.js
@@ -11,7 +11,7 @@ function Section(times, course, id) {
     this.id = id;
     this.name = this.id.substring(9, 14);
     this.type = this.name.charAt(0);
-    this.courseName = this.id.substring(0, 6) + ' (' + this.type + ')';
+    this.courseName = this.id.substring(0, 8);
     this.session = this.id.substring(15, 16);
     this.course = course;
     this.times = times;
@@ -101,7 +101,7 @@ Section.prototype.onclick = function () {
 Section.prototype.setTime = function (time) {
     'use strict';
 
-    $(time).html(this.courseName)
+    $(time).html(this.courseName.substring(0,6) + ' (' + this.type + ')')
            .attr("clicked", "true")
            .attr("type", this.type);
 };

--- a/js/grid/mouse_events.js
+++ b/js/grid/mouse_events.js
@@ -119,7 +119,7 @@ function renderAddHover(time, section) {
     'use strict';
 
     if ($(time).attr('clicked') !== 'true') {
-        $(time).html(section.courseName)
+        $(time).html(section.courseName.substring(0,6) + ' (' + section.type + ')')
                .attr('hover', 'good');
     } else if ($(time).html() === section.courseName &&
                $(time).attr('type') === section.type) {


### PR DESCRIPTION
This fixes Issue #290. Courses now display on the table without 'H1' at the end, and it displays in brackets the type of section it is - (L), (T), or (P).