### PR TITLE
react-graph-json: add non text attributes to React components

### DIFF
--- a/hs/Database/CourseQueries.hs
+++ b/hs/Database/CourseQueries.hs
@@ -17,7 +17,7 @@ module Database.CourseQueries
      deptList,
      returnTutorial,
      returnLecture,
-     getJSONs) where
+     getGraphJSON) where
 
 import Happstack.Server.SimpleHTTP
 import Database.Persist
@@ -31,8 +31,8 @@ import Data.String.Utils
 import Data.List
 import Config (databasePath)
 import Control.Monad (liftM)
-import Data.Aeson
-import Data.Int(Int64)
+import Data.Aeson ((.=))
+import Data.Int (Int64)
 
 -- ** Querying a single course
 
@@ -123,17 +123,17 @@ buildSession lecs tuts =
                           (map entityVal tuts)
 
 -- ** Other queries
--- | Gets Shape, Text and Path elements and returns as JSONs
-getJSONs :: Int64 -> IO(Response)
-getJSONs gId = do
+-- | Gets Shape, Text and Path elements for rendering graph returned as JSON
+getGraphJSON :: Int64 -> IO (Response)
+getGraphJSON gId =
     runSqlite databasePath $ do
         sqlText    :: [Entity Text] <- selectList [TextGraph ==. toSqlKey gId] []
         sqlShape   :: [Entity Shape] <- selectList [ShapeGraph ==. toSqlKey gId] []
         sqlPath    :: [Entity Path] <- selectList [PathGraph ==. toSqlKey gId] []
         let sqlTextWithoutKey = map entityVal sqlText
-        let sqlShapeWithoutKey = map entityVal sqlShape
-        let sqlPathWithoutKey = map entityVal sqlPath
-        let result = createJSONResponse ["texts" .= sqlTextWithoutKey, "shapes" .= sqlShapeWithoutKey, "paths" .= sqlPathWithoutKey]
+            sqlShapeWithoutKey = map entityVal sqlShape
+            sqlPathWithoutKey = map entityVal sqlPath
+            result = createJSONResponse ["texts" .= sqlTextWithoutKey, "shapes" .= sqlShapeWithoutKey, "paths" .= sqlPathWithoutKey]
         return result
 
 -- | Builds a list of all course codes in the database.

--- a/hs/Database/CourseQueries.hs
+++ b/hs/Database/CourseQueries.hs
@@ -127,14 +127,13 @@ buildSession lecs tuts =
 getJSONs :: Int64 -> IO(Response)
 getJSONs gId = do
     runSqlite databasePath $ do
-        sqlShape    :: [Entity Shape] <- selectList [ShapeGraph ==. toSqlKey gId] []
         sqlText    :: [Entity Text] <- selectList [TextGraph ==. toSqlKey gId] []
+        sqlShape   :: [Entity Shape] <- selectList [ShapeGraph ==. toSqlKey gId] []
         sqlPath    :: [Entity Path] <- selectList [PathGraph ==. toSqlKey gId] []
-        
+        let sqlTextWithoutKey = map entityVal sqlText
         let sqlShapeWithoutKey = map entityVal sqlShape
         let sqlPathWithoutKey = map entityVal sqlPath
-        let sqlTextWithoutKey = map entityVal sqlText
-        let result = createJSONResponse ["shapes" .= sqlShapeWithoutKey, "paths" .= sqlPathWithoutKey, "texts" .= sqlTextWithoutKey]
+        let result = createJSONResponse ["texts" .= sqlTextWithoutKey, "shapes" .= sqlShapeWithoutKey, "paths" .= sqlPathWithoutKey]
         return result
 
 -- | Builds a list of all course codes in the database.

