### PR TITLE
Facebook: Cleanup & convert SVG to PNG

### DIFF
--- a/hs/ConvertSVGToPNG.hs
+++ b/hs/ConvertSVGToPNG.hs
@@ -13,7 +13,7 @@ convertSVGToPNG :: String -> String -> IO
                       ProcessHandle)
 
 convertSVGToPNG inName outName = createProcess $ CreateProcess
-                                  (ShellCommand $ "convert ../res/graphs/graph_regions.svg graph.png"
+                                  (ShellCommand $ "convert ../res/graphs/graph_regions.svg INSERT_ID-graph.png"
                                    )
                                   Nothing
                                   Nothing

--- a/hs/ConvertSVGToPNG.hs
+++ b/hs/ConvertSVGToPNG.hs
@@ -1,0 +1,20 @@
+module ConvertSVGToPNG where
+
+import System.Process
+import GHC.IO.Handle.Types
+
+convertSVGToPNG :: IO
+                     (Maybe Handle,
+                      Maybe Handle,
+                      Maybe Handle,
+                      ProcessHandle)
+
+convertSVGToPNG = createProcess $ CreateProcess
+                                  (ShellCommand "inkscape -z -e test.png -w 1024 -h 1024 ../res/graphs/graph_regions.svg")
+                                  Nothing
+                                  Nothing
+                                  Inherit
+                                  Inherit
+                                  Inherit
+                                  False
+                                  False

--- a/hs/ConvertSVGToPNG.hs
+++ b/hs/ConvertSVGToPNG.hs
@@ -23,6 +23,7 @@ convertSVGToPNG inName outName = createProcess $ CreateProcess
                                   CreatePipe
                                   False
                                   False
+                                  False
 -- | Removes a file.
 removePNG :: String -> IO
                      (Maybe Handle,
@@ -37,6 +38,7 @@ removePNG name = createProcess $ CreateProcess
                                   Inherit
                                   CreatePipe
                                   CreatePipe
+                                  False
                                   False
                                   False
 

--- a/hs/ConvertSVGToPNG.hs
+++ b/hs/ConvertSVGToPNG.hs
@@ -3,14 +3,32 @@ module ConvertSVGToPNG where
 import System.Process
 import GHC.IO.Handle.Types
 
-convertSVGToPNG :: IO
+convertSVGToPNG :: String -> String -> IO
                      (Maybe Handle,
                       Maybe Handle,
                       Maybe Handle,
                       ProcessHandle)
 
-convertSVGToPNG = createProcess $ CreateProcess
-                                  (ShellCommand "inkscape -z -e test.png -w 1024 -h 1024 ../res/graphs/graph_regions.svg")
+convertSVGToPNG inName outName = createProcess $ CreateProcess
+                                  (ShellCommand $ "inkscape -z -e " ++
+                                   inName ++
+                                   " -w 1024 -h 1024 " ++
+                                   outName)
+                                  Nothing
+                                  Nothing
+                                  Inherit
+                                  Inherit
+                                  Inherit
+                                  False
+                                  False
+removePNG :: String -> IO
+                     (Maybe Handle,
+                      Maybe Handle,
+                      Maybe Handle,
+                      ProcessHandle)
+
+removePNG name = createProcess $ CreateProcess
+                                  (ShellCommand $ "rm " ++ name)
                                   Nothing
                                   Nothing
                                   Inherit

--- a/hs/ConvertSVGToPNG.hs
+++ b/hs/ConvertSVGToPNG.hs
@@ -4,8 +4,9 @@ import System.Process
 import GHC.IO.Handle.Types
 import Control.Monad.IO.Class  (liftIO)
 import GHC.IO.Exception
-import System.IO (hFlush, hIsEOF, hShow, hReady, hGetContents)
 
+-- | Converts an SVG file to a PNG file. Note that image magik's 'convert' command
+-- can take in file descriptors.
 convertSVGToPNG :: String -> String -> IO
                      (Maybe Handle,
                       Maybe Handle,
@@ -22,6 +23,7 @@ convertSVGToPNG inName outName = createProcess $ CreateProcess
                                   CreatePipe
                                   False
                                   False
+-- | Removes a file.
 removePNG :: String -> IO
                      (Maybe Handle,
                       Maybe Handle,
@@ -38,7 +40,8 @@ removePNG name = createProcess $ CreateProcess
                                   False
                                   False
 
--- Note: hGetContents can be used to read Handles.
+-- Note: hGetContents can be used to read Handles. Useful when trying to read from
+-- stdout.
 createPNGFile :: String -> IO ExitCode
 createPNGFile uniqueName = do (inp, out, err, pid) <- convertSVGToPNG uniqueName "../res/graphs/graph_regions.svg"
                               liftIO $ print "Waiting for process..."

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -18,7 +18,6 @@ import Database.Persist.Sqlite
 postFB :: String
 postFB = "post-fb"
 
-
 -- In order to access information as the Courseography application, the secret needs
 -- to be declared in the third string below that has the place holder 'INSERT_SECRET'.
 -- The secret should NEVER be committed to GitHub.
@@ -39,8 +38,8 @@ perms = []
 
 -- | The arguments passed to the API. The first argument is the key of the query data ('code')
 -- and the second argument is the code that was retrieved in the first authorization step.
-args :: String -> FB.Argument
-args code = ("code", BS.pack code)
+args :: String -> String -> FB.Argument
+args arg1 arg2 = (BS.pack arg1, BS.pack arg2)
 
 -- | Retrieves the user's email.
 retrieveFBData :: String -> IO Response
@@ -64,9 +63,6 @@ performFBAction action = withManager $ \manager -> FB.runFacebookT app manager a
 postToFacebook :: String -> ServerPart Response
 postToFacebook code = (liftIO $ performPost code) >> graphResponse
 
-args2 :: FB.Argument
-args2 = ("message", "Test post please ignore")
-
 performPost :: String -> IO Response
 performPost code = performFBAction $ do
         postToFB code =<< getToken url2 code
@@ -74,11 +70,11 @@ performPost code = performFBAction $ do
 
 -- | Gets a user access token.
 getToken :: (MonadResource m, MonadBaseControl IO m) => FB.RedirectUrl -> String -> FB.FacebookT FB.Auth m FB.UserAccessToken
-getToken url code = FB.getUserAccessTokenStep2 url [args code]
+getToken url code = FB.getUserAccessTokenStep2 url [args "code" code]
 
 -- | Posts a message to Facebook.
 postToFB :: (MonadResource m, MonadBaseControl IO m) => String -> FB.UserAccessToken -> FB.FacebookT FB.Auth m FB.Id
-postToFB code token = FB.postObject "me/feed" [args2] token
+postToFB code token = FB.postObject "me/feed" [args "message" "Test Post Pls Ignore"] token
 
 -- | Gets a users Facebook email.
 getEmail :: String -> ServerPart Response

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -58,9 +58,9 @@ postPhoto :: FB.UserAccessToken -> FB.UserId -> IO Response
 postPhoto (FB.UserAccessToken _ b _) id_ = withSocketsDo $ withManager $ \m -> do
     fbpost <- parseUrl $ "https://graph.facebook.com/v2.2/me/photos?access_token=" ++ T.unpack b
     flip httpLbs m =<<
-        (formDataBody [partBS "message" "Test Message",
-                       partFileSource "graph" $ (show id_) ++ "-graph.png"]
-                      fbpost)
+        formDataBody [partBS "message" "Test Message",
+                      partFileSource "graph" $ (show id_) ++ "-graph.png"]
+                      fbpost
     return $ toResponse postFB
 
 -- | Constructs the Facebook authorization URL. This method does not actually
@@ -101,7 +101,7 @@ postToFacebook code = (liftIO $ performPost (BS.pack code)) >> graphResponse
 
 -- | Performs the posting to facebook.
 performPost :: BS.ByteString -> IO Response
-performPost code = do
+performPost code = 
     performFBAction $ do
         token <- getToken testPostUrl code
         user <- FB.getUser "me" [] (Just token)

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -24,16 +24,16 @@ import Network.HTTP.Client (RequestBody(..))
 import Network (withSocketsDo)
 
 
-courseographyUrl :: String
+courseographyUrl :: T.Text
 courseographyUrl = "http://localhost:8000"
 
 testUrl :: FB.RedirectUrl
-testUrl = T.pack $ courseographyUrl ++ "/test"
+testUrl = T.append courseographyUrl "/test"
 
 testPostUrl :: FB.RedirectUrl
-testPostUrl = T.pack $ courseographyUrl ++ "/test-post"
+testPostUrl = T.append courseographyUrl "/test-post"
 
-postFB :: String
+postFB :: T.Text
 postFB = "post-fb"
 
 appId :: T.Text
@@ -49,7 +49,7 @@ appSecret :: T.Text
 appSecret = "INSERT_SECRET"
 
 credentials :: FB.Credentials
-credentials = FB.Credentials (T.pack courseographyUrl) appId appSecret
+credentials = FB.Credentials courseographyUrl appId appSecret
 
 perms :: [FB.Permission]
 perms = ["publish_actions"]
@@ -65,11 +65,11 @@ postPhoto (FB.UserAccessToken _ b _) id_ = withSocketsDo $ withManager $ \m -> d
 
 -- | Constructs the Facebook authorization URL. This method does not actually
 -- interact with Facebook.
-retrieveAuthURL :: T.Text -> IO String
+retrieveAuthURL :: T.Text -> IO T.Text
 retrieveAuthURL url = 
     performFBAction $ do
         fbAuthUrl <- FB.getUserAccessTokenStep1 url perms
-        return $ T.unpack fbAuthUrl
+        return fbAuthUrl
 
 -- | Retrieves the user's email.
 retrieveFBData :: BS.ByteString -> IO Response

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -40,7 +40,8 @@ perms = []
 -- | Constructs the Facebook authorization URL. This method does not actually
 -- interact with Facebook.
 retrieveAuthURL :: T.Text -> IO String
-retrieveAuthURL url = withManager $ \manager -> FB.runFacebookT app manager $ do
+retrieveAuthURL url = 
+	withManager $ \manager -> FB.runFacebookT app manager $ do
         fbAuthUrl <- FB.getUserAccessTokenStep1 url perms
         return $ T.unpack fbAuthUrl
 
@@ -51,7 +52,8 @@ args arg1 arg2 = (BS.pack arg1, BS.pack arg2)
 
 -- | Retrieves the user's email.
 retrieveFBData :: String -> IO Response
-retrieveFBData code = performFBAction $ do
+retrieveFBData code = 
+	performFBAction $ do
         token <- getToken url1 code
         user <- FB.getUser "me" [] (Just token)
         liftIO $ insertIdIntoDb (FB.userId user)
@@ -59,12 +61,13 @@ retrieveFBData code = performFBAction $ do
 
 -- | Inserts a string into the database along with the current user's Facebook ID.
 insertIdIntoDb :: FB.Id -> IO ()
-insertIdIntoDb id_ = runSqlite fbdbStr $ do
-                       runMigration migrateAll
-                       insert_ $ FacebookTest (show id_) "Test String"
-                       liftIO $ print "Inserted..."
-                       let sql = "SELECT * FROM facebook_test"
-                       rawQuery sql [] $$ CL.mapM_ (liftIO . print)
+insertIdIntoDb id_ = 
+	runSqlite fbdbStr $ do
+        runMigration migrateAll
+        insert_ $ FacebookTest (show id_) "Test String"
+        liftIO $ print "Inserted..."
+        let sql = "SELECT * FROM facebook_test"
+        rawQuery sql [] $$ CL.mapM_ (liftIO . print)
 
 -- | Performs a Facebook action.
 performFBAction :: FB.FacebookT FB.Auth (ResourceT IO) a -> IO a
@@ -77,7 +80,8 @@ postToFacebook code = (liftIO $ performPost code) >> graphResponse
 
 -- | Performs the posting to facebook.
 performPost :: String -> IO Response
-performPost code = performFBAction $ do
+performPost code = 
+	performFBAction $ do
         postToFB code =<< getToken url2 code
         return $ toResponse postFB
 

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -59,7 +59,7 @@ postPhoto (FB.UserAccessToken _ b _) id_ = withSocketsDo $ withManager $ \m -> d
     fbpost <- parseUrl $ "https://graph.facebook.com/v2.2/me/photos?access_token=" ++ T.unpack b
     flip httpLbs m =<<
         formDataBody [partBS "message" "Test Message",
-                      partFileSource "graph" $ (show id_) ++ "-graph.png"]
+                      partFileSource "graph" $ "INSERT_ID" ++ "-graph.png"]
                       fbpost
     return $ toResponse postFB
 
@@ -106,9 +106,9 @@ performPost code =
         token <- getToken testPostUrl code
         user <- FB.getUser "me" [] (Just token)
         let id_ = FB.userId user
-        liftIO $ createPNGFile (id_ ++ "-graph.png")
+        liftIO $ createPNGFile ("INSERT_ID" ++ "-graph.png")
         liftIO $ postPhoto token id_
-        liftIO $ removePNG (id_ ++ "-graph.png")
+        liftIO $ removePNG ("INSERT_ID" ++ "-graph.png")
         return $ toResponse postFB
 
 -- | Gets a user access token.

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -12,8 +12,11 @@ import qualified Data.Conduit.List as CL
 import Data.Conduit
 import Data.Text.Encoding as TE
 import Database.Persist
+import ConvertSVGToPNG
 import JsonParser
+import System.Process
 import GraphResponse
+import GHC.IO.Exception
 import Data.Maybe
 import Tables
 import Text.Digestive.Form as TEF
@@ -32,7 +35,7 @@ postFB = "post-fb"
 -- Should the secret be committed to GitHub, it needs to be reset immediately. If you find
 -- yourself in this pickle, please contact someone who can do this.
 app :: FB.Credentials
-app = FB.Credentials "localhost" "442286309258193" "2f29d40c58ac8d987004f967660a64db"
+app = FB.Credentials "localhost" "442286309258193" "INSERT_SECRET"
 
 url1 :: FB.RedirectUrl
 url1 = "http://localhost:8000/test"
@@ -47,7 +50,7 @@ perms = []
 -- interact with Facebook.
 retrieveAuthURL :: T.Text -> IO String
 retrieveAuthURL url = 
-	withManager $ \manager -> FB.runFacebookT app manager $ do
+	performFBAction $ do
         fbAuthUrl <- FB.getUserAccessTokenStep1 url perms
         return $ T.unpack fbAuthUrl
 
@@ -90,9 +93,17 @@ performPost code = do
 	x <- BS.readFile "test.png"
 	--let y = show $ BodyPart "source" x
 	performFBAction $ do
-        postToFB (BS.unpack x) code =<< getToken url2 code
+        liftIO createPNGFile
+        --postToFB (BS.unpack x) code =<< getToken url2 code
+        liftIO $ removePNG "test.png"
+        liftIO $ print "File Deleted."
         return $ toResponse postFB
-    
+
+createPNGFile :: IO ExitCode
+createPNGFile =  do 
+                   (inp,out,err,pid) <- convertSVGToPNG "test.png" "../res/graphs/graph_regions.svg"
+                   liftIO $ waitForProcess pid
+
 -- | Gets a user access token.
 getToken :: (MonadResource m, MonadBaseControl IO m) => FB.RedirectUrl -> String -> FB.FacebookT FB.Auth m FB.UserAccessToken
 getToken url code = FB.getUserAccessTokenStep2 url [args "code" code]
@@ -100,14 +111,8 @@ getToken url code = FB.getUserAccessTokenStep2 url [args "code" code]
 -- | Posts a message to Facebook.
 postToFB :: (MonadResource m, MonadBaseControl IO m) => String -> String -> FB.UserAccessToken -> FB.FacebookT FB.Auth m FB.Id
 postToFB dataString code token = FB.postObject "me/photos" [args "message" "Test Post Pls Ignore",
-                                                            args "source" $ cd dataString] token
+                                                            args "url" $ "teststr"] token
 
 -- | Gets a users Facebook email.
 getEmail :: String -> ServerPart Response
 getEmail code = liftIO $ retrieveFBData code
-
-
-cd :: String -> String
-cd s = "------ThisIsTheBoundary1234567890\r\n" ++ 
-       "Content-Disposition: form-data; name=\"source\"; filename=\"@test.png\"\r\n'" ++
-       "Content-Type: image/png\r\n\r\n" ++  s ++ "\r\n------ThisIsTheBoundary1234567890--\r\n"

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -59,7 +59,7 @@ postPhoto (FB.UserAccessToken _ b _) id_ = withSocketsDo $ withManager $ \m -> d
     fbpost <- parseUrl $ "https://graph.facebook.com/v2.2/me/photos?access_token=" ++ T.unpack b
     flip httpLbs m =<<
         formDataBody [partBS "message" "Test Message",
-                      partFileSource "graph" $ "INSERT_ID" ++ "-graph.png"]
+                      partFileSource "graph" $ "INSERT_ID-graph.png"]
                       fbpost
     return $ toResponse postFB
 
@@ -106,9 +106,9 @@ performPost code =
         token <- getToken testPostUrl code
         user <- FB.getUser "me" [] (Just token)
         let id_ = FB.userId user
-        liftIO $ createPNGFile ("INSERT_ID" ++ "-graph.png")
+        liftIO $ createPNGFile ("INSERT_ID-graph.png")
         liftIO $ postPhoto token id_
-        liftIO $ removePNG ("INSERT_ID" ++ "-graph.png")
+        liftIO $ removePNG ("INSERT_ID-graph.png")
         return $ toResponse postFB
 
 -- | Gets a user access token.

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -94,7 +94,7 @@ performPost code = do
 	--let y = show $ BodyPart "source" x
 	performFBAction $ do
         liftIO createPNGFile
-        --postToFB (BS.unpack x) code =<< getToken url2 code
+        postToFB (BS.unpack x) code =<< getToken url2 code
         liftIO $ removePNG "test.png"
         liftIO $ print "File Deleted."
         return $ toResponse postFB
@@ -111,7 +111,7 @@ getToken url code = FB.getUserAccessTokenStep2 url [args "code" code]
 -- | Posts a message to Facebook.
 postToFB :: (MonadResource m, MonadBaseControl IO m) => String -> String -> FB.UserAccessToken -> FB.FacebookT FB.Auth m FB.Id
 postToFB dataString code token = FB.postObject "me/photos" [args "message" "Test Post Pls Ignore",
-                                                            args "url" $ "teststr"] token
+                                                            args "url" $ "http://localhost:8000/static/hs/test2.png"] token
 
 -- | Gets a users Facebook email.
 getEmail :: String -> ServerPart Response

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, GADTs #-}
 module CourseographyFacebook where
 
 import qualified Facebook as FB
