### PR TITLE
PDF Exporting WIP

### DIFF
--- a/hs/ImageConversion.hs
+++ b/hs/ImageConversion.hs
@@ -1,8 +1,28 @@
 module ImageConversion
-    (createImageFile, removeImage) where
+    (createImageFile, removeImage, compileTexToPdf) where
 
 import System.Process
 import GHC.IO.Handle.Types
+
+-- | Compiles a TeX file to a PDF file.
+compileTexToPdf :: String -> IO
+                      (Maybe Handle,
+                       Maybe Handle,
+                       Maybe Handle,
+                       ProcessHandle)
+
+compileTexToPdf inName = createProcess $ CreateProcess
+                                   (ShellCommand $ "pdflatex " ++
+                                                   inName
+                                   )
+                                   Nothing
+                                   Nothing
+                                   CreatePipe
+                                   CreatePipe
+                                   CreatePipe
+                                   False
+                                   False
+                                   False
 
 -- | Converts an SVG file to a PNG file. Note that image magik's 'convert' command
 -- can take in file descriptors.

--- a/hs/Latex.hs
+++ b/hs/Latex.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Latex where
+
+import Text.LaTeX
+import Text.LaTeX.Packages.Graphicx
+
+fitImageToPage =
+    [IGWidth $ Pt 300.0,
+     IGHeight $ Pt 300.0,
+     KeepAspectRatio True,
+     IGScale 1.0,
+     IGAngle 0,
+     IGTrim (Pt 0) (Pt 0) (Pt 0) (Pt 0),
+     IGClip False,
+     IGPage 1]
+
+compileTex texName imageFilename = execLaTeXT (mainTex imageFilename) >>= renderFile texName 
+
+mainTex imageFilename = do
+    preamble
+    body imageFilename
+
+preamble = do
+    documentclass [] article
+    usepackage [] graphicx
+
+body imageFilename = do
+    addImage imageFilename
+
+addImage imageFilename =
+    includegraphics fitImageToPage imageFilename
+
+
+
+

--- a/hs/Latex.hs
+++ b/hs/Latex.hs
@@ -30,7 +30,3 @@ body imageFilename = do
 
 addImage imageFilename =
     includegraphics fitImageToPage imageFilename
-
-
-
-

--- a/hs/Response.hs
+++ b/hs/Response.hs
@@ -19,7 +19,9 @@ module Response
         -- | @/privacy@
         module Response.Privacy,
         -- | @/timesearch@
-        module Response.Search
+        module Response.Search,
+        -- | @/export@
+        module Response.Export
     )
     where
 
@@ -33,3 +35,4 @@ import Response.NotFound
 import Response.Post
 import Response.Privacy
 import Response.Search
+import Response.Export

--- a/hs/Response/Export.hs
+++ b/hs/Response/Export.hs
@@ -8,6 +8,8 @@ import qualified Data.ByteString.Lazy as BS
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Base64.Lazy as BEnc
 import ImageConversion
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
 import Svg.Generator
 import TimetableImageCreator (renderTable)
 import qualified Data.Map as M
@@ -15,6 +17,14 @@ import System.Random
 import Database.Tables (GraphId)
 import Database.Persist.Sql (toSqlKey)
 import Data.Int(Int64)
+=======
+import TimetableImageCreator (renderTable)
+import System.Random
+>>>>>>> Stashed changes
+=======
+import TimetableImageCreator (renderTable)
+import System.Random
+>>>>>>> Stashed changes
 import Latex
 
 -- | Returns a PDF containing the image of the timetable
@@ -38,12 +48,27 @@ returnPdfData :: String -> String -> String -> String -> IO Response
 returnPdfData svgFilename imageFilename pdfFilename texFilename = do
     createImageFile svgFilename imageFilename
     compileTex texFilename imageFilename
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
     compileTexToPdf texFilename
     pdfData <- BS.readFile texFilename
     removeImage svgFilename
     removeImage imageFilename
     removeImage pdfFilename
     removeImage texFilename
+=======
+=======
+>>>>>>> Stashed changes
+    _ <- compileTexToPdf texFilename
+    pdfData <- BS.readFile texFilename
+    _ <- removeImage svgFilename
+    _ <- removeImage imageFilename
+    _ <- removeImage pdfFilename
+    _ <- removeImage texFilename
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
     let encodedData = BEnc.encode pdfData
     return $ toResponse encodedData
  

--- a/hs/Response/Export.hs
+++ b/hs/Response/Export.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Response.Export 
+    (pdfResponse) where
+
+import Happstack.Server
+import qualified Data.ByteString.Lazy as BS
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString.Base64.Lazy as BEnc
+import ImageConversion
+import Svg.Generator
+import TimetableImageCreator (renderTable)
+import qualified Data.Map as M
+import System.Random
+import Database.Tables (GraphId)
+import Database.Persist.Sql (toSqlKey)
+import Data.Int(Int64)
+import Latex
+
+-- | Returns a PDF containing the image of the timetable
+-- requested by the user.
+pdfResponse :: String -> String -> ServerPart Response
+pdfResponse courses session =
+    liftIO $ getPdf courses session
+
+getPdf :: String -> String -> IO Response
+getPdf courses session = do
+    gen <- newStdGen
+    let (rand, _) = next gen
+        svgFilename = (show rand ++ ".svg")
+        imageFilename = (show rand ++ ".png")
+        texFilename = (show rand ++ ".tex")
+        pdfFilename = (drop 4 texFilename) ++ ".pdf"
+    renderTable svgFilename courses session
+    returnPdfData svgFilename imageFilename pdfFilename texFilename
+
+returnPdfData :: String -> String -> String -> String -> IO Response
+returnPdfData svgFilename imageFilename pdfFilename texFilename = do
+    createImageFile svgFilename imageFilename
+    compileTex texFilename imageFilename
+    compileTexToPdf texFilename
+    pdfData <- BS.readFile texFilename
+    removeImage svgFilename
+    removeImage imageFilename
+    removeImage pdfFilename
+    removeImage texFilename
+    let encodedData = BEnc.encode pdfData
+    return $ toResponse encodedData
+ 
+

