### PR TITLE
Removing duplicates from course insertion

### DIFF
--- a/app/Database/CourseInsertion.hs
+++ b/app/Database/CourseInsertion.hs
@@ -41,8 +41,10 @@ saveGraphJSON jsonStr nameStr = do
 
 -- | Inserts course into the Courses table.
 insertCourse :: MonadIO m => Course -> ReaderT SqlBackend m ()
-insertCourse course =
-    insert_ $ Courses (name course)
+insertCourse course = do 
+    maybeCourse <- selectFirst [CoursesCode ==. (name course)] []
+    case maybeCourse of
+        Nothing -> insert_ $ Courses (name course)
                       (title course)
                       (description course)
                       (manualTutorialEnrolment course)
@@ -54,6 +56,9 @@ insertCourse course =
                       (prereqString course)
                       (coreqs course)
                       []
+
+        Just _ -> return ()
+
 
 -- | Updates the manualTutorialEnrolment field of the given course.
 setTutorialEnrolment :: MonadIO m => T.Text -> Bool -> ReaderT SqlBackend m ()

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -51,6 +51,7 @@ Department json
 
 Courses json
     code T.Text
+    Primary code
     title T.Text Maybe
     description T.Text Maybe
     manualTutorialEnrolment Bool Maybe


### PR DESCRIPTION
Minor change to prevent duplicate Course entities from being inserted into the databse. Duplicates are assessed based on course code, now the primary key in Courses table (table.hs). 