@@ -6,24 +6,24 @@ import Control.Monad.IO.Class  (liftIO)
 import qualified Data.Text as T
 import Happstack.Server
 import Happstack.Server.Internal.Multipart
-import Network.HTTP.Conduit (withManager, parseUrl, httpLbs, RequestBody(..))
+import Network.HTTP.Conduit (withManager, parseUrl, httpLbs)
 import Control.Monad.Trans.Resource
 import qualified Data.Conduit.List as CL
 import Data.Conduit
-import Data.Text.Encoding as TE
 import Database.Persist
 import ConvertSVGToPNG
 import JsonParser
 import System.Process
 import GraphResponse
 import GHC.IO.Exception
-import Data.Maybe
 import Tables
-import Text.Digestive.Form as TEF
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BL
 import Database.Persist.Sqlite
 import Network.HTTP.Client.MultipartFormData
+import Network.HTTP.Client (RequestBody(..))
+import Network (withSocketsDo)
+
 
 postFB :: String
 postFB = "post-fb"
@@ -44,25 +44,29 @@ url2 :: FB.RedirectUrl
 url2 = "http://localhost:8000/test-post"
 
 perms :: [FB.Permission]
-perms = []
+perms = ["publish_actions"]
+
+postPhoto :: FB.UserAccessToken -> IO Response
+postPhoto (FB.UserAccessToken _ b _) = withSocketsDo $ withManager $ \m -> do
+    fbpost <- parseUrl $ "https://graph.facebook.com/v2.2/me/photos?access_token=" ++ T.unpack b
+    flip httpLbs m =<<
+        (formDataBody [partBS "message" "Test Message",
+                       partFileSource "graph" "graph.png"]
+                      fbpost)
+    return $ toResponse postFB
 
 -- | Constructs the Facebook authorization URL. This method does not actually
 -- interact with Facebook.
 retrieveAuthURL :: T.Text -> IO String
 retrieveAuthURL url = 
