### PR TITLE
When links in the navbar are hovered over, they change colour to gray.

### DIFF
--- a/hs/CssGen.hs
+++ b/hs/CssGen.hs
@@ -77,8 +77,8 @@ headerCSS = do
                 padding 0 (px 10) 0 (px 10)
                 a <? do
                     color white
-                a # hover <? do
-                    color gray
+                    hover & do
+                        color gray
 
 aDefaultCSS = do
     a <> a # hover <> a # visited <> a # active ? do

--- a/hs/CssGen.hs
+++ b/hs/CssGen.hs
@@ -59,7 +59,6 @@ headerCSS = do
            color white
            h2 ?
              do fontSize $ em 1.6
-                fontWeight bold
                 textAlign $ alignSide sideLeft
                 width $ px 200
                 display inlineBlock
@@ -78,6 +77,8 @@ headerCSS = do
                 padding 0 (px 10) 0 (px 10)
                 a <? do
                     color white
+                a # hover <? do
+                    color gray
 
 aDefaultCSS = do
     a <> a # hover <> a # visited <> a # active ? do


### PR DESCRIPTION
This addresses #316. I've added to CssGen.hs. Now, when links are hovered over, they turn gray. Not particularly exciting, but it certainly looks nice.

Also, "Courseography" in the navbar is no longer bold.