### PR TITLE
Fix Cookies

### DIFF
--- a/js/graph/parse_graph.js
+++ b/js/graph/parse_graph.js
@@ -22,7 +22,7 @@ function buildGraph() {
         makeHybrid('AND', id);
         $.each(reqs, function (index, elem) {
             if ($.isArray(elem)) {
-                var orNode = id + elem.join();
+                var orNode = id + elem.join('');
                 makeHybrid('OR', orNode);
                 $.each(elem, function (i, e) {
                     window[orNode].parents.push(window[e]);


### PR DESCRIPTION
This pull request removes the comma from Hybrid IDs. The IDs are used as cookie names, and commas are illegal characters in cookies. ([Source](http://curl.haxx.se/rfc/cookie_spec.html))

This is currently preventing `rqCookies` from Happstack to work properly, as Happstack cannot parse our cookies.

To see a cookie with a comma in its name, make sure that the cookie corresponding to the hybrid of CSC404 is being set.