### PR TITLE
Allow specifying stats department graph with a URL parameter.

### DIFF
--- a/public/js/common/utilities/util.js
+++ b/public/js/common/utilities/util.js
@@ -27,6 +27,15 @@ function removeFromArray(item, array) {
     return index;
 }
 
+/* URL Utilities */
+/**
+ * Gets the value of a parameter in the query string by name.
+ * @param name The name of the parameter to retrieve.
+ * @returns {string|null} The value of the parameter as a string, or null if it does not exist.
+ */
+function getURLParameter(name) {
+    return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null
+}
 
 /* These specifically manipulate the two global arrays,
 courseObjects and selectedSections. */

--- a/public/js/graph/setup.js
+++ b/public/js/graph/setup.js
@@ -21,7 +21,18 @@ var nodes = [];               // List of all nodes
 $(document).ready(function () {
     'use strict';
 
-    var active = getCookie('active-graph');
+    var urlSpecifiedGraph = getURLParameter('dept');
+
+    // HACK: Temporary workaround for giving the statistics department a link to our graph.
+    // Should be replaced with a more general solution.
+    var active;
+    if (urlSpecifiedGraph === 'sta') {
+        active = '2';
+    } else if (urlSpecifiedGraph !== null) {
+        active = '1';
+    } else {
+        active = getCookie('active-graph');
+    }
 
     if (active !== '') {
         loadGraph(active);


### PR DESCRIPTION
Usage: Navigate to `/graph?dept=sta` to go to the stats department graph.