### PR TITLE
CSS Overflow Fix

### DIFF
--- a/hs/Css/Timetable.hs
+++ b/hs/Css/Timetable.hs
@@ -11,8 +11,6 @@ import Css.Constants
  - Generates all CSS required for the timetable page. -}
 timetableStyles :: Css
 timetableStyles = do
-    body ? do
-        overflowX hidden
     ".main" ? do -- TODO: change to id, and pick better name
         height (pct 84)
         margin0


### PR DESCRIPTION
There was an issue where, if the graph was bigger than your screen, the right part of the graph that didn't fit was cut off. This fixes that.