### PR TITLE
More Check My Post Fixes

### DIFF
--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -236,7 +236,7 @@ checkPost =
                     H.p ! A.class_ "full_name CSC236240" $ "CSC236H (Introduction to the Theory of Computation)"
                     H.p ! A.class_ "full_name CSC236240" $ "CSC240H (Enriched Introduction to the Theory of Computation)"
             H.div ! A.id "min_misc" $ do
-                H.p ! A.class_ "code" $ "Any 300/400-level CSC course (atleast 1.0 FCE), CSC209H, CSC258H, CSC263H/CSC265H (1.5 FCEs)"  
+                H.p ! A.class_ "code" $ "Any 200/300/400-level CSC course (atleast 1.0 FCE), CSC209H, CSC258H, CSC263H/CSC265H (1.5 FCEs)"  
                 H.div ! A.id "minextra" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
                     H.input ! A.type_ "text"

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -236,7 +236,7 @@ checkPost =
                     H.p ! A.class_ "full_name CSC236240" $ "CSC236H (Introduction to the Theory of Computation)"
                     H.p ! A.class_ "full_name CSC236240" $ "CSC240H (Enriched Introduction to the Theory of Computation)"
             H.div ! A.id "min_misc" $ do
-                H.p ! A.class_ "code" $ "Any 200/300/400-level CSC course (atleast 1.0 FCE), CSC209H, CSC258H, CSC263H/CSC265H (1.5 FCEs)"  
+                H.p ! A.class_ "code" $ "Any 200/300/400-level CSC course (atleast 1.0 FCE of 300/400-level) (1.5 FCEs)"  
                 H.div ! A.id "minextra" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
                     H.input ! A.type_ "text"

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -113,7 +113,7 @@ checkPost =
                     H.input ! A.type_ "text"  
                     H.input ! A.type_ "text" 
             H.div ! A.id "spec_300" $ do 
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H (1.5 FCEs)"
                 H.div ! A.id "spec300" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text" 
                     H.input ! A.type_ "text"
@@ -189,7 +189,7 @@ checkPost =
                 H.div ! A.id "maj400" ! A.class_ "more-info" $ 
                     H.input ! A.type_ "text" 
             H.div ! A.id "maj_300" $ do
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H, ECE489H (1.0 FCEs)"
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB410H, BCB420H, BCB430Y, ECE385H (1.0 FCEs)"
                 H.div ! A.id "maj300" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"  
                     H.input ! A.type_ "text" 

--- a/hs/PostResponse.hs
+++ b/hs/PostResponse.hs
@@ -119,9 +119,9 @@ checkPost =
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text" 
             H.div ! A.id "spec_extra" $ do
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB/ECE/MAT/STA course (2.0 FCEs) - \
-                                         \MAT: 224, 235/237/257, any 300+ except for 329, 390, & 391 \
-                                         \; STA: 248, 261, any 300+" 
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course; \ 
+                                         \MAT: 221/223/240, 224, 235/237/257, any 300+ except for 329, 390, & 391 \ 
+                                         \; STA: 248, 261, any 300+; ECE385H/489H; BCB410H/420H/430Y (1.5 FCEs)" 
                 H.div ! A.id "specextra" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"
@@ -185,7 +185,7 @@ checkPost =
                     H.p ! A.class_ "full_name STA247255257Sta1" $ "STA257H (Probability and Statistics 1)"
             H.h2 "Later Years"
             H.div ! A.id "maj_400" $ do
-                H.p ! A.class_ "code" $ "Any 400-level CSC course, BCB410H, BCB420H, BCB430Y (0.5 FCEs)"
+                H.p ! A.class_ "code" $ "Any 400-level CSC course, BCB410H, BCB420H, BCB430Y, ECE489H (0.5 FCEs)"
                 H.div ! A.id "maj400" ! A.class_ "more-info" $ 
                     H.input ! A.type_ "text" 
             H.div ! A.id "maj_300" $ do
@@ -194,9 +194,9 @@ checkPost =
                     H.input ! A.type_ "text"  
                     H.input ! A.type_ "text" 
             H.div ! A.id "maj_extra" $ do
-                H.p ! A.class_ "code" $ "Any 300+ level CSC course, BCB/ECE/MAT/STA course (1.5 FCEs) - \ 
+                H.p ! A.class_ "code" $ "Any 300+ level CSC course; \ 
                                          \MAT: 221/223/240, 224, 235/237/257, any 300+ except for 329, 390, & 391 \ 
