### PR TITLE
fix-video-url: restore a missing function

### DIFF
--- a/public/js/common/course_videos.js
+++ b/public/js/common/course_videos.js
@@ -1,4 +1,21 @@
 /**
+ * Gets the video URLs of the courses associated with names.
+ * @param names The list of names of a particular course.
+ * @returns {Array} The video URLs associated with the course.
+ */
+function getCourseVideoUrls(names) {
+    'use strict';
+
+    var courseVideoUrls = [];
+
+    $.each(names, function (i, name) {
+        var course = getCourse(name);
+        courseVideoUrls = courseVideoUrls.concat(course.videoUrls);
+    });
+    return courseVideoUrls;
+}
+
+/**
  * Enables VideoJS.
  * Note: Must be called after the video player is set up.
  */


### PR DESCRIPTION
Took it out accidentally in a previous merge.