--- a/hs/Database/DataType.hs
+++ b/hs/Database/DataType.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, DeriveGeneric #-}
 
 {-|
 This is a small module that contains a single enumeration type.
@@ -8,7 +8,13 @@ a restriction on Template Haskell.
 module Database.DataType where
 
 import Database.Persist.TH
+import GHC.Generics
+import Data.Aeson
 
 data ShapeType = BoolNode | Node | Hybrid | Region
- deriving (Show, Read, Eq)
+ deriving (Show, Read, Eq, Generic)
 derivePersistField "ShapeType"
+
+instance ToJSON ShapeType
+
+instance FromJSON ShapeType

--- a/hs/Database/DataType.hs
+++ b/hs/Database/DataType.hs
@@ -16,5 +16,4 @@ data ShapeType = BoolNode | Node | Hybrid | Region
 derivePersistField "ShapeType"
 
 instance ToJSON ShapeType
-
 instance FromJSON ShapeType

--- a/hs/Database/Tables.hs
+++ b/hs/Database/Tables.hs
@@ -93,7 +93,7 @@ Graph json
     title String
     deriving Show
 
-Text
+Text json
     graph GraphId
     rId String
     pos Point
@@ -102,7 +102,7 @@ Text
     fill String
     deriving Show
 
-Shape
+Shape json
     graph GraphId
     id_ String
     pos Point
@@ -114,7 +114,7 @@ Shape
     tolerance Double
     type_ ShapeType
 
-Path
+Path json
     graph GraphId
     id_ String
     points [Point]

--- a/hs/Server.hs
+++ b/hs/Server.hs
@@ -12,7 +12,7 @@ import Control.Monad (msum)
 import Control.Monad.IO.Class (liftIO)
 import Happstack.Server hiding (host)
 import Response
-import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseInfo, deptList)
+import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseInfo, deptList, getJSONs)
 import Filesystem.Path.CurrentOS as Path
 import System.Directory (getCurrentDirectory)
 import System.IO (hSetBuffering, stdout, stderr, BufferMode(LineBuffering))
@@ -58,6 +58,7 @@ runServer = do
               dir "depts" $ liftIO deptList,
               dir "timesearch" searchResponse,
               dir "calendar" $ lookCookieValue "selected-lectures" >>= calendarResponse,
+              dir "graph-json" $liftIO (getJSONs 1),
               notFoundResponse
         ]
     where

--- a/hs/Server.hs
+++ b/hs/Server.hs
@@ -12,7 +12,7 @@ import Control.Monad (msum)
 import Control.Monad.IO.Class (liftIO)
 import Happstack.Server hiding (host)
 import Response
-import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseInfo, deptList, getJSONs)
+import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseInfo, deptList, getGraphJSON)
 import Filesystem.Path.CurrentOS as Path
 import System.Directory (getCurrentDirectory)
 import System.IO (hSetBuffering, stdout, stderr, BufferMode(LineBuffering))
@@ -58,7 +58,7 @@ runServer = do
               dir "depts" $ liftIO deptList,
               dir "timesearch" searchResponse,
               dir "calendar" $ lookCookieValue "selected-lectures" >>= calendarResponse,
-              dir "graph-json" $liftIO (getJSONs 1),
+              dir "graph-json" $ liftIO (getGraphJSON 1),
               notFoundResponse
         ]
     where

--- a/public/js/graph/react_node.js.jsx
+++ b/public/js/graph/react_node.js.jsx
@@ -48,6 +48,7 @@ var ReactSVG = React.createClass({
                     }
                 });
                 //data[2] is ["paths", [JSON]]
+                //data[2][1] are the JSON without "paths"
                 data[2][1].forEach(function (entry) {
                     if (entry['isRegion']){
                         regionsList.push(entry);
@@ -89,6 +90,7 @@ var ReactSVG = React.createClass({
         markerNode.setAttribute('markerWidth', 7);
         markerNode.setAttribute('markerHeight', 7);
         markerNode.setAttribute('viewBox', '0 0 10 10');
+        
     },
 
     nodeClick: function (event) {
@@ -158,23 +160,23 @@ var ReactRegionLabels = React.createClass({
     render: function () {
         return (
             <g id='region-labels'>
-            {this.props.labelsJSON.map(function (entry, value) {
-                var textAttrs = {};
-                textAttrs['x'] = entry.pos[0];
-                textAttrs['y'] = entry.pos[1];
+                {this.props.labelsJSON.map(function (entry, value) {
+                    var textAttrs = {};
+                    textAttrs['x'] = entry.pos[0];
+                    textAttrs['y'] = entry.pos[1];
 
-                var textStyle = {
-                    fill : entry['fill']
-                }
+                    var textStyle = {
+                        fill : entry['fill']
+                    }
 
-                return <text
-                        {... textAttrs}
-                        key={value}
-                        style={textStyle}
-                        textAnchor={entry['text-anchor']}>
-                            {entry['text']}
-                        </text>
-            })}
+                    return <text
+                            {... textAttrs}
+                            key={value}
+                            style={textStyle}
+                            textAnchor={entry['text-anchor']}>
+                                {entry['text']}
+                           </text>
+                })}
             </g>
         );
     }


### PR DESCRIPTION
This PR is only to show @david-yz-liu that I have retrieved information from the database into JSONs and from those JSONs, create and render the react-graph and placed the non-text attributes.
This currently removes the functionality of the graph, as the text and id's and `ref`'s have not been set, meaning that `parents`, `childs`, `outEdges`, `inEdges` so that needs to be done later.