-                                         \; STA: 248, 261, any 300+" 
+                                         \; STA: 248, 261, any 300+; ECE385H/489H; BCB410H/420H/430Y (1.5 FCEs)" 
                 H.div ! A.id "majextra" ! A.class_ "more-info" $ do
                     H.input ! A.type_ "text"
                     H.input ! A.type_ "text"

--- a/public/js/graph/create_data.js
+++ b/public/js/graph/create_data.js
@@ -21,11 +21,10 @@ var areaNames = ['theory', 'core', 'se', 'systems', 'hci',
                  'graphics', 'num', 'ai'];
 
 
-// Required for specialist
-var reqs = [
+// CSC courses required for major
+var majReqs = [
     'CSC108', 'CSC148', 'CSC165240', 'CSC207',
-    'CSC209', 'CSC236240', 'CSC258', 'CSC263265',
-    'CSC369', 'CSC373', 'MAT135136137157Calc1', 'MAT221223240Lin1', 'STA247255257Sta1'
+    'CSC236240', 'CSC258', 'CSC263265'
 ];
 
 // 'Inquiry' courses

--- a/public/js/graph/create_data.js
+++ b/public/js/graph/create_data.js
@@ -13,7 +13,7 @@ var allCourses = ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240',
                   'CSC420', 'CSC428', 'CSC386', 'CSC438', 'CSC443',
                   'CSC446', 'CSC448', 'CSC454', 'CSC456', 'CSC458',
                   'CSC463', 'CSC465', 'CSC469', 'CSC486', 'CSC488',
-                  'ECE489', 'CSC373', 'CSC466'];
+                  'ECE489', 'CSC373', 'CSC466', 'CSC200'];
 
 specialistCourses = ['CSC373', 'CSC369', 'MAT221223240Lin1'];
 

--- a/public/js/graph/create_data.js
+++ b/public/js/graph/create_data.js
@@ -5,7 +5,7 @@ var math = [
 
 // All CSC Courses
 var allCourses = ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240',
-                  'CSC209', 'CSC258', 'CSC236265', 'CSC300', 'CSC301',
+                  'CSC209', 'CSC258', 'CSC263265', 'CSC300', 'CSC301',
                   'CSC302', 'CSC309', 'CSC310', 'CSC318', 'CSC320',
                   'CSC321', 'CSC324', 'CSC336', 'CSC343', 'CSC358',
                   'CSC369', 'CSC372', 'CSC348', 'ECE385', 'CSC401',
@@ -24,7 +24,7 @@ var areaNames = ['theory', 'core', 'se', 'systems', 'hci',
 // Required for specialist
 var reqs = [
     'CSC108', 'CSC148', 'CSC165240', 'CSC207',
-    'CSC209', 'CSC236240', 'CSC258', 'CSC236265',
+    'CSC209', 'CSC236240', 'CSC258', 'CSC263265',
     'CSC369', 'CSC373', 'MAT135136137157Calc1', 'MAT221223240Lin1', 'STA247255257Sta1'
 ];
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -21,8 +21,6 @@ function fill300Textboxes(post, postElement) {
             post.creditCount += 0.5;
         }
     }
-
-    updateBCBCount(post, postElement, '300');
 }
 
 
@@ -47,10 +45,6 @@ function fill400Textboxes(post, postElement, category) {
             post['filledTextboxes' + category] += 1;
             post.creditCount += 0.5;
         }
-    }
-
-    if (category === '400') {
-        updateBCBCount(post, postElement, '400');
     }
 }
 
@@ -84,6 +78,9 @@ function fill300s() {
     if (major.filledTextboxes300 < major.textboxes300) {
         fill400Textboxes(major, maj300s, '300');
     }
+
+    updateBCBCount(specialist, spec300s, '300');
+    updateBCBCount(major, maj300s, '300');
 }
 
 
@@ -109,6 +106,9 @@ function fill400s() {
     // Fill courses that have been selected
     fill400Textboxes(specialist, spec400s, '400');
     fill400Textboxes(major, maj400s, '400');
+
+    updateBCBCount(specialist, spec400s, '400');
+    updateBCBCount(major, maj400s, '400');
 }
 
 
@@ -175,6 +175,7 @@ function fillExtra() {
     }
 
     // Fill courses that have been selected
+
     fillExtraTextboxes(specialist, specExtra, '300');
     fillExtraTextboxes(major, majExtra, '300');
     fillExtraTextboxes(minor, minExtra, '300');
