### PR TITLE
Timetable - Update style and tutorials

### DIFF
--- a/hs/Css/TimetableCss.hs
+++ b/hs/Css/TimetableCss.hs
@@ -118,6 +118,8 @@ timetableCSS = do
             fontSize (em 0.9)
         ".timetable-time" ? do
             width (pct 12)
+        ".timetable-dummy-cell" ? do
+            width (pct 1)
     -- Overriding bootstrap
     ".col-md-2" ? do
         width (pct 14)

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -228,9 +228,9 @@ instance FromJSON Tutorial where
 
 instance ToJSON Tutorial where
   toJSON (Tutorial Nothing times timeStr) =
-      Array $ V.fromList [toJSON times, toJSON timeStr]
+      Array $ V.fromList [toJSON (map convertTimeToString times), toJSON timeStr]
   toJSON (Tutorial (Just value) times timeStr) =
-      Array $ V.fromList [toJSON value, toJSON times, toJSON timeStr]
+      Array $ V.fromList [toJSON value, toJSON (map convertTimeToString times), toJSON timeStr]
 
 -- | Converts a Double to a T.Text.
 -- This removes the period from the double, as the JavaScript code,

--- a/public/js/common/objects/course.js
+++ b/public/js/common/objects/course.js
@@ -27,7 +27,7 @@ function Course(name) {
 
     this.status = 'inactive';
 
-    if (course.manualTutorialEnrolment) {
+    if (course.manualTutorialEnrolment !== false) {
         if (course.Y !== undefined) {
             this.practicalEnrolment = course.Y
                                             .tutorials.some(hasManualPractical);
@@ -110,7 +110,8 @@ Course.prototype.parseLectures = function (session, timeSuffix) {
 
         var id = tmp.name + '-' + lecture.section + '-' + timeSuffix;
         sectionTimes = sectionTimes.concat(convertTimes(lecture.time));
-        if (!tmp.manualTutorialEnrolment &&
+
+        if (tmp.manualTutorialEnrolment === false &&
             session.tutorials.length > 0) {
             sectionTimes = sectionTimes.concat(
                 convertTimes(session.tutorials[i][0]));
@@ -148,7 +149,7 @@ Course.prototype.parseLectures = function (session, timeSuffix) {
 Course.prototype.parseTutorials = function (session, timeSuffix) {
     'use strict';
 
-    if (!this.manualTutorialEnrolment) {
+    if (this.manualTutorialEnrolment === false) {
         return [];
     }
 

--- a/public/js/grid/generate_grid.js
+++ b/public/js/grid/generate_grid.js
@@ -64,8 +64,7 @@ function appendHeaders(fallThead, springThead) {
     var days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
     fallThead.append($('<th></th>')
-        .addClass('term-name')
-        .css('width', '1px'));   
+        .addClass('timetable-dummy-cell'));   
 
     fallThead.append($('<th></th>')
         .addClass('term-name')
@@ -83,8 +82,7 @@ function appendHeaders(fallThead, springThead) {
         .html('Spring'));
 
     springThead.append($('<th></th>')
-        .addClass('term-name')
-        .css('width', '1px'));  
+        .addClass('timetable-dummy-cell'));  
 }
 
 
@@ -126,9 +124,7 @@ function appendTableData(trFall, trSpring, time) {
         var adjustedTime = (time === 12 ? 12 : time % 12) + ':00';
 
         trFall.append($('<td></td>')
-            .addClass('timetable-cell')
-            .css('border-style', 'none')
-            .css('width', '1px'));
+            .addClass('timetable-dummy-cell'));
         
         trFall.append($('<td></td>')
            .addClass('timetable-time')
@@ -156,17 +152,14 @@ function appendTableData(trFall, trSpring, time) {
             .html(adjustedTime));
 
         trSpring.append($('<td></td>')
-            .addClass('timetable-cell')
-            .css('border-style', 'none')
-            .css('width', '1px'));
+            .addClass('timetable-dummy-cell'));
 
     } else {
         var adjustedTime = '';
 
         trFall.append($('<td></td>')
-            .addClass('timetable-cell')
-            .css('border-style', 'none')
-            .css('width', '1px'));
+            .addClass('timetable-dummy-cell')
+            .css('border-style', 'none'));
 
         for (var k = 0; k < 5; k++) {
             trFall.append($('<td></td>')
@@ -186,9 +179,8 @@ function appendTableData(trFall, trSpring, time) {
         }
 
         trSpring.append($('<td></td>')
-            .addClass('timetable-cell')
-            .css('border-style', 'none')
-            .css('width', '1px'));
+            .addClass('timetable-dummy-cell')
+            .css('border-style', 'none'));
     }
 
 }

--- a/public/js/grid/mouse_events.js
+++ b/public/js/grid/mouse_events.js
@@ -135,6 +135,10 @@ function renderClearHover(time) {
         $(time).css('font-size', '0');
     }
 
+    if ($(time).attr('rowspan') === '2') {
+        $(time).css('font-size', '0.9em');
+    }
+
     $(time).attr('hover', 'off');
 }
 


### PR DESCRIPTION
1. Created new dummy cell class that has Css set in the hs file

2. Rendered with Firefox display problems, now use % instead of px

3. Fixed bug relating to font-size

4. Now tutorials times are parsed correctly with '-'

5. Tutorials are now able to show up in timetable. Discovered UNDERLYING problem. The attribute of courses 'manualTutorialInrollment' is likely not parsed correctly from the internet. Now just shows as null for all the courses that i have checked, with or without tutorials. Please see attached for evidence.

Old:
![old](https://cloud.githubusercontent.com/assets/10492815/6723851/8ce113a6-cdc4-11e4-9e02-4718edb0d741.PNG)

New:
![new](https://cloud.githubusercontent.com/assets/10492815/6723854/948a95e6-cdc4-11e4-983b-09e9a77deeaf.PNG)
![new2](https://cloud.githubusercontent.com/assets/10492815/6723855/980cc1bc-cdc4-11e4-91a2-013ffff01516.PNG)

 
