### PR TITLE
POSt Constraint Fixing

### DIFF
--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, DataKinds #-}
 
 module PostResponse where
 import Data.List
@@ -10,6 +10,11 @@ import MakeElements
 import MasterTemplate
 import Scripts
 import SVGGen
+
+str :: String
+str = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
+        "MAT: 224, 235, 237, 237, 257, 300+ except for 320, 390, & 391" ++
+        "; STA: 249, 261, any 300+" 
 
 postResponse :: ServerPart Response
 postResponse =
@@ -119,7 +124,7 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
             H.div ! A.id "spec_extra" $ do
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs)"
+                H.p ! A.class_ "code" $ H.toHtml $ str
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -11,15 +11,20 @@ import MasterTemplate
 import Scripts
 import SVGGen
 
-strSpec :: String
-strSpec = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
+spec300Str :: String
+spec300Str = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
         "MAT: 224, 235, 237, 237, 257, 300+ except for 320, 390, & 391" ++
         "; STA: 249, 261, any 300+" 
 
-strMaj :: String
-strMaj = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (1.5 FCEs) - " ++
+maj300Str :: String
+maj300Str = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (1.5 FCEs) - " ++
         "MAT: 224, 235, 237, 237, 257, 300+ except for 320, 390, & 391" ++
         "; STA: 249, 261, any 300+" 
+
+inqStr :: String 
+inqStr = "Any from this list: CSC301H, CSC318H, CSC404H, CSC411H, CSC418H, CSC420H, " ++
+         "CSC428H, CSC454H, CSC485H, CSC490H, CSC491H, CSC494H, or PEY (0.5 FCEs) " ++ 
+         " \n ** Note: Type 'PEY' for Check my POSt to recognize it **"
 
 
 postResponse :: ServerPart Response
@@ -130,19 +135,16 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
             H.div ! A.id "spec_extra" $ do
-                H.p ! A.class_ "code" $ H.toHtml $ strSpec
+                H.p ! A.class_ "code" $ H.toHtml $ spec300Str
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
             H.div ! A.id "spec_misc" $ do 
-                H.p ! A.class_ "code" $ H.em "Any from this list: CSC301H, CSC318H, CSC404H, CSC411H, CSC418H, CSC420H, CSC428H, CSC454H, CSC485H, CSC490H, CSC491H, CSC494H (2.0 FCEs)"
+                H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
-                    H.input ! A.type_ "text"
-                    H.input ! A.type_ "text"
-                    H.input ! A.type_ "text"
             H.p ! A.class_ "code" $ H.em "No more than 1.0 FCEs from CSC490H, CSC491H, CSC494H, CSC495H, BCB430Y"
         H.div ! A.id "div_major" $ do
             H.h2 "First Year"
@@ -202,18 +204,15 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj" 
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj"
             H.div ! A.id "maj_extra" $ do
-                H.p ! A.class_ "code" $ H.toHtml $ strMaj
+                H.p ! A.class_ "code" $ H.toHtml $ maj300Str
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
             H.div ! A.id "maj_misc" $ do
-                H.p ! A.class_ "code" $ H.em "Any from this list: CSC301H, CSC318H, CSC404H, CSC411H, CSC418H, CSC420H, CSC428H, CSC454H, CSC485H, CSC490H, CSC491H, CSC494H (2.0 FCEs)"
+                H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
-                    H.input ! A.type_ "text"
-                    H.input ! A.type_ "text"
-                    H.input ! A.type_ "text"
             H.p ! A.class_ "code" $ H.em "No more than 1.0 FCEs from CSC490H, CSC491H, CSC494H, CSC495H, BCB430Y"
         H.div ! A.id "div_minor" $ do
             H.h2 "First Year"

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -113,7 +113,7 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl400spec" 
                     H.input ! A.type_ "text" ! A.class_ "lvl400spec" 
             H.div ! A.id "spec_300" $ do 
