### PR TITLE
GHC 8.0.2 update

### DIFF
--- a/app/Css/Constants.hs
+++ b/app/Css/Constants.hs
@@ -280,7 +280,7 @@ borderNone :: Css
 borderNone = border solid (px 0) white
 
 -- |Defines a border with a color of pink1, intended for the timetable.
-borderPink :: (Stroke -> Size Abs -> Color -> Css) -> Css
+borderPink :: (Stroke -> Size LengthUnit -> Color -> Css) -> Css
 borderPink borderStroke = borderStroke solid (px 2) pink1
 
 {- More node colours! -}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.14
+resolver: lts-8.13
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
In order to fix a GHC panic error for MacOS Sierra, this PR updates the GHC version we use from 8.0.1 to 8.0.2. This will require running `stack setup`, and many dependencies will be re-installed.