### PR TITLE
Post fixes

### DIFF
--- a/hs/Constants.hs
+++ b/hs/Constants.hs
@@ -120,6 +120,7 @@ grey1 = parse "#222"
 grey2 = parse "#dedede"
 grey3 = parse "#949494"
 grey4 = parse "#BABABA"
+grey5 = parse "#DCDCDC"
 
 beige1 = parse "#EBE8E4"
 

--- a/hs/PostCss.hs
+++ b/hs/PostCss.hs
@@ -20,7 +20,7 @@ postStyles = do
 tabsCSS = do
     "#posts" & do 
         fontFamily ["HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", "Lucida Grande"][sansSerif]
-        fontSize $ (px 15)
+        fontSize $ (px 17)
         width $ pct 97
         backgroundColor white 
         border solid (px 1) grey2
@@ -76,7 +76,7 @@ postCSS = do
             paddingLeft (px 20)
             "cursor" -: "pointer"
             "box-shadow" -: "0 2px 2px -1px rgba(0, 0, 0, 0.055)"
-            borderBottom solid (px 1) "#DCDCDC"
+            borderBottom solid (px 1) grey5
             lineHeight (px 50)
             "list-style-type" -: "none"
             textAlign $ alignSide sideCenter

--- a/hs/PostCss.hs
+++ b/hs/PostCss.hs
@@ -93,6 +93,7 @@ postCSS = do
     "#div_specialist, #div_major, #div_minor" ? do
         position absolute
         "margin-above" -: "30px"
+        paddingBottom (px 30)
         display none
         height (pct 70)
         marginLeft (px 25)
@@ -125,4 +126,6 @@ postCSS = do
     "input" ? do
         textAlign $ alignSide sideCenter
         height $ (px 40)
+    "#notes" ? do
+        textAlign $ alignSide sideCenter
     

--- a/hs/PostCss.hs
+++ b/hs/PostCss.hs
@@ -76,6 +76,7 @@ postCSS = do
             paddingLeft (px 20)
             "cursor" -: "pointer"
             "box-shadow" -: "0 2px 2px -1px rgba(0, 0, 0, 0.055)"
+            borderBottom solid (px 1) "#DCDCDC"
             lineHeight (px 50)
             "list-style-type" -: "none"
             textAlign $ alignSide sideCenter

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -143,7 +143,10 @@ checkPost =  do
             H.div ! A.id "spec_misc" $ do 
                 H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
-                    H.input ! A.type_ "text" 
+                    H.input ! A.type_ "text"
+            H.h3 "Notes"
+            H.div ! A.id "notes" $ do
+                H.p "- You may take no more than 1.0 FCE of CSC490H1, CSC491H1, CSC494H1, CSC495H1, BCB430Y1" 
         H.div ! A.id "div_major" $ do
             H.h2 "First Year"
             H.div ! A.id "maj_csc108" $ do
@@ -211,6 +214,9 @@ checkPost =  do
                 H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
+            H.h3 "Notes"
+            H.div ! A.id "notes" $ do
+                H.p "- You may take no more than 1.0 FCE of CSC490H1, CSC491H1, CSC494H1, CSC495H1, BCB430Y1"
         H.div ! A.id "div_minor" $ do
             H.h2 "First Year"
             H.div ! A.id "min_csc108" $ do
@@ -242,6 +248,9 @@ checkPost =  do
                     H.input ! A.type_ "text" ! A.class_ "lvl300min lvl400min"
                     H.input ! A.type_ "text" ! A.class_ "lvl300min lvl400min"
                     H.input ! A.type_ "text" ! A.class_ "lvl300min lvl400min"
+            H.h3 "Notes"
+            H.div ! A.id "notes" $ do
+                H.p "- You may take no more than three 300/400 level CSC/ECE courses"
                 
 
                    

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -70,7 +70,7 @@ checkPost =  do
                 H.p ! A.class_ "code" $ "CSC165H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC165" $ "CSC165H (Mathematical Expression and Reasoning for Computer Science)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC165" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.div ! A.id "spec_calc1" $ do
                 H.p ! A.class_ "code" $ "(MAT135H and MAT136H) or MAT137H or MAT157H"
                 H.div ! A.class_ "more-info" $ do
@@ -95,12 +95,12 @@ checkPost =  do
                 H.p ! A.class_ "code" $ "CSC236H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC236" $ "CSC236H (Intro to the Theory of Computation)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC236" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.div ! A.id "spec_csc263" $ do
                 H.p ! A.class_ "code" $ "CSC263H or CSC265H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC263" $ "CSC263H (Data Structures and Analysis)"
-                    H.p ! A.class_ "full_name CSC265" $ "CSC265H (Enriched Data Structures and Analysis)"
+                    H.p ! A.class_ "full_name CSC263" $ "CSC265H (Enriched Data Structures and Analysis)"
             H.div ! A.id "spec_lin1" $ do
                 H.p ! A.class_ "code" $ "MAT221H or MAT223H"
                 H.div ! A.class_ "more-info" $ do
@@ -158,7 +158,7 @@ checkPost =  do
                 H.p ! A.class_ "code" $ "CSC165H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC165" $ "CSC165H (Mathematical Expression and Reasoning for Computer Science)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC165" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.div ! A.id "maj_calc1" $ do
                 H.p ! A.class_ "code" $ "(MAT135H and MAT136H) or MAT137H or MAT157H"
                 H.div ! A.class_ "more-info" $ do
@@ -179,12 +179,12 @@ checkPost =  do
                 H.p ! A.class_ "code" $ "CSC236H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC236" $ "CSC236H (Intro to the Theory of Computation)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC236" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.div ! A.id "maj_csc263" $ do
                 H.p ! A.class_ "code" $ "CSC263H or CSC265H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC263" $ "CSC263H (Data Structures and Analysis)"
-                    H.p ! A.class_ "full_name CSC265" $ "CSC265H (Enriched Data Structures and Analysis)"
+                    H.p ! A.class_ "full_name CSC263" $ "CSC265H (Enriched Data Structures and Analysis)"
             H.div ! A.id "maj_sta1" $ do
                 H.p ! A.class_ "code" $ "STA247H or STA255H or STA257H"
                 H.div ! A.class_ "more-info" $ do
@@ -225,13 +225,13 @@ checkPost =  do
                 H.p ! A.class_ "code" $ "CSC165H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC165" $ "CSC165H (Mathematical Expression and Reasoning for Computer Science)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC165" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.h2 "Later Years"
             H.div ! A.id "min_csc236" $ do
                 H.p ! A.class_ "code" $ "CSC236H or CSC240H"
                 H.div ! A.class_ "more-info" $ do
                     H.p ! A.class_ "full_name CSC236" $ "CSC236H (Intro to the Theory of Computation)"
-                    H.p ! A.class_ "full_name CSC240" $ "CSC240H (Enriched Intro to the Theory of Computation)"
+                    H.p ! A.class_ "full_name CSC236" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.div ! A.id "min_misc" $ do
                 H.p ! A.class_ "code" $ "Any 300/400-level CSC course (atleast 1.0 FCE), CSC209H, CSC258H, CSC263H/CSC265H (1.5 FCEs)"  
                 H.div ! A.class_ "more-info" $ do

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -227,6 +227,10 @@ checkPost =  do
                     H.p ! A.class_ "full_name CSC165" $ "CSC165H (Mathematical Expression and Reasoning for Computer Science)"
                     H.p ! A.class_ "full_name CSC165" $ "CSC240H (Enriched Intro to the Theory of Computation)"
             H.h2 "Later Years"
+            H.div ! A.id "min_csc207" $ do
+                H.p ! A.class_ "code" $ "CSC207H"
+                H.div ! A.class_ "more-info" $ do
+                    H.p ! A.class_ "full_name CSC207" $ "CSC207H (Software Design)"
             H.div ! A.id "min_csc236" $ do
                 H.p ! A.class_ "code" $ "CSC236H or CSC240H"
                 H.div ! A.class_ "more-info" $ do

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -9,7 +9,6 @@ import Happstack.Server
 import MakeElements
 import MasterTemplate
 import Scripts
-import SVGGen
 
 spec300Str :: String
 spec300Str = "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - " ++
@@ -145,7 +144,6 @@ checkPost =  do
                 H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
-            H.p ! A.class_ "code" $ H.em "No more than 1.0 FCEs from CSC490H, CSC491H, CSC494H, CSC495H, BCB430Y"
         H.div ! A.id "div_major" $ do
             H.h2 "First Year"
             H.div ! A.id "maj_csc108" $ do
@@ -213,7 +211,6 @@ checkPost =  do
                 H.p ! A.class_ "code" $ H.em $ H.toHtml $ inqStr
                 H.div ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
-            H.p ! A.class_ "code" $ H.em "No more than 1.0 FCEs from CSC490H, CSC491H, CSC494H, CSC495H, BCB430Y"
         H.div ! A.id "div_minor" $ do
             H.h2 "First Year"
             H.div ! A.id "min_csc108" $ do

--- a/hs/Scripts.hs
+++ b/hs/Scripts.hs
@@ -31,7 +31,9 @@ plannerScripts = concatHtml (map makeScript["https://ajax.googleapis.com/ajax/li
                                            "static/js/graph/create_data.js",
                                            "static/js/graph/parse_graph.js",
                                            "static/js/graph/mouse_events.js",
-                                           "static/js/graph/setup.js"])
+                                           "static/js/graph/setup.js", 
+                                           "static/js/post/update_post.js",
+                                           "static/js/post/update_counts.js"])
 
 timetableScripts :: H.Html
 timetableScripts = do jQuery

