### PR TITLE
reset-graph: clear graphs tables before running 'graphs' command

### DIFF
--- a/hs/Svg/Database.hs
+++ b/hs/Svg/Database.hs
@@ -8,7 +8,7 @@ here as well at some point in the future.
 -}
 
 module Svg.Database
-    (insertGraph, insertElements) where
+    (insertGraph, insertElements, deleteGraphs) where
 
 import Database.Persist.Sqlite
 import Database.Tables
@@ -29,3 +29,11 @@ insertElements (paths, shapes, texts) =
         mapM_ insert_ shapes
         mapM_ insert_ paths
         mapM_ insert_ texts
+
+-- | Delete graphs from the database.
+deleteGraphs :: IO ()
+deleteGraphs = runSqlite databasePath $ do
+    deleteWhere ([] :: [Filter Graph])
+    deleteWhere ([] :: [Filter Text])
+    deleteWhere ([] :: [Filter Shape])
+    deleteWhere ([] :: [Filter Path])

--- a/hs/Svg/Parser.hs
+++ b/hs/Svg/Parser.hs
@@ -29,7 +29,7 @@ import Text.XML.HaXml.Namespaces (printableName)
 import System.Directory
 import Database.Tables
 import Database.DataType
-import Svg.Database
+import Svg.Database (insertGraph, insertElements, deleteGraphs)
 import Svg.Generator
 import Database.Persist.Sqlite hiding (replace)
 import Config (graphPath)
@@ -37,6 +37,7 @@ import Text.Read (readMaybe)
 
 parsePrebuiltSvgs :: IO ()
 parsePrebuiltSvgs = do
+    deleteGraphs
     performParse "Computer Science" "csc2015.svg"
     performParse "Statistics" "sta2015.svg"
     performParse "Biochemistry" "bch2015.svg"


### PR DESCRIPTION
Now when you run `courseography graphs` the graph tables will reset, so there won't be any duplicates.