### PR TITLE
React Graph Modal Fix

### DIFF
--- a/app/Scripts.hs
+++ b/app/Scripts.hs
@@ -59,7 +59,6 @@ graphScripts = do
          "/static/js/common/image_conversion.js",
          "/static/js/common/graph_image.js",
          "/static/js/common/export/export.js"])
-    H.script ! A.type_ "text/babel" ! A.src "/static/js/common/react_modal.js.jsx" $ ""
     H.script ! A.src "/static/js/requirejs-config.js" $ ""
     H.script ! H.dataAttribute "main" "/static/js/graph" ! A.src "/static/js/vendor/require.js" $ ""
 

--- a/public/js/common/react_modal.js
+++ b/public/js/common/react_modal.js
@@ -1,16 +1,4 @@
-function openReactModal(courseCode) {
-    'use strict';
-    var courseName = getCourseTitle(courseCode);
-    var formattedName = formatCourseName(courseCode);
-    var courseVideoUrls = getCourseVideoUrls(formattedName);
-
-    React.render(
-        <ModalContent course={formattedName[0]} />,
-        document.getElementById('modal-content-container')
-    );
-}
-
-var ModalContent = React.createClass({
+export var ModalContent = React.createClass({
     render: function() {
         return (
             <div>
@@ -90,9 +78,3 @@ var Video = React.createClass({
         );
     }
 });
-
-
-// Ugly way of getting openReactModal exported globally. Apparently
-// running this file through Babel hides the names. Eventually use
-// modules to remove this.
-window.openReactModal = openReactModal;

--- a/public/js/graph/tooltip.js
+++ b/public/js/graph/tooltip.js
@@ -1,4 +1,20 @@
+import {ModalContent} from 'es6!common/react_modal';
+
 var timeouts = [];            // All timeouts. Used to remove timeouts later on.
+
+
+function openReactModal(courseCode) {
+    'use strict';
+    var courseName = getCourseTitle(courseCode);
+    var formattedName = formatCourseName(courseCode);
+    var courseVideoUrls = getCourseVideoUrls(formattedName);
+
+    React.render(
+        <ModalContent course={formattedName[0]} />,
+        document.getElementById('modal-content-container')
+    );
+}
+
 
 /**
  * Displays a tooltip for a Node.


### PR DESCRIPTION
This PR fixes the short cut used to get the modals on the graph page to work using React, and now works within the require module system.