### PR TITLE
Improve image exporting

### DIFF
--- a/hs/Css/Constants.hs
+++ b/hs/Css/Constants.hs
@@ -185,3 +185,18 @@ beige1 = parse "#EBE8E4"
 {- FCE count color. Currently unused. -}
 fceCountColor :: Color
 fceCountColor = parse "#66C2FF"
+
+{- Graph styles -}
+
+-- Node font size, in pixels
+nodeFontSize :: Num a => a
+nodeFontSize = 12
+
+hybridFontSize :: Num a => a
+hybridFontSize = 7
+
+boolFontSize :: Num a => a
+boolFontSize = 6
+
+regionFontSize :: Num a => a
+regionFontSize = 14

--- a/hs/Css/Graph.hs
+++ b/hs/Css/Graph.hs
@@ -33,7 +33,7 @@ nodeCSS = "g" ? do
     ".node" & do
         cursor pointer
         "text" ? do
-            fontSize (pt 12)
+            fontSize (pt nodeFontSize)
             faded
             stroke "none"
             "text-anchor" -: "middle"
@@ -90,7 +90,7 @@ nodeCSS = "g" ? do
         "text" <? do
             stroke "none"
             fill "white"
-            fontSize (pt 7)
+            fontSize (pt hybridFontSize)
             "text-anchor" -: "middle"
         "rect" <? do
             fill "#888888"
@@ -126,7 +126,7 @@ nodeCSS = "g" ? do
             fontFamily ["Trebuchet MS", "Arial"] [sansSerif]
             fontWeight bold
             stroke "none"
-            fontSize (pt 6)
+            fontSize (pt boolFontSize)
             "text-anchor" -: "middle"
 
 {- pathCSS
@@ -348,6 +348,6 @@ regionCSS :: Css
 regionCSS = do
     "#region-labels > text" ? do
         "text-anchor" -: "start"
-        fontSize (pt 14)
+        fontSize (pt regionFontSize)
     ".region" ? do
         "fill-opacity" -: "0.25"

--- a/hs/Diagram.hs
+++ b/hs/Diagram.hs
@@ -95,9 +95,13 @@ renderTable filename courses session = do
     let courseTable = partition5 $ splitOn "_" courses
     print courseTable
     let g = makeTable (zipWith (:) times courseTable) session
-    let svg = renderDia SVG (SVGOptions (mkWidth 600) Nothing "") g
-    let txt = replace (show fs ++ "em") (show fs ++ "px") $ unpack $ renderText svg
+    let svg = renderDia SVG (SVGOptions (mkWidth 1024) Nothing "") g
+    let txt = replace (show (fs :: Double) ++ "px") (show fs' ++ "px") $
+              unpack $ renderText svg
     writeFile filename txt
     where
         partition5 [] = []
         partition5 lst = take 5 lst : partition5 (drop 5 lst)
+
+        -- relative fonts don't play well with ImageMagick, apparently
+        fs' = round $ 1024 / 600 * fs

--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -38,7 +38,9 @@ header page =
             H.li $ makeA "" "" "draw" "" "Draw"
             H.li $ makeA "" "" "post" "" "Check My POSt!"
             H.li $ makeA "" "" "about" "" "About"
-            H.li $ H.a ! A.id "nav-export" $ "Export"
+            if page `elem` ["graph", "grid"]
+            then H.li $ H.a ! A.id "nav-export" $ "Export"
+            else ""
         if page `elem` ["graph", "grid"]
         then
             H.div ! A.id "nav-fb" $ do

--- a/hs/MasterTemplate.hs
+++ b/hs/MasterTemplate.hs
@@ -38,6 +38,7 @@ header page =
             H.li $ makeA "" "" "draw" "" "Draw"
             H.li $ makeA "" "" "post" "" "Check My POSt!"
             H.li $ makeA "" "" "about" "" "About"
+            H.li $ H.a ! A.id "nav-export" $ "Export"
         if page `elem` ["graph", "grid"]
         then
             H.div ! A.id "nav-fb" $ do

--- a/hs/Scripts.hs
+++ b/hs/Scripts.hs
@@ -34,7 +34,8 @@ plannerScripts = concatHtml (map makeScript["https://ajax.googleapis.com/ajax/li
                                            "static/js/post/update_post.js",
                                            "static/js/graph/sidebar/sidebar_divs.js",
                                            "static/js/graph/sidebar/sidebar_events.js",
-                                           "static/js/graph/sidebar/focus_descriptions.js"])
+                                           "static/js/graph/sidebar/focus_descriptions.js",
+                                           "static/js/common/export/export.js"])
 
 timetableScripts :: H.Html
 timetableScripts = do jQuery