@@ -190,6 +191,9 @@ function fillExtra() {
     if (minor.filledTextboxesExtra < minor.textboxesExtra) {
         fillExtraTextboxes(minor, minExtra, '400');
     }
+
+    updateBCBCount(specialist, specExtra, '300');
+    updateBCBCount(major, majExtra, '300');
 }
 
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -128,7 +128,6 @@ function fillExtraTextboxes(post, postElement, level) {
 
         if (postElement[post.filledTextboxesExtra].value === '' &&
             (course.indexOf('CSC' + level.charAt(0)) !== -1 ||
-            //course.indexOf('Lin1') !== -1 ||
             course.indexOf('ECE' + level.charAt(0)) !== -1) &&
             ((post.name === 'major' && notMajReqCourse(course)) || 
              post.name === 'minor' ||

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -130,7 +130,8 @@ function fillExtraTextboxes(post, postElement, level) {
             (course.indexOf('CSC' + level.charAt(0)) !== -1 ||
             //course.indexOf('Lin1') !== -1 ||
             course.indexOf('ECE' + level.charAt(0)) !== -1) &&
-            (post.name === 'major' || post.name === 'minor' ||
+            ((post.name === 'major' && notMajReqCourse(course)) || 
+             post.name === 'minor' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
 
             postElement[post.filledTextboxesExtra].value = activeCourses[i];
@@ -178,6 +179,7 @@ function fillExtra() {
     fillExtraTextboxes(specialist, specExtra, '300');
     fillExtraTextboxes(major, majExtra, '300');
     fillExtraTextboxes(minor, minExtra, '300');
+    fillExtraTextboxes(major, majExtra, '200');
     fillExtraTextboxes(minor, minExtra, '200');
 
     if (specialist.filledTextboxesExtra < specialist.textboxesExtra) {

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -118,7 +118,8 @@ function fillExtraTextboxes(post, postElement, level) {
 
         if (postElement[post.filledTextboxesExtra].value === '' &&
             (course.indexOf('CSC' + level.charAt(0)) !== -1 ||
-            course.indexOf('ECE' + level.charAt(0)) !== -1) &&
+            course.indexOf('ECE' + level.charAt(0)) !== -1 ||
+            course.indexOf('BCB') !== -1) &&
             (post.name === 'major' || post.name === 'minor' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
 
@@ -148,13 +149,13 @@ function fillExtra() {
 
         // Clear text boxes
         if (specExtra[k].value.indexOf('MAT') === -1 && specExtra[k].value.indexOf('STA') === -1
-            && specExtra[k].value.indexOf('CSC49') === -1) {
+            && specExtra[k].value.indexOf('CSC49') === -1 && specExtra[k].value.indexOf('BCB') === -1) {
             specExtra[k].value = '';
             specExtra[k].disabled = false;
         }
         if (k < 3) {
             if (majExtra[k].value.indexOf('MAT') === -1 && majExtra[k].value.indexOf('STA') === -1
-                && specExtra[k].value.indexOf('CSC49') === -1) {
+                && specExtra[k].value.indexOf('CSC49') === -1 && majExtra[k].value.indexOf('BCB') === -1) {
                 majExtra[k].value = '';
                 majExtra[k].disabled = false;
             }

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -6,6 +6,8 @@
 function fill300Textboxes(post, postElement) {
     'use strict';
 
+    updateBCBCount(post, postElement, '300');
+
     for (var m = post.index300; m < activeCourses.length &&
         post.filledTextboxes300 !== post.textboxes300; m++) {
 
@@ -15,6 +17,7 @@ function fill300Textboxes(post, postElement) {
             (post.name === 'major' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
             postElement[post.filledTextboxes300].value = activeCourses[m];
+            postElement[post.filledTextboxes300].disabled = true;
             post.index300 = m + 1;
             post.filledTextboxes300 += 1;
             post.creditCount += 0.5;
@@ -32,11 +35,17 @@ function fill300Textboxes(post, postElement) {
 function fill400Textboxes(post, postElement, category) {
     'use strict';
 
+    if (category === '400') {
+        updateBCBCount(post, postElement, '400');
+    }
+
     for (var m = post.index400; m < activeCourses.length &&
         post['filledTextboxes' + category] !== post['textboxes' + category]; m++) {
         var course = activeCourses[m];
+
         if (course.indexOf('CSC4') !== -1 || course.indexOf('ECE4') !== -1) {
             postElement[post['filledTextboxes' + category]].value = activeCourses[m];
+            postElement[post['filledTextboxes' + category]].disabled = true;
             post.index400 = m + 1;
             post['filledTextboxes' + category] += 1;
             post.creditCount += 0.5;
@@ -56,11 +65,11 @@ function fill300s() {
 
     // Clear textboxes
     for (var i = 0; i < 3; i++) {
-        spec300s[i].value = '';
-        spec300s[i].disabled = true;
-        if (i < 2) {
-            maj300s[i].value = '';
-            maj300s[i].disabled = true;
+        if (spec300s[i].value.indexOf('BCB') === -1) {
+            spec300s[i].value = '';
+            if (i < 2 && maj300s[i].value.indexOf('BCB') === -1) {
+                maj300s[i].value = '';
+            }
         }
     }
 
@@ -88,11 +97,11 @@ function fill400s() {
 
     // Clear textboxes
     for (var i = 0; i < 3; i++) {
-        spec400s[i].value = '';
-        spec400s[i].disabled = true;
-        if (i < 1) {
-            maj400s[i].value = '';
-            maj400s[i].disabled = true;
+        if (spec400s[i].value.indexOf('BCB') === -1) {
+            spec400s[i].value = '';
+            if (i < 1 && maj400s[i].value.indexOf('BCB') === -1) {
+                maj400s[i].value = '';
+            }
         }
     }
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -11,7 +11,7 @@ function fill300Textboxes(post, postElement) {
 
         var course = activeCourses[m];
 
-        if (course.indexOf('CSC3') !== -1 &&
+        if ((course.indexOf('CSC3') !== -1 || course.indexOf('ECE3') !== -1) &&
             (post.name === 'major' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
             postElement[post.filledTextboxes300].value = activeCourses[m];
@@ -35,7 +35,7 @@ function fill400Textboxes(post, postElement, category) {
     for (var m = post.index400; m < activeCourses.length &&
         post['filledTextboxes' + category] !== post['textboxes' + category]; m++) {
         var course = activeCourses[m];
-        if (course.indexOf('CSC4') !== -1) {
+        if (course.indexOf('CSC4') !== -1 || course.indexOf('ECE4') !== -1) {
             postElement[post['filledTextboxes' + category]].value = activeCourses[m];
             post.index400 = m + 1;
             post['filledTextboxes' + category] += 1;
@@ -117,7 +117,8 @@ function fillExtraTextboxes(post, postElement, level) {
         var course = activeCourses[i];
 
         if (postElement[post.filledTextboxesExtra].value === '' &&
-            course.indexOf('CSC' + level.charAt(0)) != -1 &&
+            (course.indexOf('CSC' + level.charAt(0)) !== -1 ||
+            course.indexOf('ECE' + level.charAt(0)) !== -1) &&
             (post.name === 'major' || post.name === 'minor' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -6,15 +6,13 @@
 function fill300Textboxes(post, postElement) {
     'use strict';
 
-    updateBCBCount(post, postElement, '300');
-
     for (var m = post.index300; m < activeCourses.length &&
         post.filledTextboxes300 !== post.textboxes300; m++) {
 
         var course = activeCourses[m];
 
-        if ((course.indexOf('CSC3') !== -1 || course.indexOf('ECE3') !== -1) &&
-            (post.name === 'major' ||
+        if ((course.indexOf('CSC3') !== -1 || course.indexOf('ECE3') !== -1 ||
+            course.indexOf('BCB') !== -1) && (post.name === 'major' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
             postElement[post.filledTextboxes300].value = activeCourses[m];
             postElement[post.filledTextboxes300].disabled = true;
@@ -23,6 +21,8 @@ function fill300Textboxes(post, postElement) {
             post.creditCount += 0.5;
         }
     }
+
+    updateBCBCount(post, postElement, '300');
 }
 
 
@@ -35,21 +35,22 @@ function fill300Textboxes(post, postElement) {
 function fill400Textboxes(post, postElement, category) {
     'use strict';
 
-    if (category === '400') {
-        updateBCBCount(post, postElement, '400');
-    }
-
     for (var m = post.index400; m < activeCourses.length &&
         post['filledTextboxes' + category] !== post['textboxes' + category]; m++) {
         var course = activeCourses[m];
 
-        if (course.indexOf('CSC4') !== -1 || course.indexOf('ECE4') !== -1) {
+        if (course.indexOf('CSC4') !== -1 || course.indexOf('ECE4') !== -1 ||
+            course.indexOf('BCB') !== -1) {
             postElement[post['filledTextboxes' + category]].value = activeCourses[m];
             postElement[post['filledTextboxes' + category]].disabled = true;
             post.index400 = m + 1;
             post['filledTextboxes' + category] += 1;
             post.creditCount += 0.5;
         }
+    }
+
+    if (category === '400') {
+        updateBCBCount(post, postElement, '400');
     }
 }
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -128,8 +128,8 @@ function fillExtraTextboxes(post, postElement, level) {
 
         if (postElement[post.filledTextboxesExtra].value === '' &&
             (course.indexOf('CSC' + level.charAt(0)) !== -1 ||
-            course.indexOf('ECE' + level.charAt(0)) !== -1 ||
-            course.indexOf('BCB') !== -1) &&
+            //course.indexOf('Lin1') !== -1 ||
+            course.indexOf('ECE' + level.charAt(0)) !== -1) &&
             (post.name === 'major' || post.name === 'minor' ||
              (post.name === 'specialist' && notSpecialistCourse(course)))) {
 
@@ -178,6 +178,7 @@ function fillExtra() {
     fillExtraTextboxes(specialist, specExtra, '300');
     fillExtraTextboxes(major, majExtra, '300');
     fillExtraTextboxes(minor, minExtra, '300');
+    fillExtraTextboxes(minor, minExtra, '200');
 
     if (specialist.filledTextboxesExtra < specialist.textboxesExtra) {
         fillExtraTextboxes(specialist, specExtra, '400');
@@ -187,11 +188,6 @@ function fillExtra() {
     }
     if (minor.filledTextboxesExtra < minor.textboxesExtra) {
         fillExtraTextboxes(minor, minExtra, '400');
-    }
-
-    // add extra 200 courses for minor if extra space
-    if (minor.filledTextboxesExtra < minor.textboxesExtra) {
-        addExtraMinCourses();
     }
 }
 

--- a/public/js/post/fill_textboxes.js
+++ b/public/js/post/fill_textboxes.js
@@ -146,12 +146,14 @@ function fillExtra() {
     for (var k = 0; k < 4; k++) {
 
         // Clear text boxes
-        if (specExtra[k].value.indexOf('MAT') === -1 && specExtra[k].value.indexOf('STA') === -1) {
+        if (specExtra[k].value.indexOf('MAT') === -1 && specExtra[k].value.indexOf('STA') === -1
+            && specExtra[k].value.indexOf('CSC49') === -1) {
             specExtra[k].value = '';
             specExtra[k].disabled = false;
         }
         if (k < 3) {
-            if (majExtra[k].value.indexOf('MAT') === -1 && majExtra[k].value.indexOf('STA') === -1) {
+            if (majExtra[k].value.indexOf('MAT') === -1 && majExtra[k].value.indexOf('STA') === -1
+                && specExtra[k].value.indexOf('CSC49') === -1) {
                 majExtra[k].value = '';
                 majExtra[k].disabled = false;
             }
@@ -192,14 +194,14 @@ function fillMisc() {
     var majInq = $('#maj_misc')[0].getElementsByTagName('input');
 
     // Clear textboxes
-    if (specInq[0].value.indexOf('PEY') === -1) {
+    if (specInq[0].value.indexOf('PEY') === -1 && specInq[0].value.indexOf('CSC49') ) {
         specInq[0].value = '';
         specInq[0].disabled = false;
     } else {
         specialist.activeInq = 1;
     }
 
-    if (majInq[0].value.indexOf('PEY') === -1) {
+    if (majInq[0].value.indexOf('PEY') === -1 && majInq[0].value.indexOf('CSC49') ) {
         majInq[0].value = '';
         majInq[0].disabled = false;
     } else {

--- a/public/js/post/update_categories.js
+++ b/public/js/post/update_categories.js
@@ -13,7 +13,8 @@ function updateReqsCategory(post, name) {
             activateCourse(post.reqs[i]);
             updateCategory(category, 'fulfilled');
             post.categoriesCompleted += 1;
-            post.creditCount += (post.reqs[i] === 'Calc1') ? 1 : 0.5;
+            post.creditCount += (post.reqs[i] === 'MAT135136137157Calc1') ? 1 : 0.5;
+            console.log(post.creditCount);
         }
 
         // If the category is not completed

--- a/public/js/post/update_categories.js
+++ b/public/js/post/update_categories.js
@@ -14,7 +14,6 @@ function updateReqsCategory(post, name) {
             updateCategory(category, 'fulfilled');
             post.categoriesCompleted += 1;
             post.creditCount += (post.reqs[i] === 'MAT135136137157Calc1') ? 1 : 0.5;
-            console.log(post.creditCount);
         }
 
         // If the category is not completed

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -3,13 +3,13 @@ var specialist = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'fille
                   'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
                   'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
                   'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
-                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3,
-                  'textboxesExtra': 4, 'categories': 17, 'creditCount': 0, 'name': 'specialist'};
+                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3,'textboxesExtra': 4, 'categories': 17, 
+                  'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
 var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
              'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
              'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
-             'MAT135136137157Calc1'], 'textboxes300': 2,
-             'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 'creditCount': 0, 'name': 'major'};
+             'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
+             'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
 var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
              'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
              'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
@@ -51,6 +51,7 @@ function updateAllCategories() {
 
     fillCreditCount();
     checkPostCompleted();
+
 }
 
 
@@ -65,13 +66,13 @@ function resetValues() {
                   'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
                   'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
                   'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
-                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3,
-                  'textboxesExtra': 4, 'categories': 17, 'creditCount': 0, 'name': 'specialist'};
+                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3, 'textboxesExtra': 4, 'categories': 17, 
+                  'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
     var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
                  'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
                  'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
-                 'MAT135136137157Calc1'], 'textboxes300': 2,
-                 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 'creditCount': 0, 'name': 'major'};
+                 'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 
+                 'categories': 13, 'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
     var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
                  'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
                  'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
@@ -240,15 +241,17 @@ function updateMatCreditCount() {
     var specExtra = $('#specextra')[0].getElementsByTagName('input');
     var majExtra = $('#majextra')[0].getElementsByTagName('input');
 
-    for (var k = 0; k < 4; k++) {
+    for (var k = specialist.extraTypedNextBox; k < 4; k++) {
         if (specExtra[k].value.indexOf('MAT') > -1 || specExtra[k].value.indexOf('STA') > -1 ||
-            specExtra[k].value.indexOf('CSC49') > -1) {
+            specExtra[k].value.indexOf('CSC49') > -1 || specExtra[k].value.indexOf('BCB') > -1) {
             specialist.creditCount += 0.5;
+            specialist.extraTypedNextBox = k + 1;
             specialist.filledTextboxesExtra += 1;
         }
         if (k < 3 && (majExtra[k].value.indexOf('MAT') > -1 || majExtra[k].value.indexOf('STA') > -1 ||
-            majExtra[k].value.indexOf('CSC49') > -1)) {
+            majExtra[k].value.indexOf('CSC49') > -1 || specExtra[k].value.indexOf('BCB') > -1)) {
             major.creditCount += 0.5;
+            major.extraTypedNextBox = k + 1;
             major.filledTextboxesExtra += 1;
         }
     }

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -71,7 +71,7 @@ function resetValues() {
     major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
              'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
              'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
-             'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
+             'MAT135136137157Calc1'], 'index200': 0, 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
              'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
     minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
              'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
@@ -245,6 +245,19 @@ function notSpecialistCourse(course) {
 
     return specialistCourses.indexOf(course) === -1;
 }
+
+
+/**
+ * Returns whether course is a required course for the Major or not
+ * @param {string} Name of course
+ * @return {boolean} True if course is a required for major, False otherwise
+ */
+function notMajReqCourse(course) {
+    'use strict';
+
+    return majReqs.indexOf(course) === -1;
+}
+
 
 /**
  * Updates Credit Count for typed BCB Courses

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -62,20 +62,20 @@ function resetValues() {
     'use strict';
 
     activeCourses = [];
-    var specialist = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
-                      'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
-                      'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
-                      'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
-                      'CSC373'], 'textboxes300': 3, 'textboxes400': 3,'textboxesExtra': 4, 'categories': 17, 
-                      'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
-    var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
-                 'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
-                 'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
-                 'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
-                 'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
-    var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
-                 'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
-                 'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
+    specialist = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
+                  'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
+                  'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
+                  'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
+                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3,'textboxesExtra': 4, 'categories': 17, 
+                  'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
+    major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
+             'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
+             'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
+             'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
+             'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
+    minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
+             'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
+             'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
 }
 
 

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -47,7 +47,7 @@ function updateAllCategories() {
     update300Categories();
     update400Categories();
     updateExtraCategories();
-    updateMatCreditCount();
+    updateTypedCreditCount();
 
     fillCreditCount();
     checkPostCompleted();
@@ -235,7 +235,7 @@ function updateActiveCourses() {
 /**
  * Updates Credit count for MAT and STA courses.
  */
-function updateMatCreditCount() {
+function updateTypedCreditCount() {
     'use strict';
 
     var specExtra = $('#specextra')[0].getElementsByTagName('input');

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -12,7 +12,7 @@ var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledText
              'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 'creditCount': 0, 'name': 'major'};
 var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
              'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
-             'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263253'], 'name': 'minor'};
+             'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
 
 
 /**
@@ -74,7 +74,7 @@ function resetValues() {
                  'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 'creditCount': 0, 'name': 'major'};
     var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
                  'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
-                 'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263253'], 'name': 'minor'};
+                 'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
 }
 
 
@@ -247,7 +247,7 @@ function updateMatCreditCount() {
             specialist.filledTextboxesExtra += 1;
         }
         if (k < 3 && (majExtra[k].value.indexOf('MAT') > -1 || majExtra[k].value.indexOf('STA') > -1 ||
-            majExtra[k].value.indexOf('STA') > -1)) {
+            majExtra[k].value.indexOf('CSC49') > -1)) {
             major.creditCount += 0.5;
             major.filledTextboxesExtra += 1;
         }

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -241,11 +241,13 @@ function updateMatCreditCount() {
     var majExtra = $('#majextra')[0].getElementsByTagName('input');
 
     for (var k = 0; k < 4; k++) {
-        if (specExtra[k].value.indexOf('MAT') > -1 || specExtra[k].value.indexOf('STA') > -1) {
+        if (specExtra[k].value.indexOf('MAT') > -1 || specExtra[k].value.indexOf('STA') > -1 ||
+            specExtra[k].value.indexOf('CSC49') > -1) {
             specialist.creditCount += 0.5;
             specialist.filledTextboxesExtra += 1;
         }
-        if (k < 3 && (majExtra[k].value.indexOf('MAT') > -1 || majExtra[k].value.indexOf('STA') > -1)) {
+        if (k < 3 && (majExtra[k].value.indexOf('MAT') > -1 || majExtra[k].value.indexOf('STA') > -1 ||
+            majExtra[k].value.indexOf('STA') > -1)) {
             major.creditCount += 0.5;
             major.filledTextboxesExtra += 1;
         }

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -63,16 +63,16 @@ function resetValues() {
 
     activeCourses = [];
     var specialist = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
-                  'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
-                  'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
-                  'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
-                  'CSC373'], 'textboxes300': 3, 'textboxes400': 3, 'textboxesExtra': 4, 'categories': 17, 
-                  'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
+                      'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'specCount': 0,
+                      'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC209', 'CSC236240', 'CSC258', 
+                      'CSC263265', 'STA247255257Sta1', 'MAT221223240Lin1', 'MAT135136137157Calc1', 'CSC369', 
+                      'CSC373'], 'textboxes300': 3, 'textboxes400': 3,'textboxesExtra': 4, 'categories': 17, 
+                      'creditCount': 0, 'name': 'specialist', 'extraTypedNextBox': 0};
     var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxes300': 0,
                  'filledTextboxes400': 0, 'filledTextboxesExtra': 0, 'majCount': 0, 'reqs': ['CSC108',
                  'CSC148', 'CSC165240', 'CSC207', 'CSC236240', 'CSC258', 'CSC263265', 'STA247255257Sta1', 
-                 'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 
-                 'categories': 13, 'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
+                 'MAT135136137157Calc1'], 'textboxes300': 2, 'textboxes400': 1, 'textboxesExtra': 3, 'categories': 13, 
+                 'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
     var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
                  'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
                  'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
@@ -267,3 +267,23 @@ function notSpecialistCourse(course) {
 
     return specialistCourses.indexOf(course) === -1;
 }
+
+/**
+ * Updates Credit Count for typed BCB Courses
+ * @param {object} post Object corresponding to the POSt being dealt with.
+ * @param {HTMLElement[]} postElement Array of textboxes to fill.
+ * @param {string} level Level of category we are dealing with (300 or 400 level)
+ */
+function updateBCBCount(post, postElement, level) {
+
+    for (var i = 0; i < postElement.length; i++) {
+        var value =  postElement[i].value;
+
+        if (value.indexOf('BCB') > -1) { // A BCB course was typed
+            post['filledTextboxes' + level] += 1;
+            post.creditCount += (value.charAt(6) === 'Y') ? 1 : 0.5;
+            // postElement[post.filledTextboxes300].disabled = true;
+        }
+    }
+}
+

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -12,7 +12,7 @@ var major = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledText
              'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
 var minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
              'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
-             'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
+             'creditCount': 0, 'index200' : 0, 'name': 'minor'};
 
 
 /**
@@ -75,7 +75,7 @@ function resetValues() {
              'creditCount': 0, 'name': 'major', 'extraTypedNextBox': 0};
     minor = {'index300': 0, 'index400': 0, 'categoriesCompleted': 0, 'filledTextboxesExtra': 0,
              'reqs': ['CSC108', 'CSC148', 'CSC165240', 'CSC207', 'CSC236240'], 'textboxesExtra': 3, 'categories': 6,
-             'creditCount': 0, 'additionalMin200': ['CSC209', 'CSC258', 'CSC263265'], 'name': 'minor'};
+             'creditCount': 0, 'index200': 0, 'name': 'minor'};
 }
 
 
@@ -169,28 +169,6 @@ function fillMinCreditCount() {
         $('#min_creds').html('(4.0/4.0)');
     } else {
         $('#min_creds').html('(' + minor.creditCount.toFixed(1) + '/4.0)');
-    }
-}
-
-
-/**
- * Autofills extra 200-level courses for last minor constraint.
- */
-function addExtraMinCourses() {
-    'use strict';
-
-    var minExtra = $('#minextra')[0].getElementsByTagName('input');
-    var current = minor.filledTextboxesExtra;
-
-    for (var m = 0; m < 3 && current < 3; m++) {
-        if (getCookie(minor.additionalMin200[m].toLowerCase()) === 'active' ||
-            getCookie(minor.additionalMin200[m].toLowerCase()) === 'overridden') {
-            minExtra[current].value = minor.additionalMin200[m];
-            minExtra[current].disabled = true;
-            minor.creditCount += 0.5;
-            minor.filledTextboxesExtra += 1;
-            current += 1;
-        }
     }
 }
 

--- a/public/js/post/update_post.js
+++ b/public/js/post/update_post.js
@@ -222,12 +222,14 @@ function updateTypedCreditCount() {
     for (var k = specialist.extraTypedNextBox; k < 4; k++) {
         if (specExtra[k].value.indexOf('MAT') > -1 || specExtra[k].value.indexOf('STA') > -1 ||
             specExtra[k].value.indexOf('CSC49') > -1 || specExtra[k].value.indexOf('BCB') > -1) {
+            specExtra[k].disabled = true;
             specialist.creditCount += 0.5;
             specialist.extraTypedNextBox = k + 1;
             specialist.filledTextboxesExtra += 1;
         }
         if (k < 3 && (majExtra[k].value.indexOf('MAT') > -1 || majExtra[k].value.indexOf('STA') > -1 ||
             majExtra[k].value.indexOf('CSC49') > -1 || specExtra[k].value.indexOf('BCB') > -1)) {
+            majExtra[k].disabled = true;
             major.creditCount += 0.5;
             major.extraTypedNextBox = k + 1;
             major.filledTextboxesExtra += 1;
@@ -273,7 +275,7 @@ function updateBCBCount(post, postElement, level) {
         if (value.indexOf('BCB') > -1) { // A BCB course was typed
             post['filledTextboxes' + level] += 1;
             post.creditCount += (value.charAt(6) === 'Y') ? 1 : 0.5;
-            // postElement[post.filledTextboxes300].disabled = true;
+            postElement[i].disabled = true;
         }
     }
 }


### PR DESCRIPTION
This fixes Issue #566 and #580, as well as making other bug fixes and additions such as:

* You can now type in BCB courses in each of the categories
* Editable text boxes become disabled after you type in them and press 'Update POST'
* Some edits to the actual POSt information using info from Degree Explorer. I specifically took out ECE489H from the first 300+ level category because it is included in the second one (the Extra category), and degree explorer groups them together differently anyways, so how it is now ends up being exactly the same. It just made the autofilling for ECE courses cleaner

Please feel free to test it out and let me know if you find a bug somewhere. I've tried testing it extensively but I could have missed a use case.

The code could probably use some cleaning up, but since this will be moved over soon to React, maybe that can wait.