-                H.p ! A.class_ "code" $ "Any 300-level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec" 
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
@@ -181,7 +181,7 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl400maj" 
                     H.input ! A.type_ "text" ! A.class_ "lvl400maj" 
             H.div ! A.id "maj_300" $ do
-                H.p ! A.class_ "code" $ "Any 300-level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj" 
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj"

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -11,10 +11,16 @@ import MasterTemplate
 import Scripts
 import SVGGen
 
-str :: String
-str = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
+strSpec :: String
+strSpec = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
         "MAT: 224, 235, 237, 237, 257, 300+ except for 320, 390, & 391" ++
         "; STA: 249, 261, any 300+" 
+
+strMaj :: String
+strMaj = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (1.5 FCEs) - " ++
+        "MAT: 224, 235, 237, 237, 257, 300+ except for 320, 390, & 391" ++
+        "; STA: 249, 261, any 300+" 
+
 
 postResponse :: ServerPart Response
 postResponse =
@@ -124,7 +130,7 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
             H.div ! A.id "spec_extra" $ do
-                H.p ! A.class_ "code" $ H.toHtml $ str
+                H.p ! A.class_ "code" $ H.toHtml $ strSpec
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
@@ -187,17 +193,20 @@ checkPost =  do
                     H.p ! A.class_ "full_name Sta1" $ "STA257H (Probability and Statistics 1)"
             H.h2 "Later Years"
             H.div ! A.id "maj_400" $ do
-                H.p ! A.class_ "code" $ "Any 400-level CSC course, BCB410H, BCB420H, BCB430Y (1.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 400-level CSC course, BCB410H, BCB420H, BCB430Y (0.5 FCEs)"
                 H.div ! A.class_ "more-info" $ do
-                    H.input ! A.type_ "text" ! A.class_ "lvl400maj" 
-                    H.input ! A.type_ "text" ! A.class_ "lvl400maj" 
-                    H.input ! A.type_ "text" ! A.class_ "lvl400maj" 
+                    H.input ! A.type_ "text" ! A.class_ "lvl400maj"  
             H.div ! A.id "maj_300" $ do
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.0 FCEs)"
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj" 
                     H.input ! A.type_ "text" ! A.class_ "lvl300maj"
-                    H.input ! A.type_ "text" ! A.class_ "lvl300maj"
+            H.div ! A.id "maj_extra" $ do
+                H.p ! A.class_ "code" $ H.toHtml $ strMaj
+                H.div ! A.class_ "more-info" $ do
+                    H.input ! A.type_ "text"
+                    H.input ! A.type_ "text"
+                    H.input ! A.type_ "text"
             H.div ! A.id "maj_misc" $ do
                 H.p ! A.class_ "code" $ H.em "Any from this list: CSC301H, CSC318H, CSC404H, CSC411H, CSC418H, CSC420H, CSC428H, CSC454H, CSC485H, CSC490H, CSC491H, CSC494H (2.0 FCEs)"
                 H.div ! A.class_ "more-info" $ do

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -118,6 +118,13 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec" 
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
                     H.input ! A.type_ "text" ! A.class_ "lvl300spec"
