### PR TITLE
Grid display half hour courses

### DIFF
--- a/js/common/utilities/util.js
+++ b/js/common/utilities/util.js
@@ -124,7 +124,7 @@ function convertTimes(times) {
         time = times[i][1];
         if (time > 21) {
             stime = time.toString();
-            if (stime.charAt(stime.length-1) == '0') {
+            if (stime.charAt(stime.length - 1) == '0') {
                 stime = stime.slice(0, -1) + 'E';
             } else {
                 stime = stime.slice(0, -1) + 'H';

--- a/js/common/utilities/util.js
+++ b/js/common/utilities/util.js
@@ -117,14 +117,25 @@ function convertTimes(times) {
 
     var timeList = [];
     var time;
+    var stime;
 
     for (var i = 0; i < times.length; i++) {
         var timeString = 'MTWRF'.charAt(times[i][0]);
         time = times[i][1];
-        timeString = timeString + time;
+        if (time > 21) {
+            stime = time.toString();
+            if (stime.charAt(stime.length-1) == '0') {
+                stime = stime.slice(0, -1) + 'E';
+            } else {
+                stime = stime.slice(0, -1) + 'H';
+            }
+            timeString = timeString + stime;
+        } else {
+            timeString = timeString + time;
+        }
+
         timeList.push(timeString);
     }
-
     return timeList;
 }
 

--- a/js/common/utilities/util.js
+++ b/js/common/utilities/util.js
@@ -124,7 +124,7 @@ function convertTimes(times) {
         time = times[i][1];
         if (time > 21) {
             stime = time.toString();
-            if (stime.charAt(stime.length - 1) == '0') {
+            if (stime.charAt(stime.length - 1) === '0') {
                 stime = stime.slice(0, -1) + 'E';
             } else {
                 stime = stime.slice(0, -1) + 'H';

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -142,30 +142,21 @@ function appendTableData(trFall, trSpring, time) {
     } else {
         var adjustedTime = '';
 
-        trFall.append($('<td></td>')
-            .attr('hidden', 'true')
-            .addClass('timetable-time')
-            .html(adjustedTime));
 
         for (var k = 0; k < 5; k++) {
             trFall.append($('<td></td>')
-                .attr('id', weekPrefixArray[k] + time + 'F')
+                .attr('id', weekPrefixArray[k] + (time-0.5) + 'H' + 'F')
                 .attr('in-conflict', 'false')
                 .attr('satisfied', 'true')
-                .attr('hidden', 'true')
+                .attr('display', 'none')
                 .addClass('timetable-cell'));
             trSpring.append($('<td></td>')
-                .attr('id', weekPrefixArray[k] + time + 'S')
+                .attr('id', weekPrefixArray[k] + (time-0.5) + 'H' + 'S')
                 .attr('in-conflict', 'false')
                 .attr('satisfied', 'true')
-                .attr('hidden', 'true')
+                .attr('display', 'none')
                 .addClass('timetable-cell'));
         }
-        
-        trSpring.append($('<td></td>')
-            .attr('hidden', 'true')
-            .addClass('timetable-time')
-            .html(adjustedTime));
         
     }
 

--- a/js/grid/generate_grid.js
+++ b/js/grid/generate_grid.js
@@ -142,16 +142,15 @@ function appendTableData(trFall, trSpring, time) {
     } else {
         var adjustedTime = '';
 
-
         for (var k = 0; k < 5; k++) {
             trFall.append($('<td></td>')
-                .attr('id', weekPrefixArray[k] + (time-0.5) + 'H' + 'F')
+                .attr('id', weekPrefixArray[k] + (time - 0.5) + 'H' + 'F')
                 .attr('in-conflict', 'false')
                 .attr('satisfied', 'true')
                 .attr('display', 'none')
                 .addClass('timetable-cell'));
             trSpring.append($('<td></td>')
-                .attr('id', weekPrefixArray[k] + (time-0.5) + 'H' + 'S')
+                .attr('id', weekPrefixArray[k] + (time - 0.5) + 'H' + 'S')
                 .attr('in-conflict', 'false')
                 .attr('satisfied', 'true')
                 .attr('display', 'none')

--- a/js/grid/mouse_events.js
+++ b/js/grid/mouse_events.js
@@ -118,13 +118,48 @@ function renderClearHover(time) {
 function renderAddHover(time, section) {
     'use strict';
 
+    var n;
+
+    n = time.indexOf('H');
+
+    if(n != -1) {
+        extendRow(time.slice(2,n));
+    } 
+
     if ($(time).attr('clicked') !== 'true') {
         $(time).html(section.courseName)
                .attr('hover', 'good');
     } else if ($(time).html() === section.courseName &&
-               $(time).attr('type') === section.type) {
-        $(time).attr('hover', 'remove');
+        $(time).attr('type') === section.type) {
+    $(time).attr('hover', 'remove');
     } else {
         $(time).attr('hover', 'conflict');
     }
+}
+
+function extendRow(time) {
+    var weekPrefixArray = ['M', 'T', 'W', 'R', 'F'];
+    var pcells = [];
+    var ccells = [];
+    var cellID;
+
+    for (var k = 0; k < 5; k++) {
+        cellID = '#' + weekPrefixArray[k] + time + 'F';
+        pcells[pcells.length] = cellID;
+        cellID = '#' + weekPrefixArray[k] + time + 'S';
+        pcells[pcells.length] = cellID;
+    }
+
+    for (var k = 0; k < 5; k++) {
+        cellID = '#' + weekPrefixArray[k] + time +'H' + 'F';
+        ccells[ccells.length] = cellID;
+        cellID = '#' + weekPrefixArray[k] + time +'H'+ 'S';
+        ccells[ccells.length] = cellID;
+    }
+
+    for (var i = 0; i < 10; i++) {
+        $(pcells[i]).attr('rowspan', '1');
+        $(ccells[i]).attr('display', 'table-cell');
+    }
+
 }

--- a/js/grid/mouse_events.js
+++ b/js/grid/mouse_events.js
@@ -122,7 +122,7 @@ function renderAddHover(time, section) {
 
     n = time.indexOf('H');
 
-    if(n != -1) {
+    if (n != -1) {
         extendRow(time.slice(2,n));
     } 
 
@@ -131,13 +131,18 @@ function renderAddHover(time, section) {
                .attr('hover', 'good');
     } else if ($(time).html() === section.courseName &&
         $(time).attr('type') === section.type) {
-    $(time).attr('hover', 'remove');
+        $(time).attr('hover', 'remove');
     } else {
         $(time).attr('hover', 'conflict');
     }
 }
-
+/**
+ * Extends a given row to display half hour sections.
+ * @param {string} time The full hour time of the row.
+ */
 function extendRow(time) {
+    'use strict';
+
     var weekPrefixArray = ['M', 'T', 'W', 'R', 'F'];
     var pcells = [];
     var ccells = [];
@@ -148,9 +153,6 @@ function extendRow(time) {
         pcells[pcells.length] = cellID;
         cellID = '#' + weekPrefixArray[k] + time + 'S';
         pcells[pcells.length] = cellID;
-    }
-
-    for (var k = 0; k < 5; k++) {
         cellID = '#' + weekPrefixArray[k] + time +'H' + 'F';
         ccells[ccells.length] = cellID;
         cellID = '#' + weekPrefixArray[k] + time +'H'+ 'S';

--- a/js/grid/mouse_events.js
+++ b/js/grid/mouse_events.js
@@ -130,7 +130,7 @@ function renderAddHover(time, section) {
         $(time).html(section.courseName)
                .attr('hover', 'good');
     } else if ($(time).html() === section.courseName &&
-        $(time).attr('type') === section.type) {
+               $(time).attr('type') === section.type) {
         $(time).attr('hover', 'remove');
     } else {
         $(time).attr('hover', 'conflict');


### PR DESCRIPTION
Allows the grid to display classes that START on the half hour

First modified the PHL245 text file to show the half hour with added "1"

Then changed convertTimes in util to recognize the situation by adding "H" at the end of the section times (the "E" is for ending at the half hour - next step)

Also changed generate grid so the table cell IDs no longer have ".5" but "H" (for some reason ".5" doesn't work too well with rendering things...)

Finally added a function to expand the grid where an half hour course is found, and the half hour is conveniently displayed because of the "H" in its ID.

Note: currently expanding is a non-reversed process