-	performFBAction $ do
+    performFBAction $ do
         fbAuthUrl <- FB.getUserAccessTokenStep1 url perms
         return $ T.unpack fbAuthUrl
 
--- | The arguments passed to the API. The first argument is the key of the query data ('code')
--- and the second argument is the code that was retrieved in the first authorization step.
-args :: String -> String -> FB.Argument
-args arg1 arg2 = (BS.pack arg1, BS.pack arg2)
-
 -- | Retrieves the user's email.
-retrieveFBData :: String -> IO Response
+retrieveFBData :: BS.ByteString -> IO Response
 retrieveFBData code = 
-	performFBAction $ do
+    performFBAction $ do
         token <- getToken url1 code
         user <- FB.getUser "me" [] (Just token)
         liftIO $ insertIdIntoDb (FB.userId user)
@@ -71,7 +75,7 @@ retrieveFBData code =
 -- | Inserts a string into the database along with the current user's Facebook ID.
 insertIdIntoDb :: FB.Id -> IO ()
 insertIdIntoDb id_ = 
-	runSqlite fbdbStr $ do
+    runSqlite fbdbStr $ do
         runMigration migrateAll
         insert_ $ FacebookTest (show id_) "Test String"
         liftIO $ print "Inserted..."
@@ -85,34 +89,25 @@ performFBAction action = withManager $ \manager -> FB.runFacebookT app manager a
 -- | Posts a message to the user's Facebook feed, with the code 'code'. GraphResponse
 -- is then sent back to the user.
 postToFacebook :: String -> ServerPart Response
