### PR TITLE
Graph Loading with new Filenames/Attributes

### DIFF
--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -21,7 +21,8 @@ var nodes = [];               // List of all nodes
 $(document).ready(function () {
     'use strict';
 
-    loadGraph('1');
+    var active = getCookie('active-graph');
+    loadGraph(active);
     $('#fcecount').hide();
 });
 

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -21,7 +21,7 @@ var nodes = [];               // List of all nodes
 $(document).ready(function () {
     'use strict';
 
-    loadGraph('graph-csc', 1);
+    loadGraph(1);
     $('#fcecount').hide();
 });
 
@@ -35,7 +35,7 @@ function getRemote(filepath) {
 
     var SVG = $.ajax({
         type: 'GET',
-        url: 'static/res/graphs/1.svg',
+        url: filepath,
         async: false
     }).responseText;
     $('#graph').append(SVG);

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -22,7 +22,13 @@ $(document).ready(function () {
     'use strict';
 
     var active = getCookie('active-graph');
-    loadGraph(active);
+
+    if (active !== '') {
+        loadGraph(active);
+    } else {
+        loadGraph('1');
+    }
+    
     $('#fcecount').hide();
 });
 

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -21,7 +21,7 @@ var nodes = [];               // List of all nodes
 $(document).ready(function () {
     'use strict';
 
-    loadGraph(1);
+    loadGraph('1');
     $('#fcecount').hide();
 });
 

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -21,7 +21,7 @@ var nodes = [];               // List of all nodes
 $(document).ready(function () {
     'use strict';
 
-    loadGraph('graph-csc');
+    loadGraph('graph-csc', 1);
     $('#fcecount').hide();
 });
 

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
     } else {
         loadGraph('1');
     }
-    
+
     $('#fcecount').hide();
 });
 

