### PR TITLE
Fix #325 - Add corequisite support to database

### DIFF
--- a/hs/Database/CourseQueries.hs
+++ b/hs/Database/CourseQueries.hs
@@ -75,6 +75,7 @@ buildCourse fallSession springSession yearSession course =
            (coursesManualPracticalEnrolment course)
            (coursesDistribution course)
            (coursesPrereqs course)
+           (coursesCoreqs course)
 
 -- | Builds a Lecture structure from a tuple from the Lectures table.
 buildLecture :: Lectures -> Lecture

--- a/hs/Database/JsonParser.hs
+++ b/hs/Database/JsonParser.hs
@@ -41,6 +41,7 @@ insertCourse course =
                       (breadth course)
                       (distribution course)
                       (prereqString course)
+                      (coreqs course)
 
 -- | Updates the manualTutorialEnrolment field of all courses with course code course
 setTutEnrol :: MonadIO m => T.Text -> Bool -> ReaderT SqlBackend m ()

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -38,6 +38,7 @@ Courses json
     breadth T.Text Maybe
     distribution T.Text Maybe
     prereqString T.Text Maybe
+    coreqs T.Text Maybe
     deriving Show
 
 Lectures
@@ -157,11 +158,12 @@ data Course =
              manualTutorialEnrol :: Maybe Bool,
              manualPracticalEnrol :: Maybe Bool,
              distribution :: Maybe T.Text,
-             prereqs :: Maybe T.Text
+             prereqs :: Maybe T.Text,
+             coreqs :: Maybe T.Text
            } deriving Show
 
 instance ToJSON Course where
-  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol manualPracticalEnrol distribution prereqs)
+  toJSON (Course breadth description title prereqString f s y name exclusions manualTutorialEnrol manualPracticalEnrol distribution prereqs coreqs)
           = object ["breadth" .= breadth,
                     "description" .= description,
                     "title" .= title,
@@ -174,7 +176,8 @@ instance ToJSON Course where
                     "manualTutorialEnrolment" .= manualTutorialEnrol,
                     "manualPracticalEnrolment" .= manualPracticalEnrol,
                     "distribution" .= distribution,
-                    "prereqs" .= prereqs
+                    "prereqs" .= prereqs,
+                    "coreqs" .= coreqs
                    ]
 
 instance ToJSON Session where

--- a/hs/WebParsing/ParsingHelp.hs
+++ b/hs/WebParsing/ParsingHelp.hs
@@ -56,7 +56,8 @@ emptyCourse = Course {
                     manualTutorialEnrol = Nothing,
                     manualPracticalEnrol = Nothing,
                     distribution = Nothing,
-                    prereqs = Nothing}
+                    prereqs = Nothing,
+                    coreqs = Nothing}
 
 replaceAll :: [T.Text] -> T.Text -> T.Text -> T.Text
 replaceAll matches replacement str =
@@ -187,7 +188,8 @@ parsePrerequisite (tags, course) =
 parseCorequisite :: CoursePart -> CoursePart
 parseCorequisite (tags, course)  =
   let (parsed, rest) = tagBreak ["Exclusion","Recommended","Distribution","Breadth"] tags
-  in (rest, course)
+      coreqs = makeEntry parsed (Just ["Corequisite:"])
+  in (rest, course {coreqs = coreqs})
 
 parseExclusion :: CoursePart -> CoursePart
 parseExclusion (tags, course) =

--- a/public/js/common/course_description.js
+++ b/public/js/common/course_description.js
@@ -77,6 +77,10 @@ function formatCourseDescription(course) {
         courseDescription += '<p><strong>Prerequisite:</strong> ' +
                              course.prereqString + '</p>';
     }
+    if (course.coreqs !== undefined && course.coreqs !== null) {
+        courseDescription += '<p><strong>Corequisites:</strong> ' +
+                             course.coreqs + '</p>';
+    }
     if (course.prep !== undefined && course.prep !== null) {
         courseDescription += '<p><strong>Recommended Preparation:</strong> ' +
                              course.prep + '</p>';

--- a/public/js/common/objects/course.js
+++ b/public/js/common/objects/course.js
@@ -15,6 +15,7 @@ function Course(name) {
     this.title = course.title;
     this.prereqs = course.prereqs;
     this.prereqString = course.prereqString;
+    this.coreqs = course.coreqs;
     this.breadth = course.breadth;
     this.prep = course.prep;
     this.description = course.description;


### PR DESCRIPTION
Note - this was also done at the Stats Deparment's request, as we display a few arrows in the graph which represent corequisites, not prerequisites.