### PR TITLE
diagrams-svg-1.3.1: Upgrade diagrams-svg library

### DIFF
--- a/hs/Diagram.hs
+++ b/hs/Diagram.hs
@@ -58,7 +58,7 @@ renderTable filename courses session = do
     let courseTable = partition5 $ splitOn "_" courses
     print courseTable
     let g = makeTable (zipWith (:) times courseTable) session
-    let svg = renderDia SVG (SVGOptions (mkWidth 600) [] "") g
+    let svg = renderDia SVG (SVGOptions (mkWidth 600) Nothing "") g
     let txt = replace "16.0em" "16.0px" $ unpack $ renderText svg
     writeFile filename txt
     where

--- a/hs/courseography.cabal
+++ b/hs/courseography.cabal
@@ -20,6 +20,6 @@ executable courseography
   main-is:             server.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, DataKinds, NoMonomorphismRestriction, FlexibleContexts, GADTs, ScopedTypeVariables, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, DeriveGeneric, QuasiQuotes, TemplateHaskell, TypeFamilies
-  build-depends:       base, blaze-markup, blaze-html, happstack-server, blaze-svg, bytestring, aeson, transformers, base64-bytestring, split, containers, random, process, diagrams-lib >= 1.3, diagrams-svg >= 1.3, lucid, MissingH, fb, text, http-conduit, resourcet, conduit, persistent >= 2.1.2, persistent-sqlite, http-client, network, HTTP, tagsoup, regex-posix, mtl, HaXml, persistent-template, vector, clay, directory, markdown, system-filepath, hslogger, time
+  build-depends:       base, blaze-markup, blaze-html, happstack-server, blaze-svg, bytestring, aeson, transformers, base64-bytestring, split, containers, random, process, diagrams-lib >= 1.3, diagrams-svg >= 1.3.1, lucid, MissingH, fb, text, http-conduit, resourcet, conduit, persistent >= 2.1.2, persistent-sqlite, http-client, network, HTTP, tagsoup, regex-posix, mtl, HaXml, persistent-template, vector, clay, directory, markdown, system-filepath, hslogger, time
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
Note: will require a `cabal update` and `cabal install --only-dependencies`.