### PR TITLE
Fix graph json format

### DIFF
--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -31,7 +31,7 @@ import Data.String.Utils
 import Data.List
 import Config (databasePath)
 import Control.Monad (liftM)
-import Data.Aeson ((.=))
+import Data.Aeson ((.=), toJSON, object)
 import Data.Int (Int64)
 import Database.DataType
 import Svg.Builder
@@ -166,12 +166,14 @@ getGraphJSON graphName =
                                              intersectsWithShape (rects ++ ellipses))
                                             texts
 
-                    result = createJSONResponse [
-                        "texts" .= (texts ++ regionTexts),
-                        "shapes" .= (rects ++ ellipses),
-                        "paths" .= (paths ++ regions),
-                        "width" .= (graphWidth $ entityVal graph),
-                        "height" .= (graphHeight $ entityVal graph)]
+                    result = createJSONResponse $
+                        object [
+                            ("texts", toJSON $ texts ++ regionTexts),
+                            ("shapes", toJSON $ rects ++ ellipses),
+                            ("paths", toJSON $ paths ++ regions),
+                            ("width", toJSON $ graphWidth $ entityVal graph),
+                            ("height", toJSON $ graphHeight $ entityVal graph)
+                        ]
 
                 return result
 

--- a/public/js/graph/react_graph.js
+++ b/public/js/graph/react_graph.js
@@ -165,12 +165,11 @@ var Graph = React.createClass({
                 var boolsList = [];
                 var edgesList = [];
 
-                // data[0] is ["texts", [JSON]]
-                var labelsList =  data[0][1].filter(function (entry) {
+                var labelsList =  data.texts.filter(function (entry) {
                     return entry.rId.startsWith('tspan');
                 });
-                // data[1] is ["shapes", [JSON]]
-                data[1][1].forEach(function (entry) {
+
+                data.shapes.forEach(function (entry) {
                     if (entry.type_ === 'Node') {
                         nodesList.push(entry);
                     } else if (entry.type_ === 'Hybrid') {
@@ -179,9 +178,8 @@ var Graph = React.createClass({
                         boolsList.push(entry);
                     }
                 });
-                // data[2] is ["paths", [JSON]]
-                // data[2][1] are the JSON without "paths"
-                data[2][1].forEach(function (entry) {
+
+                data.paths.forEach(function (entry) {
                     if (entry.isRegion) {
                         regionsList.push(entry);
                     } else {
@@ -197,8 +195,8 @@ var Graph = React.createClass({
                         hybridsJSON: hybridsList,
                         boolsJSON: boolsList,
                         edgesJSON: edgesList,
-                        width: data[3][1],
-                        height: data[4][1]
+                        width: data.width,
+                        height: data.height
                     });
                 }
             }.bind(this),

--- a/public/js/graph/react_graph.js
+++ b/public/js/graph/react_graph.js
@@ -165,7 +165,7 @@ var Graph = React.createClass({
                 var boolsList = [];
                 var edgesList = [];
 
-                var labelsList =  data.texts.filter(function (entry) {
+                var labelsList = data.texts.filter(function (entry) {
                     return entry.rId.startsWith('tspan');
                 });
 


### PR DESCRIPTION
Rather than sending a list of lists `[["texts", [...]], ["shapes", [...]], ...]`, it now correctly sends something like `{texts: [...], shapes: [...], ...}`.