-postToFacebook code = (liftIO $ performPost code) >> graphResponse
+postToFacebook code = (liftIO $ performPost (BS.pack code)) >> graphResponse
 
 -- | Performs the posting to facebook.
-performPost :: String -> IO Response
+performPost :: BS.ByteString -> IO Response
 performPost code = do
-	x <- BS.readFile "test.png"
-	--let y = show $ BodyPart "source" x
-	performFBAction $ do
-        liftIO createPNGFile
-        postToFB (BS.unpack x) code =<< getToken url2 code
-        liftIO $ removePNG "test.png"
-        liftIO $ print "File Deleted."
+    createPNGFile
+    performFBAction $ do
+        token <- getToken url2 code
+        liftIO $ postPhoto token
         return $ toResponse postFB
 
 createPNGFile :: IO ExitCode
-createPNGFile =  do 
-                   (inp,out,err,pid) <- convertSVGToPNG "test.png" "../res/graphs/graph_regions.svg"
-                   liftIO $ waitForProcess pid
+createPNGFile =  do (inp,out,err,pid) <- convertSVGToPNG "graph.png" "../res/graphs/graph_regions.svg"
+                    liftIO $ waitForProcess pid
 
 -- | Gets a user access token.
-getToken :: (MonadResource m, MonadBaseControl IO m) => FB.RedirectUrl -> String -> FB.FacebookT FB.Auth m FB.UserAccessToken
-getToken url code = FB.getUserAccessTokenStep2 url [args "code" code]
-
--- | Posts a message to Facebook.
-postToFB :: (MonadResource m, MonadBaseControl IO m) => String -> String -> FB.UserAccessToken -> FB.FacebookT FB.Auth m FB.Id
-postToFB dataString code token = FB.postObject "me/photos" [args "message" "Test Post Pls Ignore",
-                                                            args "url" $ "http://localhost:8000/static/hs/test2.png"] token
+getToken :: (MonadResource m, MonadBaseControl IO m) => FB.RedirectUrl -> BS.ByteString -> FB.FacebookT FB.Auth m FB.UserAccessToken
+getToken url code = FB.getUserAccessTokenStep2 url [("code", code)]
 
 -- | Gets a users Facebook email.
 getEmail :: String -> ServerPart Response
