### PR TITLE
Fixed non-exhaustive pattern match warnings

### DIFF
--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -228,3 +228,4 @@ convertTimeToString :: [Double] -> [T.Text]
 convertTimeToString [day, time] =
   [T.pack . show . floor $ day,
    T.replace "." "-" . T.pack . show $ time]
+convertTimeToString [_, _] = error "Pattern matching convertTimeToString"

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -228,4 +228,4 @@ convertTimeToString :: [Double] -> [T.Text]
 convertTimeToString [day, time] =
   [T.pack . show . floor $ day,
    T.replace "." "-" . T.pack . show $ time]
-convertTimeToString [_, _] = error "Pattern matching convertTimeToString"
+convertTimeToString _ = error "Pattern matching convertTimeToString"

--- a/hs/Diagram.hs
+++ b/hs/Diagram.hs
@@ -45,6 +45,7 @@ makeTimeCell s =
 makeRow :: [String] -> Diagram B
 makeRow (x:xs) = (# centerX) . hcat $
     makeTimeCell x : vrule 0.8 # lw thin : map makeCell xs
+makeRow [] = error "Pattern matching makeRow []"
 
 rowBorder :: Diagram B
 rowBorder = hrule 12 # lw thin # lc grey

--- a/hs/Svg/Builder.hs
+++ b/hs/Svg/Builder.hs
@@ -67,6 +67,8 @@ buildRect texts entity idCounter =
         id_ = case shapeType_ entity of
               Hybrid -> "h" ++ show idCounter
               Node -> map toLower $ sanitize textString
+              BoolNode -> error "Pattern matching buildRect BoolNode"
+              Region -> error "Pattern matching buildRect Region"
     in
         entity {shapeId_ = id_,
                 shapeText = rectTexts,

--- a/hs/Svg/Generator.hs
+++ b/hs/Svg/Generator.hs
@@ -169,6 +169,8 @@ rectToSVG styled courseMap rect
             class_ = case shapeType_ rect of
                          Node -> "node"
                          Hybrid -> "hybrid"
+                         BoolNode -> error "Pattern matching rectToSVG BoolNode"
+                         Region -> error "Pattern matching rectToSVG Region"
         in S.g ! A.id_ (stringValue $ toId $ shapeId_ rect)
                ! A.class_ (stringValue class_)
                ! S.customAttribute "data-group" (stringValue

--- a/hs/Svg/Parser.hs
+++ b/hs/Svg/Parser.hs
@@ -286,6 +286,7 @@ updateShape fill transform r =
                               Hybrid   -> Hybrid
                               BoolNode -> BoolNode
                               Node     -> Node
+                              Region   -> error "Pattern matching updateShape Region"
       }
 
 updateText :: Point -- ^ Transform that will be added to the input Shape's

--- a/hs/WebParsing/ArtSciParser.hs
+++ b/hs/WebParsing/ArtSciParser.hs
@@ -68,7 +68,9 @@ parseTitleFAS (tag:tags, course) =
     let (n, t) = T.splitAt 8 $ removeTitleGarbage $ removeLectureSection tag
     in (tags, course {title = Just t, name =  n})
     where removeLectureSection (TagText s) = T.takeWhile (/= '[') s
+          removeLectureSection _ = error "Pattern matching parseTitleFAS removeLectureSection"
           removeTitleGarbage s = replaceAll ["\160"] "" s
+parseTitleFAS ([], _) = error "Pattern matching parseTitleFAS ([], _)"
 
 -- |takes a list of tags representing a single course, and returns a course Record
 processCourseToData :: [Tag T.Text] ->  Course

--- a/hs/WebParsing/ParsingHelp.hs
+++ b/hs/WebParsing/ParsingHelp.hs
@@ -65,6 +65,7 @@ OUTPUT: True if reg can match tagtext
 tagContains :: [T.Text] -> Tag T.Text -> Bool
 tagContains matches (TagText tagtext) =
   True == foldl (\bool match -> or [(T.isInfixOf match tagtext), bool]) False matches
+tagContains _ _ = error "Pattern matching tagContains"
 
 
 --converts all open and closing tags to lowercase.
@@ -165,7 +166,9 @@ preProcess tags =
   in map cleanText removeEnrol
   where
     cleanText (TagText s) = TagText (replaceAll ["\r\n                    ", "\n                    ","\160","\194","\r\n"] "" s)
+    cleanText _ = error "Pattern matching preProcess cleanText"
     isntUseless (TagText s) = not $ T.all (\c -> or [(c == ' '), (c =='\n')]) s
+    isntUseless _ = error "Pattern matching preProcess isntUseless"
 
 parseDescription :: CoursePart -> CoursePart
 parseDescription (tags, course) =

--- a/hs/WebParsing/PrerequisiteParsing.hs
+++ b/hs/WebParsing/PrerequisiteParsing.hs
@@ -45,6 +45,7 @@ toPreExprs str expr  =
                             then toPreExprs after (expr ++ before)
                             else (expr++before):(toPreExprs after "")
     (before, ";", after) -> (expr++before):(toPreExprs after "")
+    (_, _, _) -> error "Pattern matching toPreExprs case"
 
 -- | attempts to match a course in given string. returns (before, course, after)
 -- if no match occurs (input, "", "")

--- a/hs/WebParsing/TimeTableParser.hs
+++ b/hs/WebParsing/TimeTableParser.hs
@@ -47,6 +47,7 @@ getDeptList tags =
     isHref [("href", _)] = True
     isHref _ = False
     getAttribute (TagOpen _ [(_, link)]) = link
+    getAttribute _ = error "Pattern matching getDeptList getAttribute"
 
 -- | if a row contains "NOTE" we add 3 empty 'cells' to the beginning
 --used to deal with corner case found in "csc.html"


### PR DESCRIPTION
Fixes non-exhaustive pattern match warnings for #613 by making all the unnecessary patterns return an error. Not sure if this is bad practice, though.