### PR TITLE
issue-814: send graph width and height with graph info

### DIFF
--- a/app/Css/Common.hs
+++ b/app/Css/Common.hs
@@ -22,6 +22,7 @@ common = do
         do margin0
            padding0
            width100
+           height100
            minHeight $ pct 100
            fontSize $ pt 17
            fontFamily ["Trebuchet MS", "Arial"] [sansSerif]
@@ -60,7 +61,7 @@ headerCSS = do
                 padding 0 (px 10) 0 (px 10)
                 a <? do
                     color white
-                    "text-shadow" -: "0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000;" 
+                    "text-shadow" -: "0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000, 0 0 2px #000;"
                     hover & do
                         color darkgray
             height (px 50)
@@ -92,7 +93,7 @@ headerCSS = do
         paddingBottom (px 3)
     "#nav-export" ? do
         cursor pointer
-        
+
 {- aDefaultCSS
  - Generates default CSS. -}
 aDefaultCSS :: Css

--- a/app/Css/Graph.hs
+++ b/app/Css/Graph.hs
@@ -205,15 +205,14 @@ resetCSS = "#resetButton" ? do
 graphContainer :: Css
 graphContainer = do
     "#react-graph" ? do
-        width (px 1210)
-        minHeight (px 700)
-        height (px 700)
-        overflow hidden
-        margin (px 10) (px 10) (px 10) (px 10)
+        "width" -: "calc(100% - 40px)"
+        height100
+        overflow scroll
+        margin0
         display inlineBlock
         position absolute
         textAlign $ alignSide sideCenter
-        "left" -: "40px"
+        left (px 40)
     "#react-graphRootSVG" ? do
         width100
         height100
@@ -253,13 +252,13 @@ sidebarCSS = do
             backgroundColor grey1
             fontColor white
     "#container" ? do
-        width (pct 100)
-        height (px 700)
+        "height" -: "calc(100% - 100px)"
+        width100
         position relative
     "#sidebar" ? do
         display inlineBlock
         width (px 40)
-        height (pct 100)
+        height100
         float floatLeft
         backgroundColor purple8
         position absolute

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -166,9 +166,12 @@ getGraphJSON graphName =
                                              intersectsWithShape (rects ++ ellipses))
                                             texts
 
-                    result = createJSONResponse ["texts" .= (texts ++ regionTexts),
-                                                 "shapes" .= (rects ++ ellipses),
-                                                 "paths" .= (paths ++ regions)]
+                    result = createJSONResponse [
+                        "texts" .= (texts ++ regionTexts),
+                        "shapes" .= (rects ++ ellipses),
+                        "paths" .= (paths ++ regions),
+                        "width" .= (graphWidth $ entityVal graph),
+                        "height" .= (graphHeight $ entityVal graph)]
 
                 return result
 

--- a/public/js/graph/react_graph.js
+++ b/public/js/graph/react_graph.js
@@ -109,7 +109,7 @@ function parseCourse(s, prefix) {
 function renderReactGraph() {
     'use strict';
     return ReactDOM.render(
-        <Graph width={1210} height={650}/>,
+        <Graph/>,
         document.getElementById('react-graph')
     );
 }
@@ -125,7 +125,9 @@ var Graph = React.createClass({
             boolsJSON: [],
             edgesJSON: [],
             highlightedNodes: [],
-            fceCount: 0
+            fceCount: 0,
+            width: 0,
+            height: 0,
         };
     },
 
@@ -194,7 +196,9 @@ var Graph = React.createClass({
                         nodesJSON: nodesList,
                         hybridsJSON: hybridsList,
                         boolsJSON: boolsList,
-                        edgesJSON: edgesList
+                        edgesJSON: edgesList,
+                        width: data[3][1],
+                        height: data[4][1]
                     });
                 }
             }.bind(this),
@@ -305,7 +309,7 @@ var Graph = React.createClass({
 
     render: function () {
         // not all of these properties are supported in React
-        var svgAttrs = {width: this.props.width, height: this.props.height};
+        var svgAttrs = {width: this.state.width, height: this.state.height};
 
         return (
             <svg {... svgAttrs} ref='svg' version='1.1'


### PR DESCRIPTION
I also played around with the CSS to allow the entire graph to be displayed. This is a nice change to make before updating CDF.

@bell-kelly you should take a look at the changes I made to the React component - the width and height will now be state, and it will use the correct values for each graph.