### PR TITLE
Nodes not in focus are now faded

### DIFF
--- a/hs/Css/GraphCss.hs
+++ b/hs/Css/GraphCss.hs
@@ -64,8 +64,8 @@ nodeCSS = "g" ? do
             "text" <? do
                 fullyVisible
         "data-active" @= "unlit" & do
-            wideStroke
-            strokeRed
+            "rect" <?
+                faded
         "data-active" @= "unselected" & do
             "rect" <? do
                 wideStroke


### PR DESCRIPTION
This PR fixes the nodes that are not in a focus when a focus is selected - they are now faded out.  Fixes part of #251. 

I tried to work on the other part of the issue (selecting courses while focus is open), and I cannot seem to find a clean way to do this without removing the idea of the focus highlight. I can't think of a good way to highlight courses that are 'active' without making it confusing and detracting from the ones that are highlighted for the focus. I believe keeping it the way it is (not selecting a course while the focus is open) might be best. 

If anyone is opposed to that and has another suggestion, please let me know.