### PR TITLE
Make a main file with tasks to avoid using runhaskell.

### DIFF
--- a/hs/Database/database.hs
+++ b/hs/Database/database.hs
@@ -1,17 +1,19 @@
 {-# LANGUAGE FlexibleContexts, GADTs, MultiParamTypeClasses,
  OverloadedStrings, TypeFamilies #-}
 
+module Database.Database (setupDatabase) where
+
 import Database.Persist.Sqlite
 import Database.JsonParser
 import Database.Tables
 import WebParsing.ParseAll
 
-main :: IO ()
-main = do setupDistributionTable
-          print "Distribution table set up"
-          setupBreadthTable
-          print "breadth table set up"
-          parseAll
+setupDatabase :: IO ()
+setupDatabase = do setupDistributionTable
+                   print "Distribution table set up"
+                   setupBreadthTable
+                   print "breadth table set up"
+                   parseAll
 
 -- | Sets up the Distribution table.
 setupDistributionTable :: IO ()

--- a/hs/Main.hs
+++ b/hs/Main.hs
@@ -22,7 +22,7 @@ getTask taskName = Map.lookup taskName taskNamesToTasks
 main :: IO ()
 main = do
     args <- getArgs
-    let taskName = if null args then "server" else args !! 0
+    let taskName = if null args then "server" else head args
 
     -- extract and perform the task we want to run
     let taskNames = Map.keys taskNamesToTasks

--- a/hs/Main.hs
+++ b/hs/Main.hs
@@ -1,7 +1,10 @@
 module Main where
 
+import System.IO (stderr, hPutStrLn)
 import System.Environment (getArgs)
-import Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.List (intercalate)
+import qualified Data.Map.Strict as Map
 
 -- internal dependencies
 import Server (runServer)
@@ -13,10 +16,18 @@ taskNamesToTasks = Map.fromList [("server", runServer),
                                  ("database", setupDatabase),
                                  ("graphs", parsePrebuiltSvgs)]
 
+getTask :: String -> Maybe (IO ())
+getTask taskName = Map.lookup taskName taskNamesToTasks
+
 main :: IO ()
 main = do
     args <- getArgs
-    let command = if length args == 0 then "server" else args !! 0
+    let taskName = if length args == 0 then "server" else args !! 0
 
     -- extract and perform the task we want to run
-    taskNamesToTasks ! command
+    let taskNames = Map.keys taskNamesToTasks
+    let availableTasksStr = "[" ++ (intercalate ", " taskNames) ++ "]"
+    let lookupFailedMsg = "No task named " ++ taskName ++
+                          ", available tasks are " ++ availableTasksStr
+
+    fromMaybe (hPutStrLn stderr lookupFailedMsg) (getTask taskName)

--- a/hs/Main.hs
+++ b/hs/Main.hs
@@ -22,7 +22,7 @@ getTask taskName = Map.lookup taskName taskNamesToTasks
 main :: IO ()
 main = do
     args <- getArgs
-    let taskName = if length args == 0 then "server" else args !! 0
+    let taskName = if null args then "server" else args !! 0
 
     -- extract and perform the task we want to run
     let taskNames = Map.keys taskNamesToTasks

--- a/hs/Main.hs
+++ b/hs/Main.hs
@@ -1,0 +1,22 @@
+module Main where
+
+import System.Environment (getArgs)
+import Data.Map.Strict as Map
+
+-- internal dependencies
+import Server (runServer)
+import Database.Database (setupDatabase)
+import Svg.Parser (parsePrebuiltSvgs)
+
+taskNamesToTasks :: Map.Map String (IO ())
+taskNamesToTasks = Map.fromList [("server", runServer),
+                                 ("database", setupDatabase),
+                                 ("graphs", parsePrebuiltSvgs)]
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let command = if length args == 0 then "server" else args !! 0
+
+    -- extract and perform the task we want to run
+    taskNamesToTasks ! command

--- a/hs/Svg/Parser.hs
+++ b/hs/Svg/Parser.hs
@@ -15,7 +15,7 @@ The final svg files are output in @public\/res\/graphs\/gen@ and are sent
 directly to the client when viewing the @/graph@ page.
 -}
 
-module Svg.Parser where
+module Svg.Parser (parsePrebuiltSvgs) where
 
 import Data.Maybe (mapMaybe, catMaybes, fromMaybe)
 import Data.Int
@@ -33,8 +33,8 @@ import Database.DataType
 import Svg.Database
 import Svg.Generator
 
-main :: IO ()
-main = do
+parsePrebuiltSvgs :: IO ()
+parsePrebuiltSvgs = do
     performParse "Computer Science" "csc2015.svg"
     performParse "Statistics" "sta2015.svg"
 

--- a/hs/courseography.cabal
+++ b/hs/courseography.cabal
@@ -17,7 +17,7 @@ extra-source-files:  README.md
 cabal-version:       >=1.22
 
 executable courseography
-  main-is:             server.hs
+  main-is:             Main.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, DataKinds, NoMonomorphismRestriction, FlexibleContexts, GADTs, ScopedTypeVariables, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, DeriveGeneric, QuasiQuotes, TemplateHaskell, TypeFamilies
   build-depends:       base, blaze-markup, blaze-html, happstack-server, blaze-svg, bytestring, aeson, transformers, base64-bytestring, split, containers, random, process, diagrams-lib >= 1.3, diagrams-svg >= 1.3.1, lucid, MissingH, fb, text, http-conduit, resourcet, conduit, persistent >= 2.1.2, persistent-sqlite, http-client, network, HTTP, tagsoup, regex-posix, mtl, HaXml, persistent-template, vector, clay, directory, markdown, system-filepath, hslogger, time

--- a/hs/server.hs
+++ b/hs/server.hs
@@ -1,4 +1,4 @@
-module Main where
+module Server (runServer) where
 
 import Control.Monad (msum)
 import Control.Monad.IO.Class (liftIO)
@@ -36,8 +36,8 @@ logMAccessShort host user time requestLine responseCode size referer userAgent =
         , referer
         ]
 
-main :: IO ()
-main = do
+runServer :: IO ()
+runServer = do
     -- Use line buffering to ensure logging messages are printed correctly
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering


### PR DESCRIPTION
Usage:

* `cabal run` or `cabal run server` to run the server
* `cabal run database` to migrate and seed the database
* `cabal run graphs` to parse and insert the graphs.