--- a/public/js/graph/sidebar/sidebar_divs.js
+++ b/public/js/graph/sidebar/sidebar_divs.js
@@ -55,7 +55,7 @@ function resetDivs() {
 **/
 function fillFCECount() {
     'use strict';
-    
+
     $('#fcecount').show();
     $('#fcecount').html('FCE Count: ' + FCEs);
 }
@@ -66,6 +66,7 @@ function fillFCECount() {
  * @param{string} location The location where you are clicking (either the sidebar button or the graph).
 **/
 function toggleSidebar(location) {
+    'use strict';
 
     if (toggled) {
         toggled = false;

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -30,10 +30,10 @@ function createGraphButtons(graphs) {
     'use strict';
 
     for (var i = 0; i < graphs.length; i++) {
-        var graphTitle = graphs[i].title.toLowerCase();
+        var graphTitle = graphs[i].title;
         var graphButton = '<div id = "graph-' + graphTitle +'" class = "graph-button">';
         $('#graphs').append(graphButton);
-        $('#graph-' + graphTitle).html(graphTitle.toUpperCase());
+        $('#graph-' + graphTitle).html(graphTitle);
         $('#graph-' + graphTitle).data('id', graphs[i].gId);
     }
 }

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -56,9 +56,9 @@ $('div').on('click', 'div.graph-button', function() {
 **/
 function loadGraph(id) {
     'use-strict';
-    
+
     setCookie('active-graph', id);
-    
+
     // Remove current graph
     $('#graph').empty();
 

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -1,4 +1,3 @@
-var filenames = {'CSC': 'CSC/csc_graph.svg', 'STA': 'STA/sta_graph.svg'};
 
 /**
  * The click function when a focus is clicked.
@@ -31,10 +30,12 @@ function createGraphButtons(graphs) {
     'use strict';
 
     for (var i = 0; i < graphs.length; i++) {
-        var graphTitle = graphs[i].graph_title.toLowerCase();
+        var graphTitle = graphs[i].title.toLowerCase();
         var graphButton = '<div id = "graph-' + graphTitle +'" class = "graph-button">';
         $('#graphs').append(graphButton);
         $('#graph-' + graphTitle).html(graphTitle.toUpperCase());
+        $('#graph-' + graphTitle).data('id', graphs[i].gID);
+        $('#graph-' + graphTitle).data('title', graphs[i].title);
     }
 }
 
@@ -45,24 +46,25 @@ function createGraphButtons(graphs) {
 $('div').on('click', 'div.graph-button', function() {
     'use strict';
 
-    var id = $(this).attr('id');
-    loadGraph(id);
+    var id = $(this).data('id');
+    var name = $(this).data('name');
+    loadGraph(name, id);
 });
 
 
 /**
  * Loads a Graph
- * @param{string} id ID name of graph button clicked
+ * @param{string} name ID name of graph button clicked
+ * @param{string} id ID of graph in database
 **/
-function loadGraph(id) {
+function loadGraph(name, id) {
     'use-strict';
     
-    var graph = id.substring(6, id.length);
 
     // Remove current graph
     $('#graph').empty();
 
-    getRemote(graph.toUpperCase() + '/' + graph + '_graph.svg');
+    getRemote(name + '/' + id + '.svg');
 
     FCEPrerequisiteCourses = [csc318, csc454];
 
@@ -92,7 +94,6 @@ function loadGraph(id) {
 function getGraphsInDatabase() {
     'use strict';
 
-    var graphs;
     $.ajax({
         url: 'graphs',
         dataType: 'json',

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -57,7 +57,8 @@ $('div').on('click', 'div.graph-button', function() {
 function loadGraph(id) {
     'use-strict';
     
-
+    setCookie('active-graph', id);
+    
     // Remove current graph
     $('#graph').empty();
 
@@ -77,8 +78,6 @@ function loadGraph(id) {
     initializeGraphSettings();
 
     fillFCECount();
-
-    setCookie('active-graph', id);
 
     // Uncomment to enable the feedback form (must also be displayed in html)
     // activateFeedbackForm();

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -34,8 +34,7 @@ function createGraphButtons(graphs) {
         var graphButton = '<div id = "graph-' + graphTitle +'" class = "graph-button">';
         $('#graphs').append(graphButton);
         $('#graph-' + graphTitle).html(graphTitle.toUpperCase());
-        $('#graph-' + graphTitle).data('id', graphs[i].gID);
-        $('#graph-' + graphTitle).data('title', graphs[i].title);
+        $('#graph-' + graphTitle).data('id', graphs[i].gId);
     }
 }
 
@@ -47,26 +46,22 @@ $('div').on('click', 'div.graph-button', function() {
     'use strict';
 
     var id = $(this).data('id');
-    var name = $(this).data('name');
-    loadGraph(name, id);
+    loadGraph(id);
 });
 
 
 /**
  * Loads a Graph
- * @param{string} name ID name of graph button clicked
  * @param{string} id ID of graph in database
 **/
-function loadGraph(name, id) {
+function loadGraph(id) {
     'use-strict';
     
 
     // Remove current graph
     $('#graph').empty();
 
-    console.log(name + '/' + id + '.svg');
-
-    getRemote(name + '/' + id + '.svg');
+    getRemote('static/res/graphs/' + id + '.svg');
 
     FCEPrerequisiteCourses = [csc318, csc454];
 
@@ -77,7 +72,7 @@ function loadGraph(name, id) {
 
     // Initialize interface
     initializeGraphSettings();
-    
+
     fillFCECount();
 
     // Uncomment to enable the feedback form (must also be displayed in html)

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -64,7 +64,7 @@ function loadGraph(id) {
     getRemote('static/res/graphs/' + id + '.svg');
 
     // Only create this if CSC graph loaded
-    if (getCookie('active-graph' === '1')) {
+    if (getCookie('active-graph') === '1') {
         FCEPrerequisiteCourses = [csc318, csc454];
     }
 

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -64,7 +64,7 @@ function loadGraph(id) {
     getRemote('static/res/graphs/' + id + '.svg');
 
     // Only create this if CSC graph loaded
-    if ('undefined' !== typeof csc318) {
+    if (getCookie('active-graph' === '1')) {
         FCEPrerequisiteCourses = [csc318, csc454];
     }
 

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -63,7 +63,10 @@ function loadGraph(id) {
 
     getRemote('static/res/graphs/' + id + '.svg');
 
-    FCEPrerequisiteCourses = [csc318, csc454];
+    // Only create this if CSC graph loaded
+    if ('undefined' !== typeof csc318) {
+        FCEPrerequisiteCourses = [csc318, csc454];
+    }
 
     buildGraph();
 

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -75,6 +75,8 @@ function loadGraph(id) {
 
     fillFCECount();
 
+    setCookie('active-graph', id);
+
     // Uncomment to enable the feedback form (must also be displayed in html)
     // activateFeedbackForm();
     // Uncomment to enable graph dragging

--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -64,6 +64,8 @@ function loadGraph(name, id) {
     // Remove current graph
     $('#graph').empty();
 
+    console.log(name + '/' + id + '.svg');
+
     getRemote(name + '/' + id + '.svg');
 
     FCEPrerequisiteCourses = [csc318, csc454];
@@ -76,9 +78,6 @@ function loadGraph(name, id) {
     // Initialize interface
     initializeGraphSettings();
     
-    // Update credit count in nav bar
-    updateNavGraph();
-
     fillFCECount();
 
     // Uncomment to enable the feedback form (must also be displayed in html)

--- a/public/js/graph/utilities/util.js
+++ b/public/js/graph/utilities/util.js
@@ -149,8 +149,11 @@ function initializeGraphSettings() {
         clearFocus();
     }
 
-    csc318.updateStatus();
-    csc454.updateStatus();
+    // only run this if the CSC graph is loaded
+    if ('undefined' !== typeof csc318){
+        csc318.updateStatus();
+        csc454.updateStatus();
+    }
 }
 
 

--- a/public/js/graph/utilities/util.js
+++ b/public/js/graph/utilities/util.js
@@ -150,7 +150,7 @@ function initializeGraphSettings() {
     }
 
     // only run this if the CSC graph is loaded
-    if (getCookie('active-graph') === '1')) {
+    if (getCookie('active-graph') === '1') {
         csc318.updateStatus();
         csc454.updateStatus();
     }

--- a/public/js/graph/utilities/util.js
+++ b/public/js/graph/utilities/util.js
@@ -150,7 +150,7 @@ function initializeGraphSettings() {
     }
 
     // only run this if the CSC graph is loaded
-    if ('undefined' !== typeof csc318){
+    if (getCookie('active-graph') === '1')) {
         csc318.updateStatus();
         csc454.updateStatus();
     }


### PR DESCRIPTION
This PR changes the way graphs are grabbed and loaded, based on the new convention of files being named after their primary IDs. 

@Ian-Stewart-Binks the IDs right now are stored within the `graph-button` elements for each graph, with the key `id` - each respective ID stored in its respective button.  To note, however, the buttons are only dynamically created when you open the 'graphs' tab in the sidebar. If you need them stored in a different place, let me know, it should not be too hard, depending on how you want to use it. 