### PR TITLE
Graphs response

### DIFF
--- a/hs/Database/CourseQueries.hs
+++ b/hs/Database/CourseQueries.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
 
-module Database.CourseQueries (retrieveCourse, allCourses) where
+module Database.CourseQueries (retrieveCourse, allCourses, queryGraphs) where
 
 import Database.Persist
 import Database.Persist.Sqlite
@@ -93,3 +93,10 @@ allCourses = do
       return $ T.unlines codes
   return $ toResponse response
 
+-- | Queries the graphs table and returns a JSON response of Graph JSON
+-- objects.
+queryGraphs :: IO Response
+queryGraphs =
+    runSqlite dbStr $
+        do graphs :: [Entity Graph] <- selectList [] []
+           return $ toResponse $ createJSONResponse $ encodeJSON $ Aeson.toJSON $ map (Aeson.toJSON . entityVal) graphs

--- a/hs/Database/CourseQueries.hs
+++ b/hs/Database/CourseQueries.hs
@@ -40,7 +40,7 @@ queryCourse lowerStr =
             springSession = buildSession sqlLecturesSpring sqlTutorialsSpring
             yearSession   = buildSession sqlLecturesYear sqlTutorialsYear
             courseJSON    = buildCourse fallSession springSession yearSession course
-        return $ toResponse $ createJSONResponse $ encodeJSON $ Aeson.toJSON courseJSON
+        return $ createJSONResponse $ encodeJSON $ Aeson.toJSON courseJSON
 
 -- | Builds a Course structure from a tuple from the Courses table.
 -- Some fields still need to be added in.
@@ -99,4 +99,4 @@ queryGraphs :: IO Response
 queryGraphs =
     runSqlite dbStr $
         do graphs :: [Entity Graph] <- selectList [] []
-           return $ toResponse $ createJSONResponse $ encodeJSON $ Aeson.toJSON $ map (Aeson.toJSON . entityVal) graphs
+           return $ createJSONResponse $ encodeJSON $ Aeson.toJSON $ map (Aeson.toJSON . entityVal) graphs

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -241,3 +241,9 @@ convertTimeToString :: [Double] -> [T.Text]
 convertTimeToString [day, time] =
   [T.pack . show . floor $ day,
    T.replace "." "-" . T.pack . show $ time]
+
+instance ToJSON Graph where
+    toJSON (Graph id_ title)
+        = object ["graph_title" .= title,
+                  "graph_id" .= id_
+                  ]

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -246,4 +246,4 @@ instance ToJSON Graph where
     toJSON (Graph id_ title)
         = object ["graph_title" .= title,
                   "graph_id" .= id_
-                  ]
+                 ]

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -35,4 +35,3 @@ main = do
                dir "all-courses" $ liftIO allCourses,
                dir "graphs" $ liftIO queryGraphs
                ]
-

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -9,7 +9,7 @@ import DrawResponse
 import ImageResponse
 import PostResponse
 --import AboutResponse
-import Database.CourseQueries (retrieveCourse, allCourses)
+import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs)
 import Css.CssGen
 import Filesystem.Path.CurrentOS
 import System.Directory
@@ -32,5 +32,7 @@ main = do
                dir "post" postResponse,
                dir "static" $ serveDirectory EnableBrowsing [] staticDir,
                dir "course" $ look "name" >>= retrieveCourse,
-               dir "all-courses" $ liftIO allCourses
+               dir "all-courses" $ liftIO allCourses,
+               dir "graphs" $ liftIO queryGraphs
                ]
+


### PR DESCRIPTION
This pull request adds new functionality that allows the client to request graph title-id pairs in JSON format. This information will be used by the graph switching functionality to display graphs in the database on the sidebar.

The format looks like this: `[{"graph_title":"CSC","graph_id":1}]`.

This is a stepping stone for graph switching functionality.

@christinem This code can be used to get graph title/id pairs. It is of course, not yet complete, as I intend to use primary keys from the database to identify graphs. Currently, only CSC and 1 can be inserted into the graph, but this should soon change. If you wish to try on more graphs, you can change these two numbers and 'reinsert' the same graph.