-getEmail code = liftIO $ retrieveFBData code
+getEmail code = liftIO $ retrieveFBData (BS.pack code)

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings,
              ScopedTypeVariables,
-             FlexibleInstances #-}
+             FlexibleInstances,
+             FlexibleContexts #-}
 
 module Main where
 import qualified Data.Text as T
@@ -56,16 +57,18 @@ main :: IO ()
 main = do
     cwd <- getCurrentDirectory
     let staticDir = encodeString $ parent $ decodeString cwd
+    redirectUrlGraphEmail <- retrieveAuthURL url1
+    redirectUrlGraphPost <- retrieveAuthURL url2
     simpleHTTP nullConf $
       msum [ dir grid $ gridResponse,
              dir graph $ graphResponse,
-             dir code $ seeOther fbAuth1Url $ toResponse test,
+             dir code $ seeOther redirectUrlGraphEmail $ toResponse post,
+             dir post $ seeOther redirectUrlGraphPost $ toResponse test,
              dir test $ look "code" >>= getEmail,
              dir testPost $ look "code" >>= postToFacebook,
              dir about $ aboutResponse,
              dir static $ serveDirectory EnableBrowsing [] staticDir,
-             dir course $ path (\s -> liftIO $ queryCourse s),
-             dir post $ seeOther fbAuth1UrlPost $ toResponse test
+             dir course $ path (\s -> liftIO $ queryCourse s)
            ]
 
 -- | Queries the database for all information about `course`, constructs a JSON object 

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -19,7 +19,6 @@ import qualified Data.Conduit.List as CL
 import Tables
 import qualified Data.Aeson as Aeson
 import Control.Monad.IO.Class  (liftIO)
