### PR TITLE
Reset button disappear when switching tabs Fix

### DIFF
--- a/public/js/graph/sidebar/sidebar_divs.js
+++ b/public/js/graph/sidebar/sidebar_divs.js
@@ -47,7 +47,6 @@ function resetDivs() {
     $('#focuses').css('display', 'none');
     $('#graphs').css('display', 'none');
     $('#graphs-nav, #focuses-nav').removeClass('active');
-    $('#reset').css('display', 'none');
 }
 
 
@@ -75,6 +74,7 @@ function toggleSidebar(location) {
         $('#sidebar').animate({width: '40px'}, 'fast', undefined, function() {
             $('#fcecount').html('');
         });
+        $('#reset').css('display', 'none');
     } else if (!toggled && location === 'button') {
         toggled = true;
         $('#sidebar').animate({width: '400px'}, 'fast');


### PR DESCRIPTION
@david-yz-liu The fix that you made for the reset button for Firefox ended up making the Reset button disappear whenever you switched between the focus or graph tab. So I just moved the line over to toggleSidebar (when the sidebar is closed). Seems to be working fine on both Chrome and Firefox.