### PR TITLE
Tests using HUnit (not working) and QuickCheck.

### DIFF
--- a/hs/SvgTests/BuilderTests.hs
+++ b/hs/SvgTests/BuilderTests.hs
@@ -1,3 +1,10 @@
-module BuilderTests where
+module SvgTests.BuilderTests where
 
 import Svg.Builder
+import Test.QuickCheck
+
+prop1_sanitizeId str =
+    let sanitized = sanitizeId str
+        illegals  = map (\c -> not $ elem c ",()/<>% ") sanitized
+        allTrue = and illegals
+    in  allTrue

--- a/hs/SvgTests/BuilderTests.hs
+++ b/hs/SvgTests/BuilderTests.hs
@@ -1,0 +1,3 @@
+module BuilderTests where
+
+import Svg.Builder

--- a/hs/SvgTests/ParserTests.hs
+++ b/hs/SvgTests/ParserTests.hs
@@ -1,0 +1,25 @@
+module SvgTests.ParserTests where
+
+import Svg.Parser
+import Test.HUnit
+
+{- So far, this module serves as an example of the style of testing
+   HUnit is capable of executing. -}
+
+-- |Test points.
+testPts = [(i,j) | i <- [0..10], j <- [0..10]]
+
+-- |Test block for addTuples.
+test_addTuples = test ["addTuples test 1" ~: "addTuples (0,0) (0,0)"
+                                          ~: (0,0)
+                                          ~=? addTuples (0,0) (0,0),
+                       "addTuples test 2" ~: "addTuples (1,1), (1,1)"
+                                          ~: (2,2)
+                                          ~=? addTuples (1,1) (1,1),
+                       "addTuples test 3" ~: "addTuples (testPts !! 0) (10,10)"
+                                          ~: (10,10)
+                                          ~=? addTuples (testPts !! 0) (10,10),
+                       "addTuples test 4" ~: "addTuples (-10,-10) (testPts !! 10)"
+                                          ~: (-10, 0)
+                                          ~=? addTuples (-10,-10) (testPts !! 10)]
+


### PR DESCRIPTION
Do not merge. Pushing so @david-yz-liu can comment on which testing module (i.e. HUnit V. QuickCheck) is more suited to our needs. Could possibly be both. Note that QuickCheck in particular is effective for testing function invariants, while HUnit is good at, well, unit testing.