-import Control.Concurrent.MVar
 
 import Database.Persist
 import Data.Conduit (($$))
@@ -151,15 +150,6 @@ buildSession :: [Entity Lectures] -> [Entity Tutorials] -> Maybe Tables.Session
 buildSession lectures tutorials = Just $ Tables.Session (map buildLecture (map entityVal lectures))
                                                         (map buildTutorial (map entityVal tutorials))
 
-myPolicy :: BodyPolicy
-myPolicy = (defaultBodyPolicy "/tmp/" 0 1000 1000)
-
 -- | Creates a JSON response.
 createJSONResponse :: BSL.ByteString -> Response
 createJSONResponse jsonStr = toResponseBS (BS.pack "application/json") jsonStr
-
-reqExample :: ServerPartT IO Response
-reqExample = do req <- askRq
-                --nex <- ok $ takeMVar (rqBody req)
-                reqf <- decodeBody myPolicy
-                ok $ toResponse $ show $ reqf

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -14,7 +14,6 @@ import GridResponse
 import GraphResponse
 import AboutResponse
 import JsonParser
-import ConvertSVGToPNG
 import CourseographyFacebook
 import qualified Data.Conduit.List as CL
 import Tables
@@ -57,8 +56,7 @@ post = "post-fb"
 
 main :: IO ()
 main = do
