### PR TITLE
Add Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Courseography
+Courseography [![Slack][slackin-badge]][slackin]
 ==================
 #About Courseography
 Here at the University of Toronto, we have hundreds of courses to choose from, and it can be hard to navigate prerequisite chains, program requirements, and term-by-term offerings all at once. That's where Courseography comes in: by presenting course and scheduling information in a set of graphical interactive tools, we make it easier to choose the right courses for your academic career. Whether it's making sure you'll satisfy all the prerequities for that 4th year course you really want to take, or fitting together fragments of your schedule for next term, we hope Courseography makes your life easier!
@@ -21,3 +21,6 @@ Courseography is powered by [Haskell](https://www.haskell.org/).
 Learn more about setting up and installing Courseography on your local machine for development [here](https://github.com/Courseography/courseography/wiki/Installing-Courseography).
 
 More information about the project, including code and commit style guides, can be found in the [wiki](https://github.com/Courseography/courseography/wiki).
+
+[slackin]: https://courseography-slack.herokuapp.com/
+[slackin-badge]: https://courseography-slack.herokuapp.com/badge.svg


### PR DESCRIPTION
Courseograhy has a Slack team now! Go to https://courseography-slack.herokuapp.com/ to get your invite.

This PR adds a badge + link to the README:

![](http://i.imgur.com/3Top9V6.png)