+            H.div ! A.id "spec_extra" $ do
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs)"
+                H.div ! A.class_ "more-info" $ do
+                    H.input ! A.type_ "text"
+                    H.input ! A.type_ "text"
+                    H.input ! A.type_ "text"
+                    H.input ! A.type_ "text"
             H.div ! A.id "spec_misc" $ do 
                 H.p ! A.class_ "code" $ H.em "Any from this list: CSC301H, CSC318H, CSC404H, CSC411H, CSC418H, CSC420H, CSC428H, CSC454H, CSC485H, CSC490H, CSC491H, CSC494H (2.0 FCEs)"
                 H.div ! A.class_ "more-info" $ do

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -91,25 +91,27 @@ function update300s() {
 
     for (var courseCode in level300) {
         if (level300.hasOwnProperty(courseCode)) {
-            if (getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') {
-                if (level300[courseCode] < 1) {
-                    level300[courseCode] += 1;
-                    creditCount300 += 0.5;
+            if ((getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') 
+                && (active300s.indexOf(courseCode) === -1)) {
+                active300s.push(courseCode);
+                creditCount300 += 0.5;
                 } if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
                     activeInq.push(courseCode);
                 }
             } else if ((getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') 
-                       && (level300[courseCode] > 0)) {
-                level300[courseCode] -= 1;
+                       && (active300s.indexOf(courseCode) > -1)) {
+                var index300 = active300s.indexOf(courseCode);
+                active300s.splice(index300, 1);
                 creditCount300 -= 0.5;
-                var index = activeInq.indexOf(courseCode);
-                if (index > -1) {
-                    activeInq.splice(index, 1);
+                var indexInq = activeInq.indexOf(courseCode);
+                if (indexInq > -1) {
+                    activeInq.splice(indexInq, 1);
                 }
             }
-        }       
-    }
-}
+        }
+    }       
+
+
 
 
 /**
@@ -120,25 +122,26 @@ function update400s() {
 
     for (var courseCode in level400) {
         if (level400.hasOwnProperty(courseCode)) {
-            if (getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') {
-                if (level400[courseCode] < 1) {
-                    level400[courseCode] += 1;
+            if ((getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') 
+                && (active400s.indexOf(courseCode) === -1)) {
+                    active400s.push(courseCode);
                     creditCount400 += 0.5;
                 } if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
                     activeInq.push(courseCode);
                 }
             } else if ((getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') 
-                       && (level400[courseCode] > 0)) {
-                level400[courseCode] -= 1;
+                       && (active400s.indexOf(courseCode) > -1)) {
+                var index400 = active400s.indexOf(courseCode);
                 creditCount400 -= 0.5;
-                var index = activeInq.indexOf(courseCode);
-                if (index > -1) {
-                    activeInq.splice(index, 1);
+                var indexInq = activeInq.indexOf(courseCode);
+                active400s.splice(index400, 1);
+                if (indexInq > -1) {
+                    activeInq.splice(indexInq, 1);
                 }
             }
         }       
     }
-}
+
 
 
 /**

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -95,9 +95,9 @@ function update300s() {
                 && (active300s.indexOf(courseCode) === -1)) {
                 active300s.push(courseCode);
                 creditCount300 += 0.5;
-                } if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
+                if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
                     activeInq.push(courseCode);
-                }
+                }  
             } else if ((getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') 
                        && (active300s.indexOf(courseCode) > -1)) {
                 var index300 = active300s.indexOf(courseCode);
@@ -110,7 +110,7 @@ function update300s() {
             }
         }
     }       
-
+}
 
 
 
@@ -126,9 +126,9 @@ function update400s() {
                 && (active400s.indexOf(courseCode) === -1)) {
                     active400s.push(courseCode);
                     creditCount400 += 0.5;
-                } if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
-                    activeInq.push(courseCode);
-                }
+                    if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
+                        activeInq.push(courseCode);
+                    }
             } else if ((getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') 
                        && (active400s.indexOf(courseCode) > -1)) {
                 var index400 = active400s.indexOf(courseCode);
@@ -141,7 +141,7 @@ function update400s() {
             }
         }       
     }
-
+}
 
 
 /**

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -173,6 +173,22 @@ function updateAllCategories() {
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
     }
 
+    // Update Extra
+
+    i = 0; 
+    var specExtra = $('#spec_extra')[0].getElementsByTagName('input');
+    for (var l = 0; l < 4; l++) {
+        if (specExtra[l].value != '') {
+            i += 1;
+        }
+    }
+
+    if (i === 4) {
+        updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
+    } else {
+        updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
+    }
+
 
 }
 
@@ -311,10 +327,18 @@ function fillExtra() {
 
     var i = 0;
     var spec_extra = $('#spec_extra')[0].getElementsByTagName('input');
+    var count = 0
 
-     // clear textboxes
-    for (k = 0; k < 4; k++) {
-        spec_extra[k].value = '';
+    for (var k = 0; k < 4; k++) {
+        if (spec_extra[k].value.indexOf) {
+            count += 1;
+        }
+    }
+
+    for (var k = 0; k < 4; k++) {
+        if (spec_extra[k].value.indexOf('MAT') === -1 && spec_extra[k].value.indexOf('STA') === -1) {
+            spec_extra[k].value = '';
+        }
     }
 
     // fill courses that have been selected
@@ -322,9 +346,11 @@ function fillExtra() {
         if ((index300 === active300s.length) || (i === 4)) {
             break;
         }
-        spec_extra[i].value = active300s[index300];
+        if (spec_extra[i].value === '') {
+            spec_extra[i].value = active300s[index300];
+            index300 += 1;
+        }
         i += 1;
-        index300 += 1
     }
 
     if (i < 4) {
@@ -332,9 +358,11 @@ function fillExtra() {
             if ((index400 === active400s.length) || (i === 4)) {
                 break;
             }
-            spec_extra[i].value = active400s[index400];
+            if (spec_extra[i].value === '') {
+                spec_extra[i].value = active400s[index400];
+                index400 += 1;
+            }
             i += 1;
-            index400 += 1;
         }
     }
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -175,20 +175,29 @@ function updateAllCategories() {
 
     // Update Extra
 
-    i = 0; 
+    countMaj = 0; 
+    countSpec = 0;
     var specExtra = $('#spec_extra')[0].getElementsByTagName('input');
+    var majExtra = $('#maj_extra')[0].getElementsByTagName('input');
     for (var l = 0; l < 4; l++) {
         if (specExtra[l].value != '') {
-            i += 1;
+            countSpec += 1;
+        } if (l < 3) {
+            if (majExtra[l].value != '') {
+                countMaj += 1;
+            }
         }
     }
 
-    if (i === 4) {
+    if (countSpec === 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
-    } else {
+    } if (countMaj === 3) {
+        updateCategory($('#maj_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
+    } if (countSpec < 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
+    } if (countMaj < 3) {
+        updateCategory($('#maj_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
     }
-
 
 }
 
@@ -255,7 +264,9 @@ function fill300s() {
         var course = spec300s[k].value;
         if (getCookie(course) === 'inactive' || getCookie(course) === 'takeable') {
             spec300s[k].value = '';
-            maj300s[k].value = '';
+            if (k < 2) {
+                maj300s[k].value = '';
+            }
             min300s[k].value = '';
         }
     }
@@ -267,7 +278,9 @@ function fill300s() {
             break;
         }
         spec300s[i].value = active300s[index300];
-        maj300s[i].value = active300s[index300];
+        if (i < 2) {
+            maj300s[i].value = active300s[index300];
+        }
         min300s[i].value = active300s[index300];
         i += 1; 
         index300 += 1;
@@ -279,7 +292,9 @@ function fill300s() {
                 break;
             }
             spec300s[i].value = active400s[index400];
-            maj300s[i].value = active400s[index400];
+            if (i < 2) {
+                maj300s[i].value = active400s[index400];
+            }
             min300s[i].value = active400s[index400]; 
             i += 1;
             index400 += 1;
@@ -303,7 +318,9 @@ function fill400s() {
     // clear textboxes
     for (k = 0; k < 3; k++) {
         spec400s[k].value = '';
-        maj400s[k].value = '';
+        if (k < 1) {
+            maj400s[k].value = '';
+        }
         min400s[k].value = '';
     }
     
@@ -314,7 +331,9 @@ function fill400s() {
             break;
         }
         spec400s[i].value = active400s[index400];
-        maj400s[i].value = active400s[index400];
+        if (i < 1) {
+            maj400s[i].value = active400s[index400];
+        }
         min400s[i].value = active400s[index400]; 
         i += 1;
         index400 += 1;
@@ -327,17 +346,15 @@ function fillExtra() {
 
     var i = 0;
     var spec_extra = $('#spec_extra')[0].getElementsByTagName('input');
-    var count = 0
-
-    for (var k = 0; k < 4; k++) {
-        if (spec_extra[k].value.indexOf) {
-            count += 1;
-        }
-    }
+    var maj_extra = $('#maj_extra')[0].getElementsByTagName('input');
 
     for (var k = 0; k < 4; k++) {
         if (spec_extra[k].value.indexOf('MAT') === -1 && spec_extra[k].value.indexOf('STA') === -1) {
             spec_extra[k].value = '';
+        } if (k < 3) {
+            if (maj_extra[k].value.indexOf('MAT') === -1 && maj_extra[k].value.indexOf('STA') === -1) {
+                maj_extra[k].value = '';
+            }
         }
     }
 
@@ -346,10 +363,13 @@ function fillExtra() {
         if ((index300 === active300s.length) || (i === 4)) {
             break;
         }
+        if ((i < 2) && (maj_extra[i].value === '')) {
+            maj_extra[i].value = active300s[index300];
+        }
         if (spec_extra[i].value === '') {
             spec_extra[i].value = active300s[index300];
             index300 += 1;
-        }
+        } 
         i += 1;
     }
 
@@ -357,6 +377,9 @@ function fillExtra() {
         for (m = 0; m < active400s.length; m++) {
             if ((index400 === active400s.length) || (i === 4)) {
                 break;
+            }
+            if ((i < 2) && (maj_extra[i].value === '')) {
+                maj_extra[i].value = active400s[index400];
             }
             if (spec_extra[i].value === '') {
                 spec_extra[i].value = active400s[index400];

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -398,31 +398,31 @@ function fillExtra() {
 function fillMisc() {
     'use-strict';
 
-    var i = 0;
-
     var spec_inq = $('#spec_misc')[0].getElementsByTagName('input');
     var maj_inq = $('#maj_misc')[0].getElementsByTagName('input');
 
     // clear textboxes
-    for (k = 0; k < 4; k++) {
-        spec_inq[k].value = '';
-        maj_inq[k].value = '';
-    }
-    
-    for (m = 0; m < activeInq.length; m++) {
-        spec_inq[m].value = activeInq[m];
-        maj_inq[m].value = activeInq[m];
-        i += 1;
-        if (i == 4) {
-            break;
-        }
+    if (spec_inq[0].value.indexOf('PEY') === -1) {
+        spec_inq[0].value = '';
+    } if (maj_inq[0].value.indexOf('PEY') === -1) {
+        maj_inq[0].value = '';
     }
 
-    if (activeInq.length >= 4) {
-        updateCategory($('#spec_misc')[0].getElementsByClassName('code')[0], 'fulfilled'); 
+    // fill textboxes
+    if (activeInq.length > 0) {
+        spec_inq[0].value = activeInq[0];
+    } if (activeInq.length > 0){
+        maj_inq[0].value = activeInq[0];
+    }
+    
+    // update category
+    if (spec_inq[0].value != '') {
+        updateCategory($('#spec_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
+    } if (maj_inq[0].value != '') {    
         updateCategory($('#maj_misc')[0].getElementsByClassName('code')[0], 'fulfilled'); 
-    } else {
+    } if (spec_inq[0].value === '') {
         updateCategory($('#spec_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
+    } if (maj_inq[0].value === '') {
         updateCategory($('#maj_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
     }
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -22,6 +22,7 @@ var level400 = {'CSC401': 0, 'CSC404': 0, 'CSC411': 0, 'CSC412': 0, 'CSC418': 0,
 activeInq = [];
 active400s = [];
 active300s = [];
+var index400 = 0;
 creditCountSpec = 0;
 creditCountMaj = 0;
 creditCountMin = 0;
@@ -83,7 +84,7 @@ function updateAllCategories() {
     update400s();
     fill300s();
     fill400s();
-    fillInquiries();
+    fillMisc();
     updateCreditCount();
 
     // Update Specialist 
@@ -223,6 +224,7 @@ function fill300s() {
     'use-strict';
 
     var i = 0; 
+    var index300 = 0;
     var spec300s = $('.lvl300spec');
     var maj300s = $('.lvl300maj');
     var min300s = $('.lvl300min');
@@ -240,26 +242,28 @@ function fill300s() {
     
 
     // fill courses that have been selected
-    for (var m = 0; m < active300s.length; m++) {
-        spec300s[i].value = active300s[i];
-        maj300s[i].value = active300s[i];
-        min300s[i].value = active300s[i]; 
-        i += 1;
-        if (i === 3) {
+    for (var m = 0; m < 3; m++) {
+        spec300s[i].value = active300s[index300];
+        maj300s[i].value = active300s[index300];
+        min300s[i].value = active300s[index300];
+        i += 1; 
+        index300 += 1;
+        if (index300 === active300s.length) {
             break;
         }
     }
 
     if (i < 3) {
-        for (var m = 0; m < active400s.length; m++) {
-        spec300s[i].value = active400s[i];
-        maj300s[i].value = active400s[i];
-        min300s[i].value = active400s[i]; 
-        i += 1;
-        if (i === 3) {
-            break;
+        for (var m = 0; m < 3; m++) {
+            spec300s[i].value = active400s[index400];
+            maj300s[i].value = active400s[index400];
+            min300s[i].value = active400s[index400]; 
+            i += 1;
+            index400 += 1;
+            if ((index400 === active400s.length) || (i === 3)) {
+                break;
+            }
         }
-    }
     }
 }  
 
@@ -301,7 +305,7 @@ function fill400s() {
 /**
  * Autofills textboxes and updates category for Inquiry courses
 **/
-function fillInquiries() {
+function fillMisc() {
     'use-strict';
 
     var i = 0;

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -88,6 +88,7 @@ function updateAllCategories() {
     fill300s();
     fill400s();
     fillMisc();
+    fillExtra();
     updateCreditCount();
 
     // Update Specialist 
@@ -246,26 +247,26 @@ function fill300s() {
 
     // fill courses that have been selected
     for (var m = 0; m < 3; m++) {
+        if (index300 === active300s.length) {
+            break;
+        }
         spec300s[i].value = active300s[index300];
         maj300s[i].value = active300s[index300];
         min300s[i].value = active300s[index300];
         i += 1; 
         index300 += 1;
-        if (index300 === active300s.length) {
-            break;
-        }
     }
 
     if (i < 3) {
         for (var m = 0; m < 3; m++) {
+            if ((index400 === active400s.length) || (i === 3)) {
+                break;
+            }
             spec300s[i].value = active400s[index400];
             maj300s[i].value = active400s[index400];
             min300s[i].value = active400s[index400]; 
             i += 1;
             index400 += 1;
-            if ((index400 === active400s.length) || (i === 3)) {
-                break;
-            }
         }
     }
 }  
@@ -293,17 +294,51 @@ function fill400s() {
 
     // fill courses that have been selected
     for (var m = 0; m < active400s.length; m++) {
+        if ((index400 == active400s.length) || (i === 3)) {
+            break;
+        }
         spec400s[i].value = active400s[index400];
         maj400s[i].value = active400s[index400];
         min400s[i].value = active400s[index400]; 
         i += 1;
         index400 += 1;
-        if ((index400 == active400s.length) || (i === 3)) {
-            break;
-        }
     }
 }
  
+
+function fillExtra() {
+    'use-strict'
+
+    var i = 0;
+    var spec_extra = $('#spec_extra')[0].getElementsByTagName('input');
+
+     // clear textboxes
+    for (k = 0; k < 4; k++) {
+        spec_extra[k].value = '';
+    }
+
+    // fill courses that have been selected
+    for (m = 0; m < active300s.length; m++) {
+        if ((index300 === active300s.length) || (i === 4)) {
+            break;
+        }
+        spec_extra[i].value = active300s[index300];
+        i += 1;
+        index300 += 1
+    }
+
+    if (i < 4) {
+        for (m = 0; m < active400s.length; m++) {
+            if ((index400 === active400s.length) || (i === 4)) {
+                break;
+            }
+            spec_extra[i].value = active400s[index400];
+            i += 1;
+            index400 += 1;
+        }
+    }
+
+}
 
 
 /**

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -20,6 +20,8 @@ var level400 = {'CSC401': 0, 'CSC404': 0, 'CSC411': 0, 'CSC412': 0, 'CSC418': 0,
                 'BCB420': 0, 'BCB430': 0, 'CSC410': 0};
 
 activeInq = [];
+active400s = [];
+active300s = [];
 creditCountSpec = 0;
 creditCountMaj = 0;
 creditCountMin = 0;
@@ -238,17 +240,26 @@ function fill300s() {
     
 
     // fill courses that have been selected
-    for (course in level300) {
-        if (level300.hasOwnProperty(course)) {
-            if (level300[course] === 1) {
-                spec300s[i].value = course;
-                maj300s[i].value = course;
-                min300s[i].value = course; 
-                i += 1;
-            } if (i === 3) {
-                break;
-            }
+    for (var m = 0; m < active300s.length; m++) {
+        spec300s[i].value = active300s[i];
+        maj300s[i].value = active300s[i];
+        min300s[i].value = active300s[i]; 
+        i += 1;
+        if (i === 3) {
+            break;
         }
+    }
+
+    if (i < 3) {
+        for (var m = 0; m < active400s.length; m++) {
+        spec300s[i].value = active400s[i];
+        maj300s[i].value = active400s[i];
+        min300s[i].value = active400s[i]; 
+        i += 1;
+        if (i === 3) {
+            break;
+        }
+    }
     }
 }  
 
@@ -274,19 +285,17 @@ function fill400s() {
     
 
     // fill courses that have been selected
-    for (course in level400) {
-        if (level400.hasOwnProperty(course)) {
-            if (level400[course] === 1) {
-                spec400s[i].value = course;
-                maj400s[i].value = course;
-                min400s[i].value = course; 
-                i += 1;
-            } if (i === 3) {
-                break;
-            }
+    for (var m = 0; m < active400s.length; m++) {
+        spec400s[i].value = active400s[i];
+        maj400s[i].value = active400s[i];
+        min400s[i].value = active400s[i]; 
+        i += 1;
+        if (i === 3) {
+            break;
         }
     }
-} 
+}
+ 
 
 
 /**

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -22,6 +22,7 @@ var level400 = {'CSC401': 0, 'CSC404': 0, 'CSC411': 0, 'CSC412': 0, 'CSC418': 0,
 activeInq = [];
 active400s = [];
 active300s = [];
+var index300 = 0;
 var index400 = 0;
 creditCountSpec = 0;
 creditCountMaj = 0;
@@ -35,6 +36,8 @@ creditCount400 = 0;
 $('#update').click(function (e) {
     'use-strict';
 
+    index300 = 0;
+    index400 = 0;
     updateAllCategories();
 });
 
@@ -224,7 +227,7 @@ function fill300s() {
     'use-strict';
 
     var i = 0; 
-    var index300 = 0;
+
     var spec300s = $('.lvl300spec');
     var maj300s = $('.lvl300maj');
     var min300s = $('.lvl300min');
@@ -290,11 +293,12 @@ function fill400s() {
 
     // fill courses that have been selected
     for (var m = 0; m < active400s.length; m++) {
-        spec400s[i].value = active400s[i];
-        maj400s[i].value = active400s[i];
-        min400s[i].value = active400s[i]; 
+        spec400s[i].value = active400s[index400];
+        maj400s[i].value = active400s[index400];
+        min400s[i].value = active400s[index400]; 
         i += 1;
-        if (i === 3) {
+        index400 += 1;
+        if ((index400 == active400s.length) || (i === 3)) {
             break;
         }
     }


### PR DESCRIPTION
This PR accomplishes the following things:

- All main constraints (except for the 490 constraint) work properly now
- You can manually type in a MAT or STA course into the respective category and press 'Update POSt' and it will be recognized
- Courses no longer overlap categories (if a course belongs in one category, it does not belong in another)

There are a couple of minor constraints missing, but the main ones are about complete.