### PR TITLE
Fixes Issue#386: Firefox Compatibility

### DIFF
--- a/public/js/draw/draw.js
+++ b/public/js/draw/draw.js
@@ -34,11 +34,9 @@ function getPosition(elem) {
         // || 0 -> for mozilla firefox compatability !!
         xPosition += (elem.offsetLeft || 0) - elem.scrollLeft + elem.clientLeft;
         yPosition += (elem.offsetTop || 0) - elem.scrollTop + elem.clientTop;
-        // console.log(elem.offsetLeft, elem.scrollLeft, elem.clientLeft);
-        // console.log(elem.offsetTop, elem.scrollTop, elem.clientTop);
         // console.log(elem.offsetLeft, elem.offsetTop);
         // console.log(elem);
-        elem = elem.offsetParent;
+        elem = elem.parentElement; // offsetParent undefined in mozilla
     }
     return { x: xPosition, y: yPosition };
 }

--- a/public/js/draw/draw.js
+++ b/public/js/draw/draw.js
@@ -31,11 +31,9 @@ function getPosition(elem) {
     var yPosition = 0;
       
     while (elem) {
-        // || 0 -> for mozilla firefox compatability !!
+        // || 0 for firefox compatability
         xPosition += (elem.offsetLeft || 0) - elem.scrollLeft + elem.clientLeft;
         yPosition += (elem.offsetTop || 0) - elem.scrollTop + elem.clientTop;
-        // console.log(elem.offsetLeft, elem.offsetTop);
-        // console.log(elem);
         elem = elem.parentElement; // offsetParent undefined in mozilla
     }
     return { x: xPosition, y: yPosition };


### PR DESCRIPTION
parentElement used to determine parents that contribute to the offset of the click event as opposed to offsetParent, which is not always defined in Mozilla Firefox.