### PR TITLE
Move 'Get Involved' from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+One of our main goals for Courseography is to keep it a student-driven project. This means that if you want to get involved, you can! The best way to get started is by shooting us an email, but you should also feel free to check out all of the source code on Github and the accompanying Projects page.
+
+If you're coming from outside of the Department of Computer Science, we'd love to hear from you! We welcome help on making new graphs, understanding department- or program-specific policies, pointing out bugs or incorrect information, and general thoughts on the design of our tools. You don't need to be a programmer to get involved.
+
+We can be reached at courseography@cs.toronto.edu, and look forward to hearing from you!
+
+Click [here](PRIVACY.md) to learn about our Privacy Policy.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Courseography was envisioned in late 2013 by [David Liu](http://www.cs.toronto.e
 
 See [CONTRIBUTING.md](https://github.com/Courseography/courseography/blob/master/CONTRIBUTING.md).
 
+Click [here](/privacy) to learn about our Privacy Policy.
+
 ### Development
 
 Courseography is powered by [Haskell](https://www.haskell.org/).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 Courseography [![Slack][slackin-badge]][slackin]
-==================
-#About Courseography
+=============
+
 Here at the University of Toronto, we have hundreds of courses to choose from, and it can be hard to navigate prerequisite chains, program requirements, and term-by-term offerings all at once. That's where Courseography comes in: by presenting course and scheduling information in a set of graphical interactive tools, we make it easier to choose the right courses for your academic career. Whether it's making sure you'll satisfy all the prerequities for that 4th year course you really want to take, or fitting together fragments of your schedule for next term, we hope Courseography makes your life easier!
 
 Courseography was envisioned in late 2013 by [David Liu](http://www.cs.toronto.edu/~liudavid/), then a PhD student in the Department of Computer Science. However, it wasn't until he recruited [Ian Stewart-Binks](http://www.cs.toronto.edu/~iansb/) to the project that things really got rolling. Though the past year has really seen our tools take off within the CS student body, there's still a long way for us to go. Check out our Projects page to find out more about our plans for expanding to new departments, faculties, and campuses, and adding new services like POSt checking and importing/exporting data.
 
-#Get Involved
-One of our main goals for Courseography is to keep it a student-driven project. This means that if you want to get involved, you can! The best way to get started is by shooting us an email, but you should also feel free to check out all of the source code on Github and the accompanying Projects page.
+### Get Involved
 
-If you're coming from outside of the Department of Computer Science, we'd love to hear from you! We welcome help on making new graphs, understanding department- or program-specific policies, pointing out bugs or incorrect information, and general thoughts on the design of our tools. You don't need to be a programmer to get involved.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-We can be reached at courseography@cs.toronto.edu, and look forward to hearing from you!
-
-Click [here](/privacy) to learn about our Privacy Policy.
-
-#Development
+### Development
 
 Courseography is powered by [Haskell](https://www.haskell.org/).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Courseography was envisioned in late 2013 by [David Liu](http://www.cs.toronto.e
 
 ### Get Involved
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/Courseography/courseography/blob/master/CONTRIBUTING.md).
 
 ### Development
 


### PR DESCRIPTION
It's a minor change, but GitHub will now add a notice when contributors make a pull request:

![](https://camo.githubusercontent.com/71995d6b0e620a9ef1ded00a04498241c69dd1bf/68747470733a2f2f6769746875622d696d616765732e73332e616d617a6f6e6177732e636f6d2f736b697463682f6973737565732d32303132303931332d3136323533392e6a7067)

See <https://github.com/blog/1184-contributing-guidelines>