-    convertSVGToPNG
-    print "Worked"
+    print "Server is running..."
     cwd <- getCurrentDirectory
     let staticDir = encodeString $ parent $ decodeString cwd
     redirectUrlGraphEmail <- retrieveAuthURL url1

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -14,6 +14,7 @@ import GridResponse
 import GraphResponse
 import AboutResponse
 import JsonParser
+import ConvertSVGToPNG
 import CourseographyFacebook
 import qualified Data.Conduit.List as CL
 import Tables
@@ -55,6 +56,8 @@ post = "post-fb"
 
 main :: IO ()
 main = do
+    convertSVGToPNG
+    print "Worked"
     cwd <- getCurrentDirectory
     let staticDir = encodeString $ parent $ decodeString cwd
     redirectUrlGraphEmail <- retrieveAuthURL url1
@@ -63,7 +66,7 @@ main = do
       msum [ dir grid $ gridResponse,
              dir graph $ graphResponse,
              dir code $ seeOther redirectUrlGraphEmail $ toResponse post,
-             dir post $ seeOther redirectUrlGraphPost $ toResponse test,
+             dir post $ seeOther test $ toResponse test,
              dir test $ look "code" >>= getEmail,
              dir testPost $ look "code" >>= postToFacebook,
              dir about $ aboutResponse,

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -61,8 +61,7 @@ main = do
     redirectUrlGraphEmail <- retrieveAuthURL testUrl
     redirectUrlGraphPost <- retrieveAuthURL testPostUrl
     simpleHTTP nullConf $
-      msum [ dir "form" $ reqExample,
-             dir grid $ gridResponse,
+      msum [ dir grid $ gridResponse,
              dir graph $ graphResponse,
              dir code $ seeOther redirectUrlGraphEmail $ toResponse post,
              dir post $ seeOther redirectUrlGraphPost $ toResponse test,


### PR DESCRIPTION
This pull request cleans up some of the Facebook code, and also allows the user to upload a photograph to Facebook (an SVG file that is converted to a PNG file).