### PR TITLE
Add dev script, initial webpack configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cabal.sandbox.config
 
 # generated build files
 /hs/dist/
+/public/js/pages/
 
 # generated CSS
 /public/style/

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+server: npm run nodemon-server
+webpack: npm run bundle-dev

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Control.Monad (msum)
 import Control.Monad.IO.Class (liftIO)
+import Data.Maybe (fromMaybe)
 import Happstack.Server
 import GridResponse
 import GraphResponse
@@ -16,6 +17,7 @@ import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseIn
 import Css.CssGen
 import Filesystem.Path.CurrentOS
 import System.Directory
+import System.Environment (lookupEnv)
 import CourseographyFacebook
 import qualified Data.Text as T
 
@@ -28,8 +30,13 @@ main = do
     let staticDir = encodeString (parent $ decodeString cwd) ++ "public/"
     aboutContents <- readFile "../README.md"
     privacyContents <- readFile "../PRIVACY.md"
+
+    -- Bind server to PORT environment variable if provided
+    portStr <- lookupEnv "PORT"
+    let port = read (fromMaybe "8000" portStr) :: Int
+
     print "Server is running..."
-    simpleHTTP nullConf $ msum
+    simpleHTTP config { port = port } $ msum
         [ do
               nullDir
               seeOther "graph" (toResponse "Redirecting to /graph"),

--- a/js/components/Graph/Graph.js
+++ b/js/components/Graph/Graph.js
@@ -1,0 +1,11 @@
+'use strict'
+
+import React from 'react';
+
+export default class Graph extends React.Component {
+  render() {
+    return (
+      <div>This is the graph</div>
+    )
+  }
+}

--- a/js/pages/graph.js
+++ b/js/pages/graph.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import React from 'react'
+
+import Graph from '../components/Graph/Graph'
+
+React.render(
+  Graph,
+  document.querySelector('#graph')
+)

--- a/js/webpack.local.config.js
+++ b/js/webpack.local.config.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var path = require('path');
+var webpack = require('webpack');
+
+/**
+ * This is the Webpack configuration file for local development. It contains
+ * local-specific configuration such as eval sourcemaps, as well as:
+ *
+ * - The entry point of the application
+ * - Where the output file should be
+ * - Which loaders to use on what files to properly transpile the source
+ *
+ * For more information, see: http://webpack.github.io/docs/configuration.html
+ */
+module.exports = {
+
+  // Resolve file names relative to js/
+  context: __dirname,
+
+  // Efficiently evaluate modules with source maps
+  devtool: "eval",
+
+  // Set entry points for individual pages
+  entry: {
+    graph: './pages/graph'
+  },
+
+  // Output to public/js/pages/[name].bundle.js
+  output: {
+    path: path.join(__dirname, '../public/js/pages'),
+    filename: '[name].bundle.js'
+  },
+
+  // Transform source code using Babel
+  module: {
+    loaders: [
+      { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader'}
+    ]
+  },
+
+  // Automatically transform files with these extensions
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+
+  // Watch files and re-bundle upon changes
+  watch: true
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "courseography",
   "version": "0.1.0",
   "description": "Courseography is a tool created by David Liu and Ian Stewart-Binks to guide students through their undergraduate careers.",
-  "main": "js/index.js",
   "scripts": {
+    "bundle-dev": "webpack --config js/webpack.local.config.js",
+    "bundle-prod": "webpack --config js/webpack.production.config.js",
+    "foreman-dev": "nf --procfile Procfile.dev start",
+    "nodemon-server": "cd hs && nodemon --exec 'cabal exec runhaskell' server.hs",
     "test": "jest ./js"
   },
   "repository": {
@@ -17,8 +20,16 @@
   },
   "homepage": "https://courseography.cdf.toronto.edu",
   "dependencies": {
+    "babel-core": "^5.1.13",
+    "babel-loader": "^5.0.0",
+    "jest-cli": "^0.4.0",
     "jquery": "^2.1.3",
     "lodash": "^3.7.0",
-    "react": "^0.13.2"
+    "react": "^0.13.2",
+    "webpack": "^1.8.9"
+  },
+  "devDependencies": {
+    "foreman": "^1.3.0",
+    "nodemon": "^1.3.7"
   }
 }

--- a/script/dev
+++ b/script/dev
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Launch processes defined in Procfile.dev via node-foreman
+npm run foreman-dev


### PR DESCRIPTION
Added:
- `script/dev`: after bootstrapping (`script/bootstrap`), run this to launch the web server & javascript bundler. The server will restart & javascripts will re-bundle upon saving files.
- `js/pages/graph.js`: single entry point for the `/graph` page
- `js/components/Graph/Graph.js`: initial React component for the graph

The Haskell server will now also run on the port specified by a `PORT` environment variable, if it's present, defaulting to 8000.

Ref #569 