### PR TITLE
Graph IDs

### DIFF
--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -69,19 +69,19 @@ Distribution
     deriving Show
 
 Graph
-    gId Int
+    gId String
     title String
     deriving Show
 
 Text
-    gId Int
+    gId String
     rId String
     pos Point
     text String
     deriving Show
 
 Shape
-    gId Int
+    gId String
     id_ String
     pos Point
     width Double
@@ -93,7 +93,7 @@ Shape
     type_ ShapeType
 
 Path
-    gId Int
+    gId String
     id_ String
     points [Point]
     fill String

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -16,6 +16,7 @@ import Database.DataType
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import Data.Aeson
+import Data.Int
 import Control.Monad
 import Control.Applicative
 
@@ -69,19 +70,19 @@ Distribution
     deriving Show
 
 Graph
-    gId String
+    gId Int64
     title String
     deriving Show
 
 Text
-    gId String
+    gId Int64
     rId String
     pos Point
     text String
     deriving Show
 
 Shape
-    gId String
+    gId Int64
     id_ String
     pos Point
     width Double
@@ -93,7 +94,7 @@ Shape
     type_ ShapeType
 
 Path
-    gId String
+    gId Int64
     id_ String
     points [Point]
     fill String

--- a/hs/SvgParsing/parser.hs
+++ b/hs/SvgParsing/parser.hs
@@ -10,7 +10,6 @@ import Text.XML.HaXml.Util
 import Text.XML.HaXml.XmlContent.Parser
 import qualified Data.Conduit.List as CL
 import Database.Persist
-import Database.Persist.Types
 import Control.Monad.IO.Class (liftIO)
 import Database.Persist.Sqlite
 import Control.Monad


### PR DESCRIPTION
This pull request adds the initial functionality for graph identification. Graph IDs will be based on primary keys. The code no longer deletes graphs when parsing a graph that is already in the database.

The primary key is inserted into the `Graph` table under the `graphsGId` attribute because, to my knowledge, the primary key cannot be retrieved from the Graph object.

For example, the following code needs access to the primary key:
```
instance ToJSON Graph where
    toJSON (Graph id_ title)
        = object ["graph_title" .= title,
                  "graph_id" .= id_
                 ]
```

Future pull requests will insert this key into the database for each corresponding element of the graph.