--- a/js/graph/setup.js
+++ b/js/graph/setup.js
@@ -87,6 +87,7 @@ $(document).ready(function () {
 
     FCEPrerequisiteCourses = [CSC318, CSC454];
 
+
     // Set width of FCE count
     var w = $('.infoTabs').width() - $('.tabList').outerWidth() - 1;
     $('#FCECountDiv').width(w + 'px');
@@ -99,6 +100,8 @@ $(document).ready(function () {
 
     // Initialize interface
     initializeGraphSettings();
+    
+    updateNavGraph();
 
     // Uncomment to enable the feedback form (must also be displayed in html)
     // activateFeedbackForm();

--- a/js/graph/setup.js
+++ b/js/graph/setup.js
@@ -87,7 +87,6 @@ $(document).ready(function () {
 
     FCEPrerequisiteCourses = [CSC318, CSC454];
 
-
     // Set width of FCE count
     var w = $('.infoTabs').width() - $('.tabList').outerWidth() - 1;
     $('#FCECountDiv').width(w + 'px');
@@ -101,6 +100,7 @@ $(document).ready(function () {
     // Initialize interface
     initializeGraphSettings();
     
+    // Update credit count in nav bar
     updateNavGraph();
 
     // Uncomment to enable the feedback form (must also be displayed in html)

--- a/js/post/change_div.js
+++ b/js/post/change_div.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    'use-strict';
+    'use-strict'
 	
     $('#div_specialist').show();
     updateAllCategories();
@@ -7,7 +7,7 @@ $(document).ready(function () {
 
 
 $('#specialist').click(function (e) {
-    'use-strict';
+    'use-strict'
 	
     e.preventDefault();
     resetAttributes();
@@ -17,7 +17,7 @@ $('#specialist').click(function (e) {
 
 
 $('#major').click(function (e) {
-    'use-strict';
+    'use-strict'
 	
     e.preventDefault();
     resetAttributes();
@@ -27,7 +27,7 @@ $('#major').click(function (e) {
 
 
 $('#minor').click (function (e) {
-    'use-strict';
+    'use-strict'
 	
     e.preventDefault();
     resetAttributes();
@@ -36,7 +36,7 @@ $('#minor').click (function (e) {
 });
 
 $('.code').click (function (e) {
-    'use-strict';
+    'use-strict'
     
     e.preventDefault();
     $(this).parent().find('.more-info').toggle();
@@ -46,6 +46,8 @@ $('.code').click (function (e) {
     Hides all currently open divs and resets navbar to display none of the links as clicked.
 **/
 function resetAttributes() {
+    'use-strict'
+
     document.getElementById('div_specialist').style.display = 'none';
     document.getElementById('div_major').style.display = 'none';
     document.getElementById('div_minor').style.display = 'none';

--- a/js/post/change_div.js
+++ b/js/post/change_div.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
 	
     openLastActiveTab();
     updateAllCategories();
-    updateNav();
+    updateNavPost();
 });
 
 
@@ -12,7 +12,7 @@ $('#specialist').click(function (e) {
 	
     e.preventDefault();
     openTab('specialist');
-    updateNav();
+    updateNavPost();
 });
 
 
@@ -21,7 +21,7 @@ $('#major').click(function (e) {
 	
     e.preventDefault();
     openTab('major');
-    updateNav();
+    updateNavPost();
 });
 
 
@@ -30,7 +30,7 @@ $('#minor').click (function (e) {
 	
     e.preventDefault();
     openTab('minor');
-    updateNav();
+    updateNavPost();
 });
 
 $('.code').click (function (e) {

--- a/js/post/change_div.js
+++ b/js/post/change_div.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
     'use-strict'
 	
-    $('#div_specialist').show();
+    openLastActiveTab();
     updateAllCategories();
 });
 
@@ -10,9 +10,7 @@ $('#specialist').click(function (e) {
     'use-strict'
 	
     e.preventDefault();
-    resetAttributes();
-    $('#div_specialist').show();
-    $('#specialist').css('background-color', '#9C9C9C');	
+    openTab('specialist');
 });
 
 
@@ -20,9 +18,7 @@ $('#major').click(function (e) {
     'use-strict'
 	
     e.preventDefault();
-    resetAttributes();
-    $('#div_major').show();
-    $('#major').css('background-color', '#9C9C9C');
+    openTab('major');
 });
 
 
@@ -30,9 +26,7 @@ $('#minor').click (function (e) {
     'use-strict'
 	
     e.preventDefault();
-    resetAttributes();
-    $('#div_minor').show();
-    $('#minor').css('background-color', '#9C9C9C');
+    openTab('minor');
 });
 
 $('.code').click (function (e) {
@@ -43,7 +37,7 @@ $('.code').click (function (e) {
 });
 
 /**
-    Hides all currently open divs and resets navbar to display none of the links as clicked.
+ * Hides all currently open divs and resets navbar to display none of the links as clicked.
 **/
 function resetAttributes() {
     'use-strict'
@@ -53,3 +47,55 @@ function resetAttributes() {
     document.getElementById('div_minor').style.display = 'none';
     $('#specialist, #major, #minor').css('background-color', 'white');
 };
+
+/**
+ * Resets cookies of all tabs to 'inactive' - not open
+**/
+function resetTabCookies() {
+    'use-strict'
+
+    setCookie('specialist', 'inactive');
+    setCookie('major', 'inactive');
+    setCookie('minor', 'inactive');
+}
+
+/**
+ * Opens a specific tab.
+ * @param {string} tab The tab that we want to open
+**/
+function openTab(tab) {
+    'use-strict'
+
+    resetAttributes();
+    resetTabCookies();
+
+    if (tab == 'specialist') {
+        $('#div_specialist').show();
+        $('#specialist').css('background-color', '#9C9C9C');
+        setCookie('specialist', 'active');
+    } else if (tab === 'major') {
+        $('#div_major').show();
+        $('#major').css('background-color', '#9C9C9C');
+        setCookie('major', 'active');
+    } else if (tab === 'minor') {
+         $('#div_minor').show();
+        $('#minor').css('background-color', '#9C9C9C');
+        setCookie('minor', 'active');
+    }
+}
+
+/**
+ * Opens the tab that was last opened. 
+**/
+function openLastActiveTab() {
+    'use-strict'
+
+
+    if (getCookie('minor') === 'active') {
+       openTab('minor');
+    } else if (getCookie('major') === 'active') {
+        openTab('major');
+    } else {
+        openTab('specialist');
+    }
+}

--- a/js/post/change_div.js
+++ b/js/post/change_div.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    'use-strict'
+    'use strict';
 	
     openLastActiveTab();
     updateAllCategories();
@@ -8,7 +8,7 @@ $(document).ready(function () {
 
 
 $('#specialist').click(function (e) {
-    'use-strict'
+    'use strict';
 	
     e.preventDefault();
     openTab('specialist');
@@ -17,7 +17,7 @@ $('#specialist').click(function (e) {
 
 
 $('#major').click(function (e) {
-    'use-strict'
+    'use strict';
 	
     e.preventDefault();
     openTab('major');
@@ -26,7 +26,7 @@ $('#major').click(function (e) {
 
 
 $('#minor').click (function (e) {
-    'use-strict'
+    'use strict';
 	
     e.preventDefault();
     openTab('minor');
@@ -34,7 +34,7 @@ $('#minor').click (function (e) {
 });
 
 $('.code').click (function (e) {
-    'use-strict'
+    'use strict';
     
     e.preventDefault();
     $(this).parent().find('.more-info').toggle();
@@ -44,7 +44,7 @@ $('.code').click (function (e) {
  * Hides all currently open divs and resets navbar to display none of the links as clicked.
 **/
 function resetAttributes() {
-    'use-strict'
+    'use strict';
 
     document.getElementById('div_specialist').style.display = 'none';
     document.getElementById('div_major').style.display = 'none';
@@ -56,7 +56,7 @@ function resetAttributes() {
  * Resets cookies of all tabs to 'inactive' - not open
 **/
 function resetTabCookies() {
-    'use-strict'
+    'use strict';
 
     setCookie('specialist', 'inactive');
     setCookie('major', 'inactive');
@@ -68,7 +68,7 @@ function resetTabCookies() {
  * @param {string} tab The tab that we want to open
 **/
 function openTab(tab) {
-    'use-strict'
+    'use strict';
 
     resetAttributes();
     resetTabCookies();
@@ -92,7 +92,7 @@ function openTab(tab) {
  * Opens the tab that was last opened. 
 **/
 function openLastActiveTab() {
-    'use-strict'
+    'use strict';
 
     if (getCookie('minor') === 'active') {
        openTab('minor');

--- a/js/post/change_div.js
+++ b/js/post/change_div.js
@@ -3,6 +3,7 @@ $(document).ready(function () {
 	
     openLastActiveTab();
     updateAllCategories();
+    updateNav();
 });
 
 
@@ -11,6 +12,7 @@ $('#specialist').click(function (e) {
 	
     e.preventDefault();
     openTab('specialist');
+    updateNav();
 });
 
 
@@ -19,6 +21,7 @@ $('#major').click(function (e) {
 	
     e.preventDefault();
     openTab('major');
+    updateNav();
 });
 
 
@@ -27,6 +30,7 @@ $('#minor').click (function (e) {
 	
     e.preventDefault();
     openTab('minor');
+    updateNav();
 });
 
 $('.code').click (function (e) {
@@ -89,7 +93,6 @@ function openTab(tab) {
 **/
 function openLastActiveTab() {
     'use-strict'
-
 
     if (getCookie('minor') === 'active') {
        openTab('minor');

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -95,7 +95,6 @@ function updateCompletedMinCourses() {
 function update300s() {
     'use strict';
 
-
     for (var courseCode in level300) {
         if (level300.hasOwnProperty(courseCode)) {
             if ((getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') 

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -2,7 +2,7 @@
  * Updates number of completed courses in Specialist.
 **/
 function updateCompletedSpecCourses () {
-    'use-strict';
+    'use-strict'
 
     for (var courseCode in completed_spec) {
         if (completed_spec.hasOwnProperty(courseCode)) {
@@ -33,7 +33,7 @@ function updateCompletedSpecCourses () {
  * Updates number of completed courses in Major.
 **/
 function updateCompletedMajCourses () {
-    'use-strict';
+    'use-strict'
 
     for (var courseCode in completed_maj) {
         if (completed_maj.hasOwnProperty(courseCode)) {
@@ -64,7 +64,7 @@ function updateCompletedMajCourses () {
  * Updates number of completed courses in Minor.
 **/
 function updateCompletedMinCourses() {
-    'use-strict';
+    'use-strict'
 
     for (var courseCode in completed_min) {
         if (completed_min.hasOwnProperty(courseCode)) {
@@ -87,7 +87,7 @@ function updateCompletedMinCourses() {
  * Updates number of 300 level category completed courses.
  **/
 function update300s() {
-    'use-strict';
+    'use-strict'
 
     for (var courseCode in level300) {
         if (level300.hasOwnProperty(courseCode)) {
@@ -118,7 +118,7 @@ function update300s() {
  * Updates number of 400 level category completed courses.
 **/
 function update400s() {
-    'use-strict';
+    'use-strict'
 
     for (var courseCode in level400) {
         if (level400.hasOwnProperty(courseCode)) {
@@ -149,7 +149,7 @@ function update400s() {
  * TODO: Fix credit count to account for all constraints
  **/
 function updateCreditCount() {
-    'use-strict';
+    'use-strict'
 
     // account for not needing to take CSC108
     specCount = creditCountSpec - (completed_spec['CSC108'] * 0.5) + creditCount300 + creditCount400;

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -1,6 +1,8 @@
 creditCountSpec = 0;
 creditCountMaj = 0;
 creditCountMin = 0;
+creditCount300and400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+
 
 /**
  * Updates number of completed courses in Specialist.
@@ -93,12 +95,12 @@ function updateCompletedMinCourses() {
 function update300s() {
     'use-strict'
 
+
     for (var courseCode in level300) {
         if (level300.hasOwnProperty(courseCode)) {
             if ((getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') 
                 && (active300s.indexOf(courseCode) === -1)) {
                 active300s.push(courseCode);
-                creditCount300 += 0.5;
                 if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
                     activeInq.push(courseCode);
                 }  
@@ -106,7 +108,6 @@ function update300s() {
                        && (active300s.indexOf(courseCode) > -1)) {
                 var index300 = active300s.indexOf(courseCode);
                 active300s.splice(index300, 1);
-                creditCount300 -= 0.5;
                 var indexInq = activeInq.indexOf(courseCode);
                 if (indexInq > -1) {
                     activeInq.splice(indexInq, 1);
@@ -115,7 +116,6 @@ function update300s() {
         }
     }       
 }
-
 
 
 /**
@@ -129,14 +129,12 @@ function update400s() {
             if ((getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overridden') 
                 && (active400s.indexOf(courseCode) === -1)) {
                     active400s.push(courseCode);
-                    creditCount400 += 0.5;
                     if ((CSCinq.indexOf(courseCode) > -1) && (activeInq.indexOf(courseCode) === -1)) { // check if Inquiry Course
                         activeInq.push(courseCode);
                     }
             } else if ((getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') 
                        && (active400s.indexOf(courseCode) > -1)) {
                 var index400 = active400s.indexOf(courseCode);
-                creditCount400 -= 0.5;
                 var indexInq = activeInq.indexOf(courseCode);
                 active400s.splice(index400, 1);
                 if (indexInq > -1) {
@@ -147,44 +145,3 @@ function update400s() {
     }
 }
 
-
-/**
- * Updates Credit Count for each POSt.
- * TODO: Fix credit count to account for all constraints
- **/
-function updateCreditCount() {
-    'use-strict'
-
-    specCount = creditCountSpec  + creditCount300 + creditCount400;
-    majCount = creditCountMaj + creditCount300 + creditCount400;
-    minCount = creditCountMin + creditCount300 + creditCount400;
-
-
-    updateSpecCreditCount(specCount);
-    updateMajCreditCount(majCount);
-    updateMinCreditCount(minCount);
-}
-
-function updateSpecCreditCount(specCount) {
-    if (specCount >= 12) {
-        $('#spec_creds').html('(12.0/12.0)');
-    } else {
-        $('#spec_creds').html('(' + specCount + '/12.0)');
-    }
-}
-
-function updateMajCreditCount(majCount) {
-    if (majCount >= 8) {
-        $('#maj_creds').html('(8.0/8.0)')
-    } else {
-        $('#maj_creds').html('(' + majCount + '/8.0)');
-    }
-}
-
-function updateMinCreditCount(minCount) {
-    if (minCount >= 4) {
-        $('#min_creds').html('(4.0/4.0)')
-    } else {
-        $('#min_creds').html('(' + minCount + '/4.0)');
-    }
-}

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -155,10 +155,9 @@ function update400s() {
 function updateCreditCount() {
     'use-strict'
 
-    // account for not needing to take CSC108
-    specCount = creditCountSpec - (completed_spec['CSC108'] * 0.5) + creditCount300 + creditCount400;
-    majCount = creditCountMaj - (completed_maj['CSC108'] * 0.5) + creditCount300 + creditCount400;
-    minCount = creditCountMin - (completed_min['CSC108'] * 0.5) + creditCount300 + creditCount400;
+    specCount = creditCountSpec  + creditCount300 + creditCount400;
+    majCount = creditCountMaj + creditCount300 + creditCount400;
+    minCount = creditCountMin + creditCount300 + creditCount400;
 
 
     updateSpecCreditCount(specCount);

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -1,3 +1,7 @@
+creditCountSpec = 0;
+creditCountMaj = 0;
+creditCountMin = 0;
+
 /**
  * Updates number of completed courses in Specialist.
 **/
@@ -157,21 +161,31 @@ function updateCreditCount() {
     minCount = creditCountMin - (completed_min['CSC108'] * 0.5) + creditCount300 + creditCount400;
 
 
-    if (creditCountSpec >= 12) {
-        $('#spec_creds').html('(12/12.0)');
-        $('#maj_creds').html('(8/8.0)');
-        $('#min_creds').html('(4/4.0)');
-    } else if (creditCountSpec >= 8) {
-        $('#spec_creds').html('(' + creditCountSpec + '/12.0)');
-        $('#maj_creds').html('(8/8.0)');
-        $('#min_creds').html('(4/4.0)');
-    } else if (creditCountSpec >= 4) {
-        $('#spec_creds').html('(' + creditCountSpec + '/12.0)');
-        $('#maj_creds').html('(' + creditCountSpec + '/8.0)');
-        $('#min_creds').html('(4/4.0)');
+    updateSpecCreditCount(specCount);
+    updateMajCreditCount(majCount);
+    updateMinCreditCount(minCount);
+}
+
+function updateSpecCreditCount(specCount) {
+    if (specCount >= 12) {
+        $('#spec_creds').html('(12.0/12.0)');
     } else {
-        $('#spec_creds').html('(' + creditCountSpec + '/12.0)');
-        $('#maj_creds').html('(' + creditCountSpec + '/8.0)');
-        $('#min_creds').html('(' + creditCountSpec + '/4.0)');
+        $('#spec_creds').html('(' + specCount + '/12.0)');
+    }
+}
+
+function updateMajCreditCount(majCount) {
+    if (majCount >= 8) {
+        $('#maj_creds').html('(8.0/8.0)')
+    } else {
+        $('#maj_creds').html('(' + majCount + '/8.0)');
+    }
+}
+
+function updateMinCreditCount(minCount) {
+    if (minCount >= 4) {
+        $('#min_creds').html('(4.0/4.0)')
+    } else {
+        $('#min_creds').html('(' + minCount + '/4.0)');
     }
 }

--- a/js/post/update_counts.js
+++ b/js/post/update_counts.js
@@ -8,7 +8,7 @@ creditCount300and400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
  * Updates number of completed courses in Specialist.
 **/
 function updateCompletedSpecCourses () {
-    'use-strict'
+    'use strict';
 
     for (var courseCode in completed_spec) {
         if (completed_spec.hasOwnProperty(courseCode)) {
@@ -39,7 +39,7 @@ function updateCompletedSpecCourses () {
  * Updates number of completed courses in Major.
 **/
 function updateCompletedMajCourses () {
-    'use-strict'
+    'use strict';
 
     for (var courseCode in completed_maj) {
         if (completed_maj.hasOwnProperty(courseCode)) {
@@ -70,7 +70,7 @@ function updateCompletedMajCourses () {
  * Updates number of completed courses in Minor.
 **/
 function updateCompletedMinCourses() {
-    'use-strict'
+    'use strict';
 
     for (var courseCode in completed_min) {
         if (completed_min.hasOwnProperty(courseCode)) {
@@ -93,7 +93,7 @@ function updateCompletedMinCourses() {
  * Updates number of 300 level category completed courses.
  **/
 function update300s() {
-    'use-strict'
+    'use strict';
 
 
     for (var courseCode in level300) {
@@ -122,7 +122,7 @@ function update300s() {
  * Updates number of 400 level category completed courses.
 **/
 function update400s() {
-    'use-strict'
+    'use strict';
 
     for (var courseCode in level400) {
         if (level400.hasOwnProperty(courseCode)) {

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -202,7 +202,6 @@ function updateAllCategories() {
     }
 
     checkPostCompleted();
-
 }
 
 
@@ -564,7 +563,7 @@ function addExtraMinCourses(index, min300s) {
     'use strict';
 
     for (var m = 0; m < 3; m++) {
-        if(index === 3) {
+        if (index === 3) {
             break;      
         } if (getCookie(additional_min_200s[m]) === 'active') {
             min300s[index].value = additional_min_200s[m];

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -41,37 +41,6 @@ $('#update').click(function (e) {
 
 
 /**
- * Sets cookie when clicking on a course in Check My POSt
- * TODO: Check prereqs properly
-**/
-/*
-$('.full_name').click(function (e) {
-    'use-strict';
-
-    var index = 0;
-    if (this.className.indexOf('CSC') > -1) {
-        index = this.className.indexOf('CSC'); 
-    } else if (this.className.indexOf('Calc') > -1) {
-        index = this.className.indexOf('Calc'); 
-    } else if (this.className.indexOf('Lin') > -1) {
-        index = this.className.indexOf('Lin'); 
-    } else if (this.className.indexOf('Sta') > -1) {
-        index = this.className.indexOf('Sta'); 
-    }
-    
-
-    var courseCode = this.className.substring(index, this.className.length);
-    if (getCookie(courseCode) === 'inactive' || getCookie(courseCode) === 'takeable') {
-            setCookie(courseCode, 'active');
-    } if (getCookie(courseCode) === 'active' || getCookie(courseCode) === 'overriden') {
-            setCookie(courseCode, 'inactive');
-    }
-    updateAllCategories();
-});
-*/
-
-
-/**
  * Updates all categories to see if they are fulfilled or not.
 **/
 // TODO: Add CSC240 and CSC265
@@ -405,7 +374,9 @@ function fill400s() {
 
 }
  
-
+/**
+ * Autofills the textboxes for the extra 300+ credits category
+**/
 function fillExtra() {
     'use-strict'
 
@@ -539,7 +510,8 @@ function fillCreditCount() {
 }
 
 /**
- *
+ * Autofills the credit count for Specialist
+ * @param {number} specCount The credit count for Specialist
 **/
 function fillSpecCreditCount(specCount) {
     if (specCount >= 12) {
@@ -550,7 +522,8 @@ function fillSpecCreditCount(specCount) {
 }
 
 /**
- *
+ * Autofills the credit count for Major
+ * @param {number} majCount The credit count for Major
 **/
 function fillMajCreditCount(majCount) {
     if (majCount >= 8) {
@@ -561,7 +534,8 @@ function fillMajCreditCount(majCount) {
 }
 
 /**
- *
+ * Autofills the credit count for Minor.
+ * @param {number} minCount The credit count for Minor
 **/
 function fillMinCreditCount(minCount) {
     if (minCount >= 4) {
@@ -572,7 +546,9 @@ function fillMinCreditCount(minCount) {
 }
 
 /**
- *
+ * Autofills extra 200-level courses for last Minor constraint.
+ * @param {number} index The textbox number we are at
+ * @param HTMLElement} min300s Array of textbox elements to fill
 **/
 function addExtraMinCourses(index, min300s) {
     for (var m = 0; m < 3; m++) {
@@ -589,7 +565,7 @@ function addExtraMinCourses(index, min300s) {
 }
 
 /**
- *
+ * Checks whether a POSt is completed and updates credit count colour if it is.
 **/
 function checkPostCompleted() {
     if (categories_completed['Spec'] === 17) {
@@ -612,7 +588,7 @@ function checkPostCompleted() {
 }
 
 /**
- *
+ * Updates the Nav Bar on the Check My Post! page
 **/
 function updateNavPost() {
     var nav_post = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
@@ -630,7 +606,7 @@ function updateNavPost() {
 }
 
 /**
- *
+ * Updates the Nav Bar on the Graph page.
 **/
 function updateNavGraph() {
     var nav_graph = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -36,7 +36,7 @@ $('#update').click(function (e) {
     'use-strict'
 
     updateAllCategories();
-    updateNav();
+    updateNavPost();
 });
 
 
@@ -603,15 +603,32 @@ function checkPostCompleted() {
 /**
  *
 **/
-function updateNav() {
+function updateNavPost() {
     var nav_post = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
 
     if (getCookie('specialist') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (specCount).toFixed(1) + '/12.0)';
+        setCookie('activecount', (specCount).toFixed(1));
     } if (getCookie('major') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (majCount).toFixed(1) + '/8.0)';
+        setCookie('activecount', (majCount).toFixed(1));
     } if (getCookie('minor') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (minCount).toFixed(1) + '/4.0)';
+        setCookie('activecount', (minCount).toFixed(1));
     } 
 }
 
+/**
+ *
+**/
+function updateNavGraph() {
+    var nav_graph = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
+
+    if (getCookie('specialist') === 'active') {
+        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/12.0)';
+    } if (getCookie('major') === 'active') {
+        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/8.0)';
+    } if (getCookie('minor') === 'active') {
+        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/4.0)';
+    } 
+}

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -24,8 +24,8 @@ var additional_min_200s = ['CSC209', 'CSC258', 'CSC263'];
 activeInq = [];
 active400s = [];
 active300s = [];
-var index300 = 0;
-var index400 = 0;
+var index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+var index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var index200 = 0;
 
 /**
@@ -34,8 +34,6 @@ var index200 = 0;
 $('#update').click(function (e) {
     'use-strict'
 
-    index300 = 0;
-    index400 = 0;
     updateAllCategories();
 });
 
@@ -77,6 +75,10 @@ $('.full_name').click(function (e) {
 // TODO: Add CSC240 and CSC265
 function updateAllCategories() {
     'use-strict'
+
+    index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+    index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+    index200 = 0;
 
     creditCount300and400['Maj'] = 0;
     creditCount300and400['Spec'] = 0;
@@ -145,11 +147,12 @@ function updateAllCategories() {
             i += 1;
         }
     }
+
+    console.log(i);
     if (i === 3) {
         updateCategory($('#spec_300')[0].getElementsByClassName('code')[0], 'fulfilled');
-        updateCategory($('#maj_300')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
-
+        updateCategory($('#maj_300')[0].getElementsByClassName('code')[0], 'fulfilled');
     } else {
         updateCategory($('#spec_300')[0].getElementsByClassName('code')[0], 'not fulfilled');
         updateCategory($('#maj_300')[0].getElementsByClassName('code')[0], 'not fulfilled');
@@ -274,58 +277,59 @@ function fill300s() {
     
     // clear textboxes
     for (k = 0; k < 3; k++) {
-        var course = spec300s[k].value;
-        if (getCookie(course) === 'inactive' || getCookie(course) === 'takeable') {
-            spec300s[k].value = '';
-            spec300s[k].readOnly = false;
-            if (k < 2) {
-                maj300s[k].value = '';
-                maj300s[k].readOnly = false;
-            }
-            min300s[k].value = '';
-            min300s[k].readOnly = false;
+        spec300s[k].value = '';
+        spec300s[k].readOnly = false;
+        if (k < 2) {
+            maj300s[k].value = '';
+            maj300s[k].readOnly = false;
         }
+        min300s[k].value = '';
+        min300s[k].readOnly = false;
     }
     
 
     // fill courses that have been selected
     for (var m = 0; m < 3; m++) {
-        if (index300 === active300s.length) {
+        if (index300['Spec'] === active300s.length) {
             break;
         }
-        spec300s[i].value = active300s[index300];
+        spec300s[i].value = active300s[index300['Spec']];
         spec300s[i].readOnly = true;
+        index300['Spec'] += 1;
         creditCount300and400['Spec'] += 0.5;
         if (i < 2) {
-            maj300s[i].value = active300s[index300];
+            maj300s[i].value = active300s[index300['Maj']];
             maj300s[i].readOnly = true;
+            index300['Maj'] += 1;
             creditCount300and400['Maj'] += 0.5;
         }
-        min300s[i].value = active300s[index300];
+        min300s[i].value = active300s[index300['Min']];
         min300s[i].readOnly = true;
+        index300['Min'] += 1;
         creditCount300and400['Min'] += 0.5;
         i += 1; 
-        index300 += 1;
     }
 
     if (i < 3) {
         for (var m = 0; m < 3; m++) {
-            if ((index400 === active400s.length) || (i === 3)) {
+            if ((index400['Spec'] === active400s.length) || (i === 3)) {
                 break;
             }
-            spec300s[i].value = active400s[index400];
+            spec300s[i].value = active400s[index400['Spec']];
             spec300s[i].readOnly = true;
+            index400['Spec'] += 1;
             creditCount300and400['Spec'] += 0.5;
             if (i < 2) {
-                maj300s[i].value = active400s[index400];
+                maj300s[i].value = active400s[index400['Maj']];
                 maj300s[i].readOnly = true;
+                index400['Maj'] += 1;
                 creditCount300and400['Maj'] += 0.5;
             }
-            min300s[i].value = active400s[index400]; 
+            min300s[i].value = active400s[index400['Min']]; 
             min300s[i].readOnly = true;
+            index400['Min'] += 1;
             creditCount300and400['Min'] += 0.5;
             i += 1;
-            index400 += 1;
         }
     }
 
@@ -363,23 +367,26 @@ function fill400s() {
 
     // fill courses that have been selected
     for (var m = 0; m < active400s.length; m++) {
-        if ((index400 == active400s.length) || (i === 3)) {
+        if ((index400['Spec'] == active400s.length) || (i === 3)) {
             break;
         }
-        spec400s[i].value = active400s[index400];
+        spec400s[i].value = active400s[index400['Spec']];
         spec400s[i].readOnly = true;
+        index400['Spec'] += 1;
         creditCount300and400['Spec'] += 0.5;
         if (i < 1) {
-            maj400s[i].value = active400s[index400];
+            maj400s[i].value = active400s[index400['Maj']];
             maj400s[i].readOnly = true;
+            index400['Maj'] += 1;
             creditCount300and400['Maj'] += 0.5;
         }
-        min400s[i].value = active400s[index400]; 
+        min400s[i].value = active400s[index400['Min']]; 
         min400s[i].readOnly = true;
+        index400['Min'] += 1;
         creditCount300and400['Min'] += 0.5;
         i += 1;
-        index400 += 1;
     }
+
 }
  
 
@@ -404,38 +411,40 @@ function fillExtra() {
 
     // fill courses that have been selected
     for (m = 0; m < active300s.length; m++) {
-        if ((index300 === active300s.length) || (i === 4)) {
+        if ((index300['Spec'] === active300s.length) || (i === 4)) {
             break;
         }
         if ((i < 2) && (maj_extra[i].value === '')) {
-            maj_extra[i].value = active300s[index300];
+            maj_extra[i].value = active300s[index300['Maj']];
             maj_extra[i].readOnly = true;
+            index300['Maj'] += 1;
             creditCount300and400['Maj'] += 0.5;
         }
         if (spec_extra[i].value === '') {
-            spec_extra[i].value = active300s[index300];
+            spec_extra[i].value = active300s[index300['Spec']];
             spec_extra[i].readOnly = true;
+            index300['Spec'] += 1;
             creditCount300and400['Spec'] += 0.5;
-            index300 += 1;
         } 
         i += 1;
     }
 
     if (i < 4) {
         for (m = 0; m < active400s.length; m++) {
-            if ((index400 === active400s.length) || (i === 4)) {
+            if (((index400['Spec'] === active400s.length) && (index400['Maj'] === active400s.length)) || (i === 4)) {
                 break;
             }
-            if ((i < 2) && (maj_extra[i].value === '')) {
-                maj_extra[i].value = active400s[index400];
+            if ((i < 3) && (maj_extra[i].value === '')) {
+                maj_extra[i].value = active400s[index400['Maj']];
                 maj_extra[i].readOnly = true;
+                index400['Maj'] += 1;
                 creditCount300and400['Maj'] += 0.5;
             }
-            if (spec_extra[i].value === '') {
-                spec_extra[i].value = active400s[index400];
+            if ((spec_extra[i].value === '') && (index400['Spec'] < active400s.length)){
+                spec_extra[i].value = active400s[index400['Spec']];
                 spec_extra[i].readOnly = true;
+                index400['Spec'] += 1;
                 creditCount300and400['Spec'] += 0.5;
-                index400 += 1;
             }
             i += 1;
         }

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -28,12 +28,15 @@ var index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var categories_completed = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var index200 = 0;
+var minCount = 0;
+var majCount = 0;
+var specCount = 0;
 
 /**
  * Updates POSts when button is clicked.
 **/
 $('#update').click(function (e) {
-    'use-strict'
+    'use strict';
 
     updateAllCategories();
     updateNavPost();
@@ -45,7 +48,7 @@ $('#update').click(function (e) {
 **/
 // TODO: Add CSC240 and CSC265
 function updateAllCategories() {
-    'use-strict'
+    'use strict';
 
     index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
     index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
@@ -162,9 +165,9 @@ function updateAllCategories() {
 
     // Update Extra
 
-    countMaj = 0; 
-    countSpec = 0;
-    countMin = 0;
+    var countMaj = 0; 
+    var countSpec = 0;
+    var countMin = 0;
     var specExtra = $('#spec_extra')[0].getElementsByTagName('input');
     var majExtra = $('#maj_extra')[0].getElementsByTagName('input');
     var minExtra = $('#min_misc')[0].getElementsByTagName('input');
@@ -211,7 +214,7 @@ function activateCourse(courseCode) {
     'use-strict'
     
     var elements = document.getElementsByClassName(courseCode);
-    for (i = 0; i < elements.length; i++) {
+    for (var i = 0; i < elements.length; i++) {
         elements[i].style.backgroundColor = '#99ff99';
     }
 }
@@ -225,7 +228,7 @@ function deactivateCourse(courseCode) {
     'use-strict'
     
     var elements = document.getElementsByClassName(courseCode);
-    for (i = 0; i < elements.length; i++) {
+    for (var i = 0; i < elements.length; i++) {
             elements[i].style.backgroundColor = '#BABABA';
     }
 }
@@ -251,7 +254,7 @@ function updateCategory(category, status) {
  * Autofills textboxes for 300 level courses. 
 **/
 function fill300s() {
-    'use-strict'
+    'use strict';
 
     var i = 0; 
 
@@ -261,7 +264,7 @@ function fill300s() {
 
     
     // clear textboxes
-    for (k = 0; k < 3; k++) {
+    for (var k = 0; k < 3; k++) {
         spec300s[k].value = '';
         spec300s[k].readOnly = false;
         if (k < 2) {
@@ -293,6 +296,7 @@ function fill300s() {
         index300['Min'] += 1;
         creditCount300and400['Min'] += 0.5;
         i += 1; 
+
     }
 
     if (i < 3) {
@@ -329,7 +333,7 @@ function fill300s() {
  * Autofills textboxes for 400 level courses. 
 **/
 function fill400s() {
-    'use-strict'
+    'use strict';
 
     var i = 0; 
     var spec400s = $('.lvl400spec');
@@ -338,7 +342,7 @@ function fill400s() {
 
     
     // clear textboxes
-    for (k = 0; k < 3; k++) {
+    for (var k = 0; k < 3; k++) {
         spec400s[k].value = '';
         spec400s[k].readOnly = false;
         if (k < 1) {
@@ -370,7 +374,7 @@ function fill400s() {
         index400['Min'] += 1;
         creditCount300and400['Min'] += 0.5;
         i += 1;
-    }
+    } 
 
 }
  
@@ -378,7 +382,7 @@ function fill400s() {
  * Autofills the textboxes for the extra 300+ credits category
 **/
 function fillExtra() {
-    'use-strict'
+    'use strict';
 
     var i = 0;
     var spec_extra = $('#spec_extra')[0].getElementsByTagName('input');
@@ -408,7 +412,7 @@ function fillExtra() {
     }
 
     // fill courses that have been selected
-    for (m = 0; m < active300s.length; m++) {
+    for (var m = 0; m < active300s.length; m++) {
         if ((index300['Spec'] === active300s.length) || (i === 4)) {
             break;
         }
@@ -428,7 +432,7 @@ function fillExtra() {
     }
 
     if (i < 4) {
-        for (m = 0; m < active400s.length; m++) {
+        for (var m = 0; m < active400s.length; m++) {
             if (((index400['Spec'] === active400s.length) && (index400['Maj'] === active400s.length)) || (i === 4)) {
                 break;
             }
@@ -455,7 +459,7 @@ function fillExtra() {
  * Autofills textboxes and updates category for Inquiry courses
 **/
 function fillMisc() {
-    'use-strict'
+    'use strict';
 
     var spec_inq = $('#spec_misc')[0].getElementsByTagName('input');
     var maj_inq = $('#maj_misc')[0].getElementsByTagName('input');
@@ -497,7 +501,7 @@ function fillMisc() {
  * Updates Credit Count for each POSt.
  **/
 function fillCreditCount() {
-    'use-strict'
+    'use strict';
 
     specCount = creditCountSpec  + creditCount300and400['Spec'];
     majCount = creditCountMaj + creditCount300and400['Maj'];
@@ -514,6 +518,8 @@ function fillCreditCount() {
  * @param {number} specCount The credit count for Specialist
 **/
 function fillSpecCreditCount(specCount) {
+    'use strict';
+
     if (specCount >= 12) {
         $('#spec_creds').html('(12.0/12.0)');
     } else {
@@ -526,6 +532,8 @@ function fillSpecCreditCount(specCount) {
  * @param {number} majCount The credit count for Major
 **/
 function fillMajCreditCount(majCount) {
+    'use strict';
+
     if (majCount >= 8) {
         $('#maj_creds').html('(8.0/8.0)')
     } else {
@@ -538,6 +546,8 @@ function fillMajCreditCount(majCount) {
  * @param {number} minCount The credit count for Minor
 **/
 function fillMinCreditCount(minCount) {
+    'use strict';
+
     if (minCount >= 4) {
         $('#min_creds').html('(4.0/4.0)')
     } else {
@@ -551,6 +561,8 @@ function fillMinCreditCount(minCount) {
  * @param HTMLElement} min300s Array of textbox elements to fill
 **/
 function addExtraMinCourses(index, min300s) {
+    'use strict';
+
     for (var m = 0; m < 3; m++) {
         if(index === 3) {
             break;      
@@ -568,6 +580,8 @@ function addExtraMinCourses(index, min300s) {
  * Checks whether a POSt is completed and updates credit count colour if it is.
 **/
 function checkPostCompleted() {
+    'use strict';
+
     if (categories_completed['Spec'] === 17) {
         $('#spec_creds').css('color', 'green');
     } else {
@@ -591,6 +605,8 @@ function checkPostCompleted() {
  * Updates the Nav Bar on the Check My Post! page
 **/
 function updateNavPost() {
+    'use strict';
+
     var nav_post = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
 
     if (getCookie('specialist') === 'active') {
@@ -609,6 +625,8 @@ function updateNavPost() {
  * Updates the Nav Bar on the Graph page.
 **/
 function updateNavGraph() {
+    'use strict';
+
     var nav_graph = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
 
     if (getCookie('specialist') === 'active') {

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -27,8 +27,6 @@ active300s = [];
 var index300 = 0;
 var index400 = 0;
 var index200 = 0;
-creditCount300 = 0;
-creditCount400 = 0;
 
 /**
  * Updates POSts when button is clicked.
@@ -80,6 +78,11 @@ $('.full_name').click(function (e) {
 function updateAllCategories() {
     'use-strict'
 
+    creditCount300and400['Maj'] = 0;
+    creditCount300and400['Spec'] = 0;
+    creditCount300and400['Min'] = 0;
+
+
     updateCompletedMinCourses();
     updateCompletedMajCourses();
     updateCompletedSpecCourses();
@@ -89,7 +92,8 @@ function updateAllCategories() {
     fill300s();
     fillMisc();
     fillExtra();
-    updateCreditCount();
+    // updateCreditCount();
+    fillCreditCount();
 
     // Update Specialist 
     for (var property in completed_spec) {
@@ -291,12 +295,15 @@ function fill300s() {
         }
         spec300s[i].value = active300s[index300];
         spec300s[i].readOnly = true;
+        creditCount300and400['Spec'] += 0.5;
         if (i < 2) {
             maj300s[i].value = active300s[index300];
             maj300s[i].readOnly = true;
+            creditCount300and400['Maj'] += 0.5;
         }
         min300s[i].value = active300s[index300];
         min300s[i].readOnly = true;
+        creditCount300and400['Min'] += 0.5;
         i += 1; 
         index300 += 1;
     }
@@ -308,12 +315,15 @@ function fill300s() {
             }
             spec300s[i].value = active400s[index400];
             spec300s[i].readOnly = true;
+            creditCount300and400['Spec'] += 0.5;
             if (i < 2) {
                 maj300s[i].value = active400s[index400];
                 maj300s[i].readOnly = true;
+                creditCount300and400['Maj'] += 0.5;
             }
             min300s[i].value = active400s[index400]; 
             min300s[i].readOnly = true;
+            creditCount300and400['Min'] += 0.5;
             i += 1;
             index400 += 1;
         }
@@ -358,12 +368,15 @@ function fill400s() {
         }
         spec400s[i].value = active400s[index400];
         spec400s[i].readOnly = true;
+        creditCount300and400['Spec'] += 0.5;
         if (i < 1) {
             maj400s[i].value = active400s[index400];
             maj400s[i].readOnly = true;
+            creditCount300and400['Maj'] += 0.5;
         }
         min400s[i].value = active400s[index400]; 
         min400s[i].readOnly = true;
+        creditCount300and400['Min'] += 0.5;
         i += 1;
         index400 += 1;
     }
@@ -397,10 +410,12 @@ function fillExtra() {
         if ((i < 2) && (maj_extra[i].value === '')) {
             maj_extra[i].value = active300s[index300];
             maj_extra[i].readOnly = true;
+            creditCount300and400['Maj'] += 0.5;
         }
         if (spec_extra[i].value === '') {
             spec_extra[i].value = active300s[index300];
             spec_extra[i].readOnly = true;
+            creditCount300and400['Spec'] += 0.5;
             index300 += 1;
         } 
         i += 1;
@@ -414,10 +429,12 @@ function fillExtra() {
             if ((i < 2) && (maj_extra[i].value === '')) {
                 maj_extra[i].value = active400s[index400];
                 maj_extra[i].readOnly = true;
+                creditCount300and400['Maj'] += 0.5;
             }
             if (spec_extra[i].value === '') {
                 spec_extra[i].value = active400s[index400];
                 spec_extra[i].readOnly = true;
+                creditCount300and400['Spec'] += 0.5;
                 index400 += 1;
             }
             i += 1;
@@ -467,13 +484,66 @@ function fillMisc() {
 
 }
 
+/**
+ * Updates Credit Count for each POSt.
+ **/
+function fillCreditCount() {
+    'use-strict'
 
+    specCount = creditCountSpec  + creditCount300and400['Spec'];
+    majCount = creditCountMaj + creditCount300and400['Maj'];
+    minCount = creditCountMin + creditCount300and400['Min'];
+
+
+    fillSpecCreditCount(specCount);
+    fillMajCreditCount(majCount);
+    fillMinCreditCount(minCount);
+}
+
+/**
+ *
+**/
+function fillSpecCreditCount(specCount) {
+    if (specCount >= 12) {
+        $('#spec_creds').html('(12.0/12.0)');
+    } else {
+        $('#spec_creds').html('(' + specCount + '/12.0)');
+    }
+}
+
+/**
+ *
+**/
+function fillMajCreditCount(majCount) {
+    if (majCount >= 8) {
+        $('#maj_creds').html('(8.0/8.0)')
+    } else {
+        $('#maj_creds').html('(' + majCount + '/8.0)');
+    }
+}
+
+/**
+ *
+**/
+function fillMinCreditCount(minCount) {
+    if (minCount >= 4) {
+        $('#min_creds').html('(4.0/4.0)')
+    } else {
+        $('#min_creds').html('(' + minCount + '/4.0)');
+    }
+}
+
+/**
+ *
+**/
 function addExtraMinCourses(index, min300s) {
     for (var m = 0; m < 3; m++) {
-        if((index === 3)) {
+        if(index === 3) {
             break;      
         } if (getCookie(additional_min_200s[m]) === 'active') {
             min300s[index].value = additional_min_200s[m];
+            min300s[index].readOnly = true;
+            creditCount300and400['Min'] += 0.5;
             index += 1;
         }
         

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -85,8 +85,8 @@ function updateAllCategories() {
     updateCompletedSpecCourses();
     update300s();
     update400s();
-    fill300s();
     fill400s();
+    fill300s();
     fillMisc();
     fillExtra();
     updateCreditCount();

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -414,6 +414,8 @@ function fillExtra() {
     var maj_extra = $('#maj_extra')[0].getElementsByTagName('input');
 
     for (var k = 0; k < 4; k++) {
+
+        // clear text boxes
         if (spec_extra[k].value.indexOf('MAT') === -1 && spec_extra[k].value.indexOf('STA') === -1) {
             spec_extra[k].value = '';
             spec_extra[k].readOnly = false;
@@ -421,6 +423,15 @@ function fillExtra() {
             if (maj_extra[k].value.indexOf('MAT') === -1 && maj_extra[k].value.indexOf('STA') === -1) {
                 maj_extra[k].value = '';
                 maj_extra[k].readOnly = false;
+            }
+        } 
+
+        // add credit count for MAT and STA courses
+        if (spec_extra[k].value.indexOf('MAT') > -1 || spec_extra[k].value.indexOf('STA') > -1) {
+            creditCount300and400['Spec'] += 0.5;
+        } if (k < 3) {
+            if (maj_extra[k].value.indexOf('MAT') > -1 || maj_extra[k].value.indexOf('STA') > -1) {
+                creditCount300and400['Maj'] += 0.5;
             }
         }
     }

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -59,7 +59,6 @@ function updateAllCategories() {
     creditCount300and400['Spec'] = 0;
     creditCount300and400['Min'] = 0;
 
-
     updateCompletedMinCourses();
     updateCompletedMajCourses();
     updateCompletedSpecCourses();
@@ -71,6 +70,8 @@ function updateAllCategories() {
     fillExtra();
     // updateCreditCount();
     fillCreditCount();
+
+
 
     // Update Specialist 
     for (var property in completed_spec) {
@@ -117,6 +118,7 @@ function updateAllCategories() {
             }
         }
     }
+
 
 
     // Update 300s
@@ -282,8 +284,10 @@ function fill300s() {
             maj300s[k].value = '';
             maj300s[k].readOnly = false;
         }
-        min300s[k].value = '';
-        min300s[k].readOnly = false;
+        if (min300s[k].value.indexOf('CSC4') === -1) {
+            min300s[k].value = '';
+            min300s[k].readOnly = false;
+        }
     }
     
 
@@ -302,10 +306,12 @@ function fill300s() {
             index300['Maj'] += 1;
             creditCount300and400['Maj'] += 0.5;
         }
-        min300s[i].value = active300s[index300['Min']];
-        min300s[i].readOnly = true;
-        index300['Min'] += 1;
-        creditCount300and400['Min'] += 0.5;
+        if (min300s[i].value === '') {
+            min300s[i].value = active300s[index300['Min']];
+            min300s[i].readOnly = true;
+            index300['Min'] += 1;
+            creditCount300and400['Min'] += 0.5;
+        }
         i += 1; 
 
     }
@@ -516,7 +522,7 @@ function fillCreditCount() {
 
     specCount = creditCountSpec  + creditCount300and400['Spec'];
     majCount = creditCountMaj + creditCount300and400['Maj'];
-    minCount = creditCountMin + (creditCount300and400['Min'] * 0.5);
+    minCount = creditCountMin + creditCount300and400['Min'];
 
 
     fillSpecCreditCount(specCount);

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -36,6 +36,7 @@ $('#update').click(function (e) {
     'use-strict'
 
     updateAllCategories();
+    updateNav();
 });
 
 
@@ -597,5 +598,20 @@ function checkPostCompleted() {
     } else {
         $('#min_creds').css('color', 'red');
     }
+}
+
+/**
+ *
+**/
+function updateNav() {
+    var nav_post = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
+
+    if (getCookie('specialist') === 'active') {
+        nav_post.innerHTML = 'Check My POSt! (' + (specCount).toFixed(1) + '/12.0)';
+    } if (getCookie('major') === 'active') {
+        nav_post.innerHTML = 'Check My POSt! (' + (majCount).toFixed(1) + '/8.0)';
+    } if (getCookie('minor') === 'active') {
+        nav_post.innerHTML = 'Check My POSt! (' + (minCount).toFixed(1) + '/4.0)';
+    } 
 }
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -157,13 +157,13 @@ function updateAllCategories() {
 
     i = 0; 
     var spec400s = $('.lvl400spec');
-    for (var l = 0; l < 3; l++) {
+    for (var l = 0; l < 1; l++) {
         if (spec400s[l].value != '') {
             i += 1;
         }
     }
 
-    if (i === 3) {
+    if (i === 1) {
         updateCategory($('#spec_400')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -26,6 +26,7 @@ active400s = [];
 active300s = [];
 var index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+var categories_completed = {'Spec': 0, 'Maj': 0, 'Min': 0};
 var index200 = 0;
 
 /**
@@ -78,6 +79,7 @@ function updateAllCategories() {
 
     index300 = {'Spec': 0, 'Maj': 0, 'Min': 0};
     index400 = {'Spec': 0, 'Maj': 0, 'Min': 0};
+    categories_completed = {'Spec': 0, 'Maj': 0, 'Min': 0};
     index200 = 0;
 
     creditCount300and400['Maj'] = 0;
@@ -104,6 +106,7 @@ function updateAllCategories() {
             if (completed_spec[property] === 1) { // if the category is completed
                 activateCourse(property);
                 updateCategory(category, 'fulfilled');
+                categories_completed['Spec'] += 1;
             } else { // if the category is not completed
                 deactivateCourse(property);
                 updateCategory(category, 'not fulfilled');
@@ -118,12 +121,14 @@ function updateAllCategories() {
             if (completed_maj[property] === 1) { // if the category is completed
                 activateCourse(property);
                 updateCategory(category, 'fulfilled');
+                categories_completed['Maj'] += 1;
             } else { // if the category is not completed
                 deactivateCourse(property);
                 updateCategory(category, 'not fulfilled');
             }
         }
     }
+
 
     // Update Minor
     for (var property in completed_min) {
@@ -132,12 +137,14 @@ function updateAllCategories() {
             if (completed_min[property] === 1) { // if the category is completed
                 activateCourse(property);
                 updateCategory(category, 'fulfilled');
+                categories_completed['Min'] += 1;
             } else { // if the category is not completed
                 deactivateCourse(property);
                 updateCategory(category, 'not fulfilled');
             }
         }
     }
+
 
     // Update 300s
     var i = 0; 
@@ -148,17 +155,18 @@ function updateAllCategories() {
         }
     }
 
-    console.log(i);
     if (i === 3) {
         updateCategory($('#spec_300')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#maj_300')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Spec'] += 1;
+        categories_completed['Maj'] += 1;
     } else {
         updateCategory($('#spec_300')[0].getElementsByClassName('code')[0], 'not fulfilled');
         updateCategory($('#maj_300')[0].getElementsByClassName('code')[0], 'not fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
-        
     }
+
 
     // Update 400s
 
@@ -174,6 +182,8 @@ function updateAllCategories() {
         updateCategory($('#spec_400')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Spec'] += 1;
+        categories_completed['Maj'] += 1;
     } else {
         updateCategory($('#spec_400')[0].getElementsByClassName('code')[0], 'not fulfilled');
         updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'not fulfilled');
@@ -203,10 +213,13 @@ function updateAllCategories() {
 
     if (countSpec === 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Spec'] += 1;
     } if (countMaj === 3) {
         updateCategory($('#maj_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Maj'] += 1;
     } if (countMin === 3) {
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Min'] += 1;
     } if (countSpec < 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
     } if (countMaj < 3) {
@@ -214,6 +227,8 @@ function updateAllCategories() {
     } if (countMin < 3) {
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
     }
+
+    checkPostCompleted();
 
 }
 
@@ -483,8 +498,10 @@ function fillMisc() {
     // update category
     if (spec_inq[0].value != '') {
         updateCategory($('#spec_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Spec'] += 1;
     } if (maj_inq[0].value != '') {    
         updateCategory($('#maj_misc')[0].getElementsByClassName('code')[0], 'fulfilled'); 
+        categories_completed['Maj'] += 1;
     } if (spec_inq[0].value === '') {
         updateCategory($('#spec_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
     } if (maj_inq[0].value === '') {
@@ -501,7 +518,7 @@ function fillCreditCount() {
 
     specCount = creditCountSpec  + creditCount300and400['Spec'];
     majCount = creditCountMaj + creditCount300and400['Maj'];
-    minCount = creditCountMin + creditCount300and400['Min'];
+    minCount = creditCountMin + (creditCount300and400['Min'] * 0.5);
 
 
     fillSpecCreditCount(specCount);
@@ -516,7 +533,7 @@ function fillSpecCreditCount(specCount) {
     if (specCount >= 12) {
         $('#spec_creds').html('(12.0/12.0)');
     } else {
-        $('#spec_creds').html('(' + specCount + '/12.0)');
+        $('#spec_creds').html('(' + (specCount).toFixed(1) + '/12.0)');
     }
 }
 
@@ -527,7 +544,7 @@ function fillMajCreditCount(majCount) {
     if (majCount >= 8) {
         $('#maj_creds').html('(8.0/8.0)')
     } else {
-        $('#maj_creds').html('(' + majCount + '/8.0)');
+        $('#maj_creds').html('(' + (majCount).toFixed(1) + '/8.0)');
     }
 }
 
@@ -538,7 +555,7 @@ function fillMinCreditCount(minCount) {
     if (minCount >= 4) {
         $('#min_creds').html('(4.0/4.0)')
     } else {
-        $('#min_creds').html('(' + minCount + '/4.0)');
+        $('#min_creds').html('(' + (minCount).toFixed(1) + '/4.0)');
     }
 }
 
@@ -556,6 +573,29 @@ function addExtraMinCourses(index, min300s) {
             index += 1;
         }
         
+    }
+}
+
+/**
+ *
+**/
+function checkPostCompleted() {
+    if (categories_completed['Spec'] === 17) {
+        $('#spec_creds').css('color', 'green');
+    } else {
+        $('#spec_creds').css('color', 'red');
+    }
+    
+    if (categories_completed['Maj'] === 13) {
+        $('#maj_creds').css('color', 'green');
+    } else {
+        $('#maj_creds').css('color', 'red');
+    } 
+
+    if (categories_completed['Min'] === 6) {
+        $('#min_creds').css('color', 'green');
+    } else {
+        $('#min_creds').css('color', 'red');
     }
 }
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -19,11 +19,14 @@ var level400 = {'CSC401': 0, 'CSC404': 0, 'CSC411': 0, 'CSC412': 0, 'CSC418': 0,
                 'CSC490': 0, 'CSC491': 0, 'CSC494': 0, 'CSC495': 0, 'BCB410': 0, 
                 'BCB420': 0, 'BCB430': 0, 'CSC410': 0};
 
+var additional_min_200s = ['CSC209', 'CSC258', 'CSC263'];
+
 activeInq = [];
 active400s = [];
 active300s = [];
 var index300 = 0;
 var index400 = 0;
+var index200 = 0;
 creditCountSpec = 0;
 creditCountMaj = 0;
 creditCountMin = 0;
@@ -177,26 +180,35 @@ function updateAllCategories() {
 
     countMaj = 0; 
     countSpec = 0;
+    countMin = 0;
     var specExtra = $('#spec_extra')[0].getElementsByTagName('input');
     var majExtra = $('#maj_extra')[0].getElementsByTagName('input');
+    var minExtra = $('#min_misc')[0].getElementsByTagName('input');
     for (var l = 0; l < 4; l++) {
         if (specExtra[l].value != '') {
             countSpec += 1;
         } if (l < 3) {
             if (majExtra[l].value != '') {
                 countMaj += 1;
+            } if (minExtra[l].value != '') {
+                countMin += 1;
             }
         }
     }
+
 
     if (countSpec === 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
     } if (countMaj === 3) {
         updateCategory($('#maj_extra')[0].getElementsByClassName('code')[0], 'fulfilled');
+    } if (countMin === 3) {
+        updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
     } if (countSpec < 4) {
         updateCategory($('#spec_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
     } if (countMaj < 3) {
         updateCategory($('#maj_extra')[0].getElementsByClassName('code')[0], 'not fulfilled');
+    } if (countMin < 3) {
+        updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
     }
 
 }
@@ -308,6 +320,11 @@ function fill300s() {
             i += 1;
             index400 += 1;
         }
+    }
+
+    // add extra 200 level courses for min
+    if (i < 3) {
+        addExtraMinCourses(i, min300s);
     }
 }  
 
@@ -453,4 +470,16 @@ function fillMisc() {
 
 }
 
+
+function addExtraMinCourses(index, min300s) {
+    for (var m = 0; m < 3; m++) {
+        if((index === 3)) {
+            break;      
+        } if (getCookie(additional_min_200s[m]) === 'active') {
+            min300s[index].value = additional_min_200s[m];
+            index += 1;
+        }
+        
+    }
+}
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -5,7 +5,7 @@ var completed_spec = {'CSC108': 0, 'CSC148': 0, 'CSC165': 0, 'Calc1': 0, 'CSC207
 var completed_maj = {'CSC108': 0, 'CSC148': 0, 'CSC165': 0, 'Calc1': 0, 'CSC207': 0, 'CSC236': 0, 
                      'CSC258': 0, 'CSC263': 0, 'Sta1': 0};
 
-var completed_min = {'CSC108': 0, 'CSC148': 0, 'CSC165': 0, 'CSC236': 0}; 
+var completed_min = {'CSC108': 0, 'CSC148': 0, 'CSC165': 0, 'CSC236': 0, 'CSC207': 0}; 
 
 var level300 = {'CSC300': 0, 'CSC301': 0, 'CSC302': 0, 'CSC309': 0, 'CSC310': 0, 
                 'CSC318': 0, 'CSC320': 0, 'CSC321': 0, 'CSC324': 0, 'CSC336': 0,
@@ -27,9 +27,6 @@ active300s = [];
 var index300 = 0;
 var index400 = 0;
 var index200 = 0;
-creditCountSpec = 0;
-creditCountMaj = 0;
-creditCountMin = 0;
 creditCount300 = 0;
 creditCount400 = 0;
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -264,10 +264,13 @@ function fill300s() {
         var course = spec300s[k].value;
         if (getCookie(course) === 'inactive' || getCookie(course) === 'takeable') {
             spec300s[k].value = '';
+            spec300s[k].readOnly = false;
             if (k < 2) {
                 maj300s[k].value = '';
+                maj300s[k].readOnly = false;
             }
             min300s[k].value = '';
+            min300s[k].readOnly = false;
         }
     }
     
@@ -278,10 +281,13 @@ function fill300s() {
             break;
         }
         spec300s[i].value = active300s[index300];
+        spec300s[i].readOnly = true;
         if (i < 2) {
             maj300s[i].value = active300s[index300];
+            maj300s[i].readOnly = true;
         }
         min300s[i].value = active300s[index300];
+        min300s[i].readOnly = true;
         i += 1; 
         index300 += 1;
     }
@@ -292,10 +298,13 @@ function fill300s() {
                 break;
             }
             spec300s[i].value = active400s[index400];
+            spec300s[i].readOnly = true;
             if (i < 2) {
                 maj300s[i].value = active400s[index400];
+                maj300s[i].readOnly = true;
             }
             min300s[i].value = active400s[index400]; 
+            min300s[i].readOnly = true;
             i += 1;
             index400 += 1;
         }
@@ -318,10 +327,13 @@ function fill400s() {
     // clear textboxes
     for (k = 0; k < 3; k++) {
         spec400s[k].value = '';
+        spec400s[k].readOnly = false;
         if (k < 1) {
             maj400s[k].value = '';
+            maj400s[k].readOnly = false;
         }
         min400s[k].value = '';
+        min400s[k].readOnly = false;
     }
     
 
@@ -331,10 +343,13 @@ function fill400s() {
             break;
         }
         spec400s[i].value = active400s[index400];
+        spec400s[i].readOnly = true;
         if (i < 1) {
             maj400s[i].value = active400s[index400];
+            maj400s[i].readOnly = true;
         }
         min400s[i].value = active400s[index400]; 
+        min400s[i].readOnly = true;
         i += 1;
         index400 += 1;
     }
@@ -351,9 +366,11 @@ function fillExtra() {
     for (var k = 0; k < 4; k++) {
         if (spec_extra[k].value.indexOf('MAT') === -1 && spec_extra[k].value.indexOf('STA') === -1) {
             spec_extra[k].value = '';
+            spec_extra[k].readOnly = false;
         } if (k < 3) {
             if (maj_extra[k].value.indexOf('MAT') === -1 && maj_extra[k].value.indexOf('STA') === -1) {
                 maj_extra[k].value = '';
+                maj_extra[k].readOnly = false;
             }
         }
     }
@@ -365,9 +382,11 @@ function fillExtra() {
         }
         if ((i < 2) && (maj_extra[i].value === '')) {
             maj_extra[i].value = active300s[index300];
+            maj_extra[i].readOnly = true;
         }
         if (spec_extra[i].value === '') {
             spec_extra[i].value = active300s[index300];
+            spec_extra[i].readOnly = true;
             index300 += 1;
         } 
         i += 1;
@@ -380,9 +399,11 @@ function fillExtra() {
             }
             if ((i < 2) && (maj_extra[i].value === '')) {
                 maj_extra[i].value = active400s[index400];
+                maj_extra[i].readOnly = true;
             }
             if (spec_extra[i].value === '') {
                 spec_extra[i].value = active400s[index400];
+                spec_extra[i].readOnly = true;
                 index400 += 1;
             }
             i += 1;
@@ -397,22 +418,26 @@ function fillExtra() {
 **/
 function fillMisc() {
     'use-strict'
-    
+
     var spec_inq = $('#spec_misc')[0].getElementsByTagName('input');
     var maj_inq = $('#maj_misc')[0].getElementsByTagName('input');
 
     // clear textboxes
     if (spec_inq[0].value.indexOf('PEY') === -1) {
         spec_inq[0].value = '';
+        spec_inq[0].readOnly = false;
     } if (maj_inq[0].value.indexOf('PEY') === -1) {
         maj_inq[0].value = '';
+        maj_inq[0].readOnly = false;
     }
 
     // fill textboxes
     if (activeInq.length > 0) {
         spec_inq[0].value = activeInq[0];
+        spec_inq[0].readOnly = true;
     } if (activeInq.length > 0){
         maj_inq[0].value = activeInq[0];
+        maj_inq[0].readOnly = true;
     }
     
     // update category

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -565,7 +565,7 @@ function addExtraMinCourses(index, min300s) {
     for (var m = 0; m < 3; m++) {
         if (index === 3) {
             break;      
-        } if (getCookie(additional_min_200s[m]) === 'active') {
+        } else if (getCookie(additional_min_200s[m]) === 'active') {
             min300s[index].value = additional_min_200s[m];
             min300s[index].readOnly = true;
             creditCount300and400['Min'] += 0.5;
@@ -611,10 +611,10 @@ function updateNavPost() {
     if (getCookie('specialist') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (specCount).toFixed(1) + '/12.0)';
         setCookie('activecount', (specCount).toFixed(1));
-    } if (getCookie('major') === 'active') {
+    } else if (getCookie('major') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (majCount).toFixed(1) + '/8.0)';
         setCookie('activecount', (majCount).toFixed(1));
-    } if (getCookie('minor') === 'active') {
+    } else if (getCookie('minor') === 'active') {
         nav_post.innerHTML = 'Check My POSt! (' + (minCount).toFixed(1) + '/4.0)';
         setCookie('activecount', (minCount).toFixed(1));
     } 
@@ -630,9 +630,9 @@ function updateNavGraph() {
 
     if (getCookie('specialist') === 'active') {
         nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/12.0)';
-    } if (getCookie('major') === 'active') {
+    } else if (getCookie('major') === 'active') {
         nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/8.0)';
-    } if (getCookie('minor') === 'active') {
+    } else if (getCookie('minor') === 'active') {
         nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/4.0)';
     } 
 }

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -34,7 +34,7 @@ creditCount400 = 0;
  * Updates POSts when button is clicked.
 **/
 $('#update').click(function (e) {
-    'use-strict';
+    'use-strict'
 
     index300 = 0;
     index400 = 0;
@@ -78,7 +78,7 @@ $('.full_name').click(function (e) {
 **/
 // TODO: Add CSC240 and CSC265
 function updateAllCategories() {
-    'use-strict';
+    'use-strict'
 
     updateCompletedMinCourses();
     updateCompletedMajCourses();
@@ -207,7 +207,7 @@ function updateAllCategories() {
  * @param {string} courseCode The course code
 **/
 function activateCourse(courseCode) {
-    'use-strict';
+    'use-strict'
     
     var elements = document.getElementsByClassName(courseCode);
     for (i = 0; i < elements.length; i++) {
@@ -221,7 +221,7 @@ function activateCourse(courseCode) {
  * @param {string} courseCode The course code
 **/
 function deactivateCourse(courseCode) {
-    'use-strict';
+    'use-strict'
     
     var elements = document.getElementsByClassName(courseCode);
     for (i = 0; i < elements.length; i++) {
@@ -236,7 +236,7 @@ function deactivateCourse(courseCode) {
  * @param {string} status Whether it is 'fulfilled' or 'not fulfilled'
 **/
 function updateCategory(category, status) {
-    'use-strict';
+    'use-strict'
 
     if (status === 'fulfilled') {
         category.style.backgroundColor = "#3CB371";
@@ -250,7 +250,7 @@ function updateCategory(category, status) {
  * Autofills textboxes for 300 level courses. 
 **/
 function fill300s() {
-    'use-strict';
+    'use-strict'
 
     var i = 0; 
 
@@ -307,7 +307,7 @@ function fill300s() {
  * Autofills textboxes for 400 level courses. 
 **/
 function fill400s() {
-    'use-strict';
+    'use-strict'
 
     var i = 0; 
     var spec400s = $('.lvl400spec');
@@ -396,8 +396,8 @@ function fillExtra() {
  * Autofills textboxes and updates category for Inquiry courses
 **/
 function fillMisc() {
-    'use-strict';
-
+    'use-strict'
+    
     var spec_inq = $('#spec_misc')[0].getElementsByTagName('input');
     var maj_inq = $('#maj_misc')[0].getElementsByTagName('input');
 

--- a/js/post/update_post.js
+++ b/js/post/update_post.js
@@ -143,24 +143,36 @@ function updateAllCategories() {
 
     // Update 400s
 
-    i = 0; 
+    var i = 0;
+    var k = 0; 
     var spec400s = $('.lvl400spec');
-    for (var l = 0; l < 1; l++) {
+    var maj400s = $('.lvl400maj');
+
+    for (var l = 0; l < 3; l++) {
         if (spec400s[l].value != '') {
             i += 1;
         }
     }
 
-    if (i === 1) {
+    if (maj400s[0].value != '') {
+        k = 1;
+    }
+
+
+    if (i === 3) {
         updateCategory($('#spec_400')[0].getElementsByClassName('code')[0], 'fulfilled');
-        updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'fulfilled');
         categories_completed['Spec'] += 1;
-        categories_completed['Maj'] += 1;
     } else {
         updateCategory($('#spec_400')[0].getElementsByClassName('code')[0], 'not fulfilled');
-        updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'not fulfilled');
         updateCategory($('#min_misc')[0].getElementsByClassName('code')[0], 'not fulfilled');
+    }
+
+    if (k === 1) {
+        updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'fulfilled');
+        categories_completed['Maj'] += 1;
+    } else {    
+        updateCategory($('#maj_400')[0].getElementsByClassName('code')[0], 'not fulfilled'); 
     }
 
     // Update Extra


### PR DESCRIPTION
This Pull Request just about completes the "Check My POSt!" page. 

This fixes issues #365 and #366.

The credit count now properly calculates how many credits are completed in each post - and the credit count turns green when a POSt is completed. The autofilling of textboxes for the 300+ level courses is now working correctly. Now, using cookies, the browser remembers the last active post tab that was open, and opens this tab when you switch back to the page. Also (a suggestion from David from our code sprint ) - you can now see the credit count of the last active post tab that was open in the main navbar, beside "Check My POSt!". You can see this both from the POSt page and the Graph page. 

Please feel free to try it out with different selections of courses, and if you find a bug somewhere, please let me know! I think I have covered all the edge cases but there is a chance I have missed a few. 

(Code is still kind of long and messy in this, refactoring will come in the next PR).