### PR TITLE
Timetable - New course time & Styling

### DIFF
--- a/hs/Css/TimetableCss.hs
+++ b/hs/Css/TimetableCss.hs
@@ -97,7 +97,7 @@ timetableCSS = do
                 paddingLeft (px 10) -- important
         tbody |> tr |> td <> thead |> th ? do
             width (pct 13.5)
-            height (px 35)
+            height (px 18)
             padding0 -- !important
             margin0 -- !important
             alignCenter

--- a/public/js/common/objects/section.js
+++ b/public/js/common/objects/section.js
@@ -138,25 +138,23 @@ Section.prototype.removeTimes = function () {
     $.each(this.times, function (i, time) {
         n = time.charAt(time.length-1);
 
-        if (time.indexOf('-5') === -1 && $(time).length > 0) {
-            if (n === 'E') {
-                compressCell(parseInt(time.slice(2)), time.charAt(1), time.charAt(time.length-2));
-                time = time.slice(0, time.length-1);
-            }
+        if (n === 'E') {
+            compressCell(parseInt(time.slice(2)), time.charAt(1), time.charAt(time.length-2));
+            time = time.slice(0, time.length-1);
+        }
 
-            $(time).css('border-top-style', 'default')
-                   .css('border-left-style', 'default')
-                   .css('border-right-style', 'default');
+        $(time).css('border-top-style', 'default')
+               .css('border-left-style', 'default')
+               .css('border-right-style', 'default');
 
-            if (n === 'H') {
-                compressCell(parseInt(time.slice(2)), time.charAt(1), time.charAt(time.length-2));
-            }
+        if (n === 'H') {
+            compressCell(parseInt(time.slice(2)), time.charAt(1), time.charAt(time.length-2));
+        }
 
-            if ($(time).data("conflicts").length > 0) {
-                tmp.removeConflict(time);
-            } else {
-                renderClearTime(time);
-            }
+        if ($(time).data("conflicts").length > 0) {
+            tmp.removeConflict(time);
+        } else {
+             renderClearTime(time);
         }
     });
 };

--- a/public/js/common/utilities/util.js
+++ b/public/js/common/utilities/util.js
@@ -124,18 +124,30 @@ function convertTimes(times) {
         time = times[i][1];
 
         if (time.charAt(time.length - 1) === '0') {
-            if (i !== times.length-1) {
-                timeString = timeString + time;
-                timeList.push(timeString);
-            }
-            else {
+            if (i === times.length-1) {
                 timeString = timeString + time + 'E';
                 timeList.push(timeString);
+            } else {
+                stime = time.replace('-0', '-5');
+                if (times[i+1][1] === stime) {
+                    timeString = timeString + time;
+                    timeList.push(timeString);
+                } else {
+                    timeString = timeString + time + 'E';
+                    timeList.push(timeString);
+                }
+
             }
         } else {
             if (i === 0) {
                 timeString = timeString + time + 'H';
                 timeList.push(timeString);
+            } else {
+                stime = time.replace('-5', '-0');
+                if (times[i-1][1] !== stime) {
+                    timeString = timeString + time + 'H';
+                    timeList.push(timeString);
+                }
             }
         }
     }

--- a/public/js/common/utilities/util.js
+++ b/public/js/common/utilities/util.js
@@ -122,20 +122,24 @@ function convertTimes(times) {
     for (var i = 0; i < times.length; i++) {
         var timeString = 'MTWRF'.charAt(times[i][0]);
         time = times[i][1];
-        if (time > 21) {
-            stime = time.toString();
-            if (stime.charAt(stime.length - 1) === '0') {
-                stime = stime.slice(0, -1) + 'E';
-            } else {
-                stime = stime.slice(0, -1) + 'H';
-            }
-            timeString = timeString + stime;
-        } else {
-            timeString = timeString + time;
-        }
 
-        timeList.push(timeString);
+        if (time.charAt(time.length - 1) === '0') {
+            if (i !== times.length-1) {
+                timeString = timeString + time;
+                timeList.push(timeString);
+            }
+            else {
+                timeString = timeString + time + 'E';
+                timeList.push(timeString);
+            }
+        } else {
+            if (i === 0) {
+                timeString = timeString + time + 'H';
+                timeList.push(timeString);
+            }
+        }
     }
+
     return timeList;
 }
 

--- a/public/js/grid/generate_grid.js
+++ b/public/js/grid/generate_grid.js
@@ -62,6 +62,11 @@ function appendHeaders(fallThead, springThead) {
     'use strict';
 
     var days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+    fallThead.append($('<th></th>')
+        .addClass('term-name')
+        .css('width', '1px'));   
+
     fallThead.append($('<th></th>')
         .addClass('term-name')
         .html('Fall'));
@@ -76,6 +81,10 @@ function appendHeaders(fallThead, springThead) {
     springThead.append($('<th></th>')
         .addClass('term-name')
         .html('Spring'));
+
+    springThead.append($('<th></th>')
+        .addClass('term-name')
+        .css('width', '1px'));  
 }
 
 
@@ -115,10 +124,15 @@ function appendTableData(trFall, trSpring, time) {
 
     if (time % 1 === 0) {
         var adjustedTime = (time === 12 ? 12 : time % 12) + ':00';
+
+        trFall.append($('<td></td>')
+            .addClass('timetable-cell')
+            .css('border-style', 'none')
+            .css('width', '1px'));
         
         trFall.append($('<td></td>')
            .addClass('timetable-time')
-           .attr('rowspan', '1')
+           .attr('rowspan', '2')
            .html(adjustedTime));
 
         for (var k = 0; k < 5; k++) {
@@ -138,17 +152,21 @@ function appendTableData(trFall, trSpring, time) {
         
         trSpring.append($('<td></td>')
             .addClass('timetable-time')
-            .attr('rowspan', '1')
+            .attr('rowspan', '2')
             .html(adjustedTime));
+
+        trSpring.append($('<td></td>')
+            .addClass('timetable-cell')
+            .css('border-style', 'none')
+            .css('width', '1px'));
 
     } else {
         var adjustedTime = '';
 
         trFall.append($('<td></td>')
-           .addClass('timetable-time')
-           .attr('rowspan', '1')
-           .html(adjustedTime)
-           .css('border-style', 'none'));
+            .addClass('timetable-cell')
+            .css('border-style', 'none')
+            .css('width', '1px'));
 
         for (var k = 0; k < 5; k++) {
             trFall.append($('<td></td>')
@@ -168,10 +186,9 @@ function appendTableData(trFall, trSpring, time) {
         }
 
         trSpring.append($('<td></td>')
-            .addClass('timetable-time')
-            .attr('rowspan', '1')
-            .html(adjustedTime)
-            .css('border-style', 'none'));
+            .addClass('timetable-cell')
+            .css('border-style', 'none')
+            .css('width', '1px'));
     }
 
 }

--- a/public/js/grid/mouse_events.js
+++ b/public/js/grid/mouse_events.js
@@ -213,19 +213,20 @@ function previousCell(time) {
 
     if (n === 'H') {
         ptime = time.slice(0, time.length-1);
+        ptime = ptime.replace('-5', '-0');
         return ptime;
     } else if (n === 'E') {
-        ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + time.charAt(time.length-2) + 'H'
+        ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + '-5' + time.charAt(time.length-2) + 'H';
 
         if ($(ptime).css('display') == 'none') {
-            ptime = ptime.slice(0, ptime.length-1);
+            ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + '-0' + time.charAt(time.length-2);
         }
         return ptime;
     } else {
-        ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + time.charAt(time.length-1) + 'H'
+        ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + '-5' + time.charAt(time.length-1) + 'H';
 
         if ($(ptime).css('display') == 'none') {
-            ptime = ptime.slice(0, ptime.length-1);
+            ptime = time.slice(0, 2) + String(parseInt(time.slice(2))-1) + '-0' + time.charAt(time.length-1);
         }
         return ptime;
     }
@@ -240,8 +241,8 @@ function previousCell(time) {
 function extendCell(timeInt, day, term) {
     'use strict';
 
-    var pcell = '#' + day + timeInt + term;
-    var ccell = '#' + day + timeInt + term + 'H';
+    var pcell = '#' + day + timeInt + '-0' + term;
+    var ccell = '#' + day + timeInt + '-5' + term + 'H';
 
     $(ccell).css('display', 'table-cell');
     $(pcell).attr('rowspan', '1');
@@ -250,15 +251,14 @@ function extendCell(timeInt, day, term) {
 /**
  * Compress a given cell to hide half hour section.
  * @param {Int} timeInt The full hour time of the row.
- * @param {string} week The week of the timetable cell.
  * @param {string} day The day of the time.
  * @param {string} term The term of the timetable cell.
  */
 function compressCell(timeInt, day, term) {
     'use strict';
 
-    var pcell = '#' + day + timeInt + term;
-    var ccell = '#' + day + timeInt + term + 'H';
+    var pcell = '#' + day + timeInt + '-0' + term;
+    var ccell = '#' + day + timeInt + '-5' + term + 'H';
 
     $(pcell).attr('rowspan', '2');
     $(ccell).css('display', 'none');


### PR DESCRIPTION
Style: dummy cells have now been created to teach the other cells to maintain rowspan of 2. dummy cells are cells of 1px width at the leftmost and rightmost sides of the timetable. all other cells can now be styled properly.

New course time: new course time now able to be displayed in timetable, including half hours. No tutorial times can be shown due to new format. Weird border line for half hour cell still exists.

PS. the half hour times i used to use for testing: PHL245H1 (none course...) and the BIO120H1 labs (tutorials don't work at the moment) all cannot be displayed properly. so i manually changed some things to test the half-hour functionality. Everything should work. Please see attached.

![e](https://cloud.githubusercontent.com/assets/10492815/6658373/bb503746-cb3d-11e4-83e9-86b2d9aef21c.PNG)

![h](https://cloud.githubusercontent.com/assets/10492815/6658375/c5ec5b58-cb3d-11e4-8fc5-db7593f06bde.PNG)

![none](https://cloud.githubusercontent.com/assets/10492815/6658382/df41b940-cb3d-11e4-99d5-15c4f0d647db.PNG)