--- a/hs/Response/Export.hs
+++ b/hs/Response/Export.hs
@@ -8,23 +8,8 @@ import qualified Data.ByteString.Lazy as BS
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Base64.Lazy as BEnc
 import ImageConversion
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-import Svg.Generator
-import TimetableImageCreator (renderTable)
-import qualified Data.Map as M
-import System.Random
-import Database.Tables (GraphId)
-import Database.Persist.Sql (toSqlKey)
-import Data.Int(Int64)
-=======
 import TimetableImageCreator (renderTable)
 import System.Random
->>>>>>> Stashed changes
-=======
-import TimetableImageCreator (renderTable)
-import System.Random
->>>>>>> Stashed changes
 import Latex
 
 -- | Returns a PDF containing the image of the timetable
@@ -48,27 +33,12 @@ returnPdfData :: String -> String -> String -> String -> IO Response
 returnPdfData svgFilename imageFilename pdfFilename texFilename = do
     createImageFile svgFilename imageFilename
     compileTex texFilename imageFilename
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-    compileTexToPdf texFilename
-    pdfData <- BS.readFile texFilename
-    removeImage svgFilename
-    removeImage imageFilename
-    removeImage pdfFilename
-    removeImage texFilename
-=======
-=======
->>>>>>> Stashed changes
     _ <- compileTexToPdf texFilename
     pdfData <- BS.readFile texFilename
     _ <- removeImage svgFilename
     _ <- removeImage imageFilename
     _ <- removeImage pdfFilename
     _ <- removeImage texFilename
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
     let encodedData = BEnc.encode pdfData
     return $ toResponse encodedData
  

--- a/hs/Server.hs
+++ b/hs/Server.hs
@@ -42,6 +42,7 @@ runServer = do
               dir "graph" graphResponse,
               dir "image" graphImageResponse,
               dir "timetable-image" $ look "courses" >>= \x -> look "session" >>= timetableImageResponse x,
+              dir "pdf" $ look "courses" >>= \x -> look "session" >>= pdfResponse x,
               dir "graph-fb" $ seeOther redirectUrlGraphEmail $ toResponse "",
               dir "post-fb" $ seeOther redirectUrlGraphPost $ toResponse "",
               dir "test" $ look "code" >>= getEmail,

--- a/hs/courseography.cabal
+++ b/hs/courseography.cabal
@@ -58,6 +58,7 @@ executable courseography
     http-client,
     network,
     HTTP,
+    HaTeX,
     tagsoup,
     regex-posix,
     mtl,

--- a/public/js/common/export/export.js
+++ b/public/js/common/export/export.js
@@ -18,7 +18,7 @@ function createExportModalDiv() {
     var contentDiv = $('<div></div>');
     var topContentDiv = $('<div></div>');
     var calendarOption = $('<a href="calendar">Download ICS</a>');
-    var gridOption = $('<a href="export-grid">Export to PDF</a><br>');
+    var gridOption = $('<a href="pdf">Export to PDF</a><br>');
     calendarOption.attr('target', '_blank');
     calendarOption.attr('style', 'display:block');
     gridOption.attr('style', 'display:block');

--- a/public/js/common/export/export.js
+++ b/public/js/common/export/export.js
@@ -17,11 +17,16 @@ function createExportModalDiv() {
     var img = (context === 'graph') ? getGraphImage() : getGridImage(session);
     var contentDiv = $('<div></div>');
     var topContentDiv = $('<div></div>');
-    var calendarOption = $('<a href="calendar">Download ICS</a>')
+    var calendarOption = $('<a href="calendar">Download ICS</a>');
+    var gridOption = $('<a href="export-grid">Export to PDF</a><br>');
     calendarOption.attr('target', '_blank');
+    calendarOption.attr('style', 'display:block');
+    gridOption.attr('style', 'display:block');
+    gridOption.attr('target', '_blank');
     topContentDiv.html('<img id="post-image" src="data:image/png;base64,' + img + '" />');
     contentDiv.attr('id', 'modal-content-container')
               .append(calendarOption)
+              .append(gridOption)
               .append(topContentDiv);
 
     if (context === 'grid') {


### PR DESCRIPTION
@david-yz-liu : .tex files are generated with timetable images in them. They are then compiled into .pdf, where the only remaining step is to serve them to the client. This is not the best way to do this. It would be easier and cleaner to store timetable info in cookies. The modal is yet to be tabbed for selection between graph/grid exporting. and Facebook exporting