### PR TITLE
Update FB app

### DIFF
--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -35,7 +35,7 @@ postFB :: T.Text
 postFB = "post-fb"
 
 appId :: T.Text
-appId = "442286309258193"
+appId = "432140593606098"
 
 -- In order to access information as the Courseography application, the secret needs
 -- to be declared in the third string below that has the place holder 'INSERT_SECRET'.

--- a/hs/CourseographyFacebook.hs
+++ b/hs/CourseographyFacebook.hs
@@ -40,7 +40,7 @@ appId = "432140593606098"
 -- In order to access information as the Courseography application, the secret needs
 -- to be declared in the third string below that has the place holder 'INSERT_SECRET'.
 -- The secret should NEVER be committed to GitHub.
--- The secret can be found here: https://developers.facebook.com/apps/442286309258193/dashboard/
+-- The secret can be found here: https://developers.facebook.com/apps/432140593606098/dashboard/
 -- Should the secret be committed to GitHub, it needs to be reset immediately. If you find
 -- yourself in this pickle, please contact someone who can do this.
 appSecret :: T.Text

--- a/public/js/common/facebook/facebook_login.js
+++ b/public/js/common/facebook/facebook_login.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
     $.getScript('//connect.facebook.net/en_UK/all.js', function() {
 
         FB.init({
-            appId      : '442286309258193',
+            appId      : '432140593606098',
             xfbml      : true,
             version    : 'v2.1'
         });


### PR DESCRIPTION
This pull request updates the FB app ID to the *real* Courseography app.

This app is currently set to point to courseography.cdf.toronto.edu.