### PR TITLE
Post parsec parsing

### DIFF
--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -47,8 +47,7 @@ addPostToDatabase tags = do
     let postCode = T.pack (fromAttrib "name" ((take 1 $ filter (isTagOpenName "a") tags) !! 0))
         fullPostName = innerText (take 1 $ filter (isTagText) tags)
         postType = T.pack $ getPostType postCode
-        --departmentName = T.pack $ unwords $ reverse $ drop 3  $ reverse $ words $ fullPostName
-        departmentName = T.pack $ getDepartmentName fullPostName
+        departmentName = T.pack $ (getDepartmentName fullPostName postType)
     insertPost departmentName postType postCode
 
 getPostType :: T.Text -> String
@@ -60,12 +59,12 @@ getPostType postCode =
             "MAJ" -> "Major"
             "MIN" ->  "Minor"
 
-getDepartmentName :: [Char] -> [Char]
-getDepartmentName fullPostName = do
-    let parsed = P.parse isDepartmentName "(source)" fullPostName
+getDepartmentName :: [Char] -> T.Text -> [Char]
+getDepartmentName fullPostName postType = do
+    let parsed = P.parse (isDepartmentName (T.unpack postType)) "(source)" fullPostName
     case parsed of 
         Right name -> name
         Left _ -> ""
 
-isDepartmentName ::  P.Parsec String () String
-isDepartmentName = P.manyTill P.anyChar (P.try ((P.string "Specialist") <|> (P.string "Major") <|> (P.string "Minor")))
+isDepartmentName ::  [Char] -> P.Parsec String () String
+isDepartmentName postType = P.manyTill P.anyChar (P.try (P.string postType))

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -52,12 +52,24 @@ addPostToDatabase tags = do
 
 getPostType :: T.Text -> String
 getPostType postCode = 
-    let codeSection = T.unpack $ T.takeEnd 3 $ T.take 5 postCode
+    let codeSection = extractPostType (T.unpack postCode)
     in
         case codeSection of
             "SPE" -> "Specialist"
             "MAJ" -> "Major"
             "MIN" ->  "Minor"
+
+extractPostType :: [Char] -> [Char]
+extractPostType postCode = do
+    let parsed = P.parse findPostType "(source)" postCode
+    case parsed of 
+        Right name -> name
+        Left _ -> ""
+
+findPostType :: P.Parsec String () String
+findPostType = do
+   P.string "AS"
+   P.many1 P.letter
 
 getDepartmentName :: [Char] -> T.Text -> [Char]
 getDepartmentName fullPostName postType = do

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -122,7 +122,8 @@ executable courseography
     system-filepath,
     hslogger,
     old-locale,
-    time
+    time,
+    parsec
   default-language: Haskell2010
   ghc-options: -Wall -fwarn-tabs
   hs-source-dirs: app


### PR DESCRIPTION
This PR fixes the parsing of the department name and post type using the Parsec library. There are still a couple of entries in the database that are missing a department name after parsing that are due to mistakes/typos in UofT's html code, or very slight differences in the way a couple of post names are formatted which are hard to account for.