### PR TITLE
Post Schema Initial Setup

### DIFF
--- a/app/Database/PostInsertion.hs
+++ b/app/Database/PostInsertion.hs
@@ -19,7 +19,6 @@ import Data.Aeson
 insertPost :: T.Text -> T.Text -> T.Text -> IO ()
 insertPost departmentName postName postCode =
     runSqlite databasePath $ do
-        runMigration migrateAll
         insert_ $ Post postName departmentName postCode
 
 -- | Insert a new post category into the database

--- a/app/Database/PostInsertion.hs
+++ b/app/Database/PostInsertion.hs
@@ -5,15 +5,9 @@ module Database.PostInsertion(
     insertPost, insertPostCategory) where
 
 import qualified Data.Text as T
-import qualified Data.ByteString.Lazy.Char8 as BSL
-import Happstack.Server.SimpleHTTP
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Reader (ReaderT)
-import Data.Maybe (fromMaybe)
 import Config (databasePath)
-import Database.Persist.Sqlite (selectFirst, fromSqlKey, toSqlKey, insertMany_, insert_, insert, SqlBackend, (=.), (==.), updateWhere, runSqlite, runMigration)
+import Database.Persist.Sqlite (insert_, runSqlite, runMigration)
 import Database.Tables
-import Data.Aeson
 
 -- | Insert a new post into the database
 insertPost :: T.Text -> T.Text -> T.Text -> IO ()

--- a/app/Database/PostInsertion.hs
+++ b/app/Database/PostInsertion.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE FlexibleContexts, GADTs, MultiParamTypeClasses,
+    OverloadedStrings, TypeFamilies #-}
+
+module Database.PostInsertion(
+    insertPost, insertPostCategory) where
+
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Happstack.Server.SimpleHTTP
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Reader (ReaderT)
+import Data.Maybe (fromMaybe)
+import Config (databasePath)
+import Database.Persist.Sqlite (selectFirst, fromSqlKey, toSqlKey, insertMany_, insert_, insert, SqlBackend, (=.), (==.), updateWhere, runSqlite, runMigration)
+import Database.Tables
+import Data.Aeson
+
+-- | Insert a new post into the database
+insertPost :: T.Text -> T.Text -> T.Text -> IO ()
+insertPost departmentName postName postCode =
+    runSqlite databasePath $ do
+        runMigration migrateAll
+        insert_ $ Post postName departmentName postCode
+
+-- | Insert a new post category into the database
+insertPostCategory :: T.Text -> T.Text -> IO ()
+insertPostCategory postCategoryName postName =
+    runSqlite databasePath $ do
+        runMigration migrateAll
+        insert_ $ PostCategory postCategoryName postName
+

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -137,6 +137,17 @@ FacebookTest
     fId String
     testString String
     deriving Show
+
+Post
+    name T.Text
+    department T.Text
+    code T.Text
+    deriving Show
+
+PostCategory
+    name T.Text
+    post T.Text
+    deriving Show
 |]
 
 -- ** TODO: Remove these extra types and class instances

--- a/app/WebParsing/ParseAll.hs
+++ b/app/WebParsing/ParseAll.hs
@@ -3,9 +3,11 @@ module WebParsing.ParseAll
 
 import WebParsing.ArtSciParser
 import WebParsing.TimeTableParser
+import WebParsing.PostParser
 
 parseAll :: IO ()
 parseAll = do
     parseArtSci
     --parseUTSC
     parseTT
+    parsePosts

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module WebParsing.PostParser
+    (parsePosts) where
+
+import Network.HTTP
+import Text.HTML.TagSoup
+import Text.HTML.TagSoup.Match
+import Database.Persist.Sqlite
+import Database.PostInsertion(insertPost, insertPostCategory)
+import Data.List
+import qualified Data.Text as T
+import Database.Tables
+import WebParsing.ParsingHelp
+import Config (databasePath)
+
+parsePosts :: IO ()
+parsePosts = do
+    putStrLn "Parsing Posts..."
+    insertPost "Computer Science" "Major" "AJSM24"
+    insertPostCategory "CSC148" "Computer Science"

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -2,16 +2,7 @@
 module WebParsing.PostParser
     (parsePosts) where
 
-import Network.HTTP
-import Text.HTML.TagSoup
-import Text.HTML.TagSoup.Match
-import Database.Persist.Sqlite
 import Database.PostInsertion(insertPost, insertPostCategory)
-import Data.List
-import qualified Data.Text as T
-import Database.Tables
-import WebParsing.ParsingHelp
-import Config (databasePath)
 
 parsePosts :: IO ()
 parsePosts = do

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -32,6 +32,7 @@ executable courseography
     Database.CourseInsertion,
     Database.CourseQueries,
     Database.CourseVideoSeed,
+    Database.PostInsertion,
     Database.DataType,
     Database.Database,
     Database.Tables,
@@ -65,7 +66,8 @@ executable courseography
     WebParsing.ParsingHelp,
     WebParsing.PrerequisiteParsing,
     WebParsing.TimeConverter,
-    WebParsing.TimeTableParser
+    WebParsing.TimeTableParser,
+    WebParsing.PostParser
   other-extensions:
     OverloadedStrings,
     DataKinds,


### PR DESCRIPTION
Set up initial basic tables for Posts and Post Categories. Also set up initial parsing overhead to work when running `stack exec courseography database`. At the current moment, all it does is run two function calls, one that inserts a new post and one that inserts a new post category. Tested it by commenting out all function calls in `parseAll` except for `parsePosts` (since the rest of the parsing is currently broken with the new timetable format), and ran the above stack command, and can confirm it properly creates the new tables and adds the new values.