### PR TITLE
Issue 578 Graph Button ID fix

### DIFF
--- a/public/js/graph/sidebar/sidebar_events.js
+++ b/public/js/graph/sidebar/sidebar_events.js
@@ -40,11 +40,12 @@ function createGraphButtons(graphs) {
     'use strict';
 
     for (var i = 0; i < graphs.length; i++) {
+        var graphId = graphs[i].gId;
         var graphTitle = graphs[i].title;
-        var graphButton = '<div id = "graph-' + graphTitle +'" class = "graph-button">';
+        var graphButton = '<div id = "graph-' + graphId +'" class = "graph-button">';
         $('#graphs').append(graphButton);
-        $('#graph-' + graphTitle).html(graphTitle);
-        $('#graph-' + graphTitle).data('id', graphs[i].gId);
+        $('#graph-' + graphId).html(graphTitle);
+        $('#graph-' + graphId).data('id', graphs[i].gId);
     }
 }
 


### PR DESCRIPTION
This fixes Issue #578. Graph titles can now have spaces, and graph button IDs are now based on the graph ID from the database.