### PR TITLE
Some facebook styling tweaks

### DIFF
--- a/hs/Css/CommonCss.hs
+++ b/hs/Css/CommonCss.hs
@@ -45,10 +45,11 @@ headerCSS = do
                 width $ px 200
                 display inlineBlock
                 margin (px 10) 0 (px 5) 0
+           height (px 50)
     "#nav-links" ?
         do
             "list-style" -: "none"
-            width $ pct 70
+            minWidth $ pct 50
             margin nil nil nil nil
             display inlineBlock
             a ?
@@ -61,6 +62,27 @@ headerCSS = do
                     color white
                     hover & do
                         color gray
+            height (px 50)
+    "#nav-fb" ? do
+        float floatRight
+        height (px 50)
+        "#nav-fb-post" ? do
+            backgroundColor blueFb
+            height (px 40)
+            margin (px 5) (px 10) (px 5) (px 10)
+            padding nil (px 5) nil (px 5)
+            lineHeight (px 40)
+            verticalAlign middle
+            display none
+            a <? do
+                color white
+            borderRadius (px 3) (px 3) (px 3) (px 3)
+        ".fb-login-button" ? do
+            height (px 40)
+            verticalAlign middle
+            width (px 140)
+            overflow hidden
+            margin (px 5) nil (px 5) nil
 
 {- aDefaultCSS
  - Generates default CSS. -}

--- a/hs/Css/Constants.hs
+++ b/hs/Css/Constants.hs
@@ -106,6 +106,7 @@ blue3 = parse "#437699"
 blue4 = parse "#5566F5"
 blue5 = parse "#A5A6F5"
 blue6 = rgb 184 231 249
+blueFb = rgb 59 89 152
 
 red1 = parse "#C92343"
 red2 = parse "#B91333"

--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -34,15 +34,19 @@ header page =
             H.li $ makeA "" "" "draw" "" "Draw"
             H.li $ makeA "" "" "post" "" "Check My POSt!"
             H.li $ makeA "" "" "about" "" "About"
-            H.li $ makeA "post-fb" "" "#" "" $ "Post to Facebook!"
-            H.li ! A.id "facebook-name" $ ""
-            H.li ! A.class_ "fb-login-button"
-                 ! H.customAttribute "data-max-rows" "1"
-                 ! H.customAttribute "data-size" "medium"
-                 ! H.customAttribute "autologoutlink" "true"
-                 ! H.customAttribute "data-show-faces" "false"
-                 ! H.customAttribute "data-auto-logout-link" "false" $ ""
-
+        if page `elem` ["graph", "grid"]
+        then
+            H.div ! A.id "nav-fb" $ do
+                H.span ! A.id "nav-fb-post" $ do
+                    H.a ! A.id "post-fb" $ "Post to Facebook"
+                H.span ! A.class_ "fb-login-button"
+                       ! H.customAttribute "data-max-rows" "1"
+                       ! H.customAttribute "data-size" "xlarge"
+                       ! H.customAttribute "data-show-faces" "false"
+                       ! H.customAttribute "data-auto-logout-link" "true"
+                       $ ""
+        else
+            ""
 -- Disclaimer. This will be the same for both pages, I guess?
 disclaimer :: H.Html
 disclaimer =

--- a/public/js/common/facebook/facebook_login.js
+++ b/public/js/common/facebook/facebook_login.js
@@ -3,7 +3,6 @@ $(document).ready(function () {
 
     $.ajaxSetup({ cache: true });
     $.getScript('//connect.facebook.net/en_UK/all.js', function() {
-
         FB.init({
             appId      : '432140593606098',
             xfbml      : true,
@@ -12,9 +11,9 @@ $(document).ready(function () {
         FB.Event.subscribe('auth.statusChange', function (response) {
             FB.getLoginStatus(function (response) {
                 if (response.status === 'connected') {
-                    addNameToNavBar();
+                    $('#nav-fb-post').css('display', 'inline-block');
                 } else {
-                    removeNameFromNavBar();
+                    $('#nav-fb-post').hide();
                 }
             });
         });


### PR DESCRIPTION
1. Styled the buttons (nav bar still needs work for spacing)
2. Removed the display of full name. My reasoning is it doesn't really do much for the user, and at this point another piece of information we need to be accountable for.
3. Only display "Post to Facebook" when on Graph/Grid, and logged in. In other situations, it looks misleading.

@Ian-Stewart-Binks Do you have any thoughts? My main hope is for our first version of a Privacy Policy to basically say "we don't use any of your personal information, we just let you post to Facebook."