### PR TITLE
Fixes issue 518: region movement

### DIFF
--- a/public/js/draw/draw.js
+++ b/public/js/draw/draw.js
@@ -276,7 +276,7 @@ function moveNodeElbow(e) {
             prevY = position.y;
         } else if (regionMoving !== null) {
             // move each elbow
-            position = getClickPosition(e, elbowMoving);
+            position = getClickPosition(e, regionMoving);
             regionMoving.elbows.map(function (elbow) {
                 moveElbow(elbow, position);
             });


### PR DESCRIPTION
Simple fix for the incorrect offset applied when moving a region (#518)  in draw.js. 