### PR TITLE
Showcase bugs

### DIFF
--- a/hs/Css/GraphCss.hs
+++ b/hs/Css/GraphCss.hs
@@ -311,7 +311,7 @@ sidebarCSS = do
         paddingLeft (px 5)
         paddingRight (px 5)
     ".active" & do
-        backgroundColor purple1
+        backgroundColor purple2
     ".graph-button" & do
         display block
         cursor pointer

--- a/public/js/graph/utilities/util.js
+++ b/public/js/graph/utilities/util.js
@@ -178,7 +178,7 @@ function reset() {
     // Edges
     $('path').attr('data-active', 'inactive');
 
-    $('.region').attr('data-active', '');
+    $('.region').removeAttr('data-active');
 
     // Clear 'My Courses' tab
     $('#courseGrid').empty();

--- a/public/js/graph/utilities/util.js
+++ b/public/js/graph/utilities/util.js
@@ -178,6 +178,8 @@ function reset() {
     // Edges
     $('path').attr('data-active', 'inactive');
 
+    $('.region').attr('data-active', '');
+
     // Clear 'My Courses' tab
     $('#courseGrid').empty();
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -29,12 +29,12 @@ function fill300Textboxes(post, postElement) {
 function fill400Textboxes(post, postElement, category) {
     'use strict';
 
-    for (var m = post.index400 + 1; m < activeCourses.length &&
+    for (var m = post.index400; m < activeCourses.length &&
         post['filledTextboxes' + category] !== post['textboxes' + category]; m++) {
         var course = activeCourses[m];
         if (course.indexOf('CSC4') !== -1) {
             postElement[post['filledTextboxes' + category]].value = activeCourses[m];
-            post.index400 = m;
+            post.index400 = m + 1;
             post['filledTextboxes' + category] += 1;
             post.creditCount += 0.5;
         }


### PR DESCRIPTION
This fixes some of the bugs below found during the showcase today (sorry @david-yz-liu =) )

- 400 level courses would sometimes be repeated in the 400 level category and the 300+ level category
- Clicking the Reset Graphs button would fade out the regions as well, since the regions are considered a `path` 
- The colour of a tab on the sidebar nav when selected was pretty dark, so you couldn't see the actual text

There were some funky things going on with the Reset button during the showcase which surprisingly don't happen when I checkout the current version of master (such as the button not collapsing properly and being unable to select a course after you press the reset button, unless you refresh), so I am not quite sure what happened there.