@@ -55,10 +56,11 @@ timetableScripts = do jQuery
                                                 "/static/js/common/image_conversion.js",
                                                 "/static/js/draw/draw.js",
                                                 "static/js/common/modal.js",
-                                                "static/js/common/course_description.js"])
+                                                "static/js/common/course_description.js",
+                                                "static/js/common/export/export.js"])
 
 drawScripts :: H.Html
-drawScripts = do jQuery 
+drawScripts = do jQuery
                  concatHtml (map makeScript ["https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js",
                                              "static/js/draw/variables.js",
                                              "static/js/draw/path.js",

--- a/hs/Svg/Generator.hs
+++ b/hs/Svg/Generator.hs
@@ -16,6 +16,7 @@ import Svg.Builder
 import Database.Tables
 import Database.DataType
 import Control.Monad.IO.Class (liftIO)
+import Data.Monoid (mappend)
 import Database.Persist.Sqlite
 import Data.List hiding (map, filter)
 import MakeElements
@@ -228,6 +229,8 @@ textToSVG styled type_ xPos' text =
                       then xPos
                       else xPos')
             ! A.y (stringValue $ show yPos)
+            ! A.fontFamily "'Trebuchet MS', 'Arial', sans-serif"
+            ! A.stroke "none"
             ! A.style (stringValue $ align ++ fontStyle ++ fill)
             $ toMarkup $ textText text
     where
@@ -243,17 +246,17 @@ textToSVG styled type_ xPos' text =
         getTextStyle Hybrid    = hybridTextStyle
         getTextStyle BoolNode  = ellipseTextStyle
         getTextStyle Region    = regionTextStyle
-        getTextStyle _         = ""
+        getTextStyle _         = nodeTextStyle
 
         -- TODO: Possibly move this closer to the CSS
-        hybridTextStyle = "font-size:7.5pt;fill:white;"
-        ellipseTextStyle = "font-size:7.5pt;"
-        regionTextStyle = "font-size:9pt;"
+        hybridTextStyle = "font-size:7pt;fill:white;"
+        ellipseTextStyle = "font-size:6pt;"
+        regionTextStyle = "font-size:14pt;"
+        nodeTextStyle = "font-size:12pt;"
 
         fontStyle = if styled
                     then
-                        getTextStyle type_ ++
-                        "font-family:sans-serif;stroke:none;"
+                        getTextStyle type_
                     else
                         ""
 
@@ -270,7 +273,9 @@ edgeToSVG styled path =
                                                           $ pathTarget path)
            ! if styled
              then
-                 A.style (stringValue $ "fill:" ++
+                 mappend
+                     (A.strokeWidth "2px") $
+                     A.style (stringValue $ "fill:" ++
                           pathFill path ++
                           ";fill-opacity:1;")
              else

--- a/public/js/common/export/export.js
+++ b/public/js/common/export/export.js
@@ -1,0 +1,35 @@
+$(document).ready(function () {
+  $('#nav-export').click(function () {
+    openModal('Export', createExportModalDiv());
+  });
+});
+
+/**
+ * Creates and returns the Facebook modal content div.
+ * @returns {jQuery} The Facebook modal content div.
+ */
+function createExportModalDiv() {
+    'use strict';
+
+    var context = $('#courseography-header').attr('context');
+    var session = 'fall';
+    var img = (context === 'graph') ? getGraphImage() : getGridImage(session);
+    var contentDiv = $('<div></div>');
+    var topContentDiv = $('<div></div>');
+    contentDiv.attr('id', 'modal-content-container');
+    topContentDiv.html('<img id="post-image" src="data:image/png;base64,' + img + '" />');
+    contentDiv.append(topContentDiv);
+    contentDiv.attr('id', 'modal-content-container');
+
+    if (context === 'grid') {
+        var sessionButton = $('<button type="button" class="btn btn-primary">Switch Sessions</button>');
+        sessionButton.click(function () {
+            session = session === 'fall' ? 'spring' : 'fall';
+            img = getGridImage(session);
+            $('#post-image').attr('src', 'data:image/png;base64,' + img);
+        });
+        contentDiv.append(sessionButton);
+    }
+
+    return contentDiv;
+}


### PR DESCRIPTION
Two main changes:

1. There is now an Export link, which on the Graph and Grid pages will create a modal and produce a image. This is based on @Ian-Stewart-Binks's work on the Facebook modal; eventually they should be merged.
2. Improve the quality of images generated for both the graph and the grid. There are still discrepancies between the generated images and the appearance of the application itself, but the images look fairly good now.

Note: Blaze attributes (and hence blaze SVG attributes) form a [Monoid](https://hackage.haskell.org/package/base-4.7.0.1/docs/Data-Monoid.html#t:Monoid), something I had forgotten. We can make much better use of this fact to improve the code.