### PR TITLE
Remove Post FCE Count from Graph page

### DIFF
--- a/hs/Scripts.hs
+++ b/hs/Scripts.hs
@@ -31,8 +31,7 @@ plannerScripts = concatHtml (map makeScript["https://ajax.googleapis.com/ajax/li
                                            "static/js/graph/create_data.js",
                                            "static/js/graph/parse_graph.js",
                                            "static/js/graph/mouse_events.js",
-                                           "static/js/graph/setup.js",
-                                           "static/js/post/update_post.js"])
+                                           "static/js/graph/setup.js"])
 
 timetableScripts :: H.Html
 timetableScripts = do jQuery

--- a/public/js/graph/mouse_events.js
+++ b/public/js/graph/mouse_events.js
@@ -63,8 +63,8 @@ function turnNode(event) {
         updateFCECount();
 
         // Check the courses with FCE reqs
-        CSC318.updateStatus();
-        CSC454.updateStatus();
+        csc318.updateStatus();
+        csc454.updateStatus();
 
     }
 }

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -40,9 +40,6 @@ $(document).ready(function () {
     // Initialize interface
     initializeGraphSettings();
     
-    // Update credit count in nav bar
-    updateNavGraph();
-
     // Uncomment to enable the feedback form (must also be displayed in html)
     // activateFeedbackForm();
     // Uncomment to enable graph dragging

--- a/public/js/post/change_div.js
+++ b/public/js/post/change_div.js
@@ -3,7 +3,6 @@ $(document).ready(function () {
 	
     openLastActiveTab();
     updateAllCategories();
-    updateNavPost();
 });
 
 
@@ -12,7 +11,6 @@ $('#specialist').click(function (e) {
 	
     e.preventDefault();
     openTab('specialist');
-    updateNavPost();
 });
 
 
@@ -21,7 +19,6 @@ $('#major').click(function (e) {
 	
     e.preventDefault();
     openTab('major');
-    updateNavPost();
 });
 
 
@@ -30,7 +27,6 @@ $('#minor').click (function (e) {
 	
     e.preventDefault();
     openTab('minor');
-    updateNavPost();
 });
 
 $('.code').click (function (e) {

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -228,25 +228,6 @@ function updateNavPost() {
     } 
 }
 
-
-/**
- * Updates the Nav Bar on the Graph page.
-**/
-function updateNavGraph() {
-    'use strict';
-
-    var nav_graph = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
-
-    if (getCookie('specialist') === 'active') {
-        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/12.0)';
-    } else if (getCookie('major') === 'active') {
-        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/8.0)';
-    } else if (getCookie('minor') === 'active') {
-        nav_graph.innerHTML = 'Check My POSt! (' + getCookie('activecount') + '/4.0)';
-    } 
-}
-
-
 /**
  * Updates list of current active (selected) courses in Graph.
 **/

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -230,6 +230,7 @@ function updateActiveCourses() {
     }
 }
 
+
 /**
  * Updates Credit count for MAT and STA courses.
 **/

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -214,7 +214,7 @@ function checkPostCompleted() {
 function updateNavPost() {
     'use strict';
 
-    var navPost = $('#nav-links')[0].getElementsByTagName('li')[3].getElementsByTagName('a')[0];
+    var navPost = $('#nav-links')[0].getElementsByTagName('li')[4].getElementsByTagName('a')[0];
 
     if (getCookie('specialist') === 'active') {
         navPost.innerHTML = 'Check My POSt! (' + specialist.creditCount.toFixed(1) + '/12.0)';

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -209,26 +209,6 @@ function checkPostCompleted() {
 
 
 /**
- * Updates the Nav Bar on the Check My Post! page
-**/
-function updateNavPost() {
-    'use strict';
-
-    var navPost = $('#nav-links')[0].getElementsByTagName('li')[4].getElementsByTagName('a')[0];
-
-    if (getCookie('specialist') === 'active') {
-        navPost.innerHTML = 'Check My POSt! (' + specialist.creditCount.toFixed(1) + '/12.0)';
-        setCookie('activecount', specialist.creditCount.toFixed(1));
-    } else if (getCookie('major') === 'active') {
-        navPost.innerHTML = 'Check My POSt! (' + major.creditCount.toFixed(1) + '/8.0)';
-        setCookie('activecount', major.creditCount.toFixed(1));
-    } else if (getCookie('minor') === 'active') {
-        navPost.innerHTML = 'Check My POSt! (' + minor.creditCount.toFixed(1) + '/4.0)';
-        setCookie('activecount', minor.creditCount.toFixed(1));
-    } 
-}
-
-/**
  * Updates list of current active (selected) courses in Graph.
 **/
 function updateActiveCourses() {

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -20,7 +20,6 @@ $('#update').click(function (e) {
     'use strict';
 
     updateAllCategories();
-    updateNavPost();
 });
 
 


### PR DESCRIPTION
On suggestion from @david-yz-liu, this PR removes the FCE count for the active POSt from the Graph page nav bar. In the future it can be added somewhere else such as the sidebar.

David, would you like me to remove it from the nav bar on the POSt page as well?