### PR TITLE
Hook Post Parsing back in

### DIFF
--- a/app/Database/DataType.hs
+++ b/app/Database/DataType.hs
@@ -31,7 +31,7 @@ instance ToJSON ShapeType
 -- .
 instance FromJSON ShapeType
 
-data PostType = Specialist | Major | Minor
+data PostType = Specialist | Major | Minor | Other
  deriving (Show, Read, Eq, Generic)
 derivePersistField "PostType"
 

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -139,8 +139,8 @@ Post
     name PostType
     department T.Text
     code T.Text
-    UniquePostode code
-    Primary code
+    --UniquePostCode code
+    --Primary code
     description T.Text
     deriving Show
 

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -21,6 +21,7 @@ import Database.CourseInsertion (insertCourse)
 import Database.Tables (Courses(..), Department(..))
 import WebParsing.ReqParser (parseReqs)
 import Config (databasePath)
+import WebParsing.PostParser (addPostToDatabase)
 
 
 -- | The URLs of the Faculty of Arts & Science calendar.
@@ -81,20 +82,10 @@ parseDepartment (relativeURL, _) = do
 parsePrograms :: [Tag T.Text] -> SqlPersistM ()
 parsePrograms programs = do
     let elems = TS.partitions isPost programs 
-    mapM_ parsePost elems
+    mapM_ addPostToDatabase elems
     return ()
     where
          isPost tag = tagOpenAttrNameLit "h3" "class" (T.isInfixOf "programs_view") tag
-
--- | Parse a particular post in a program section
-parsePost :: [Tag T.Text] -> SqlPersistM ()
-parsePost programElements = do
-    -- TODO: Remove Focuses from programElements
-    -- TODDO: Store name of post before we lose that information in the next line
-    let requirements = map TS.innerText $ TS.sections isRequirementSection programElements
-    liftIO (print requirements)
-    where
-        isRequirementSection element = tagOpenAttrLit "div" ("class", "field-content") element
 
 -- | Parse the section of the course calendar listing the courses offered by a department.
 parseCourses :: [Tag T.Text] -> [(Courses, T.Text, T.Text)]

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -42,7 +42,6 @@ parseArtSci = do
         mapM_ parseDepartment deptInfo
         --parseDepartment ("/section/Computer-Science","Computer Science")
 
-
 -- | Converts the processed main page and extracts a list of department html pages
 -- and department names
 getDeptList :: [Tag T.Text] -> [(T.Text, T.Text)]

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -81,15 +81,20 @@ parseDepartment (relativeURL, _) = do
 parsePrograms :: [Tag T.Text] -> SqlPersistM ()
 parsePrograms programs = do
     let elems = TS.partitions isPost programs 
-    mapM_ parseProgram elems
+    mapM_ parsePost elems
     return ()
     where
          isPost tag = tagOpenAttrNameLit "h3" "class" (T.isInfixOf "programs_view") tag
 
-parseProgram :: [Tag T.Text] -> SqlPersistM ()
-parseProgram program =
-    liftIO (print program)
-
+-- | Parse a particular post in a program section
+parsePost :: [Tag T.Text] -> SqlPersistM ()
+parsePost programElements = do
+    -- TODO: Remove Focuses from programElements
+    -- TODDO: Store name of post before we lose that information in the next line
+    let requirements = map TS.innerText $ TS.sections isRequirementSection programElements
+    liftIO (print requirements)
+    where
+        isRequirementSection element = tagOpenAttrLit "div" ("class", "field-content") element
 
 -- | Parse the section of the course calendar listing the courses offered by a department.
 parseCourses :: [Tag T.Text] -> [(Courses, T.Text, T.Text)]

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -38,8 +38,8 @@ parseArtSci = do
     runSqlite databasePath $ do
         liftIO $ putStrLn "Inserting departments"
         insertDepts $ map snd deptInfo
-        --mapM_ parseDepartment deptInfo
-        parseDepartment ("/section/Computer-Science","Computer Science")
+        mapM_ parseDepartment deptInfo
+        --parseDepartment ("/section/Computer-Science","Computer Science")
 
 
 -- | Converts the processed main page and extracts a list of department html pages

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -38,7 +38,8 @@ parseArtSci = do
     runSqlite databasePath $ do
         liftIO $ putStrLn "Inserting departments"
         insertDepts $ map snd deptInfo
-        mapM_ parseDepartment deptInfo
+        --mapM_ parseDepartment deptInfo
+        parseDepartment ("/section/Computer-Science","Computer Science")
 
 
 -- | Converts the processed main page and extracts a list of department html pages
@@ -78,9 +79,16 @@ parseDepartment (relativeURL, _) = do
 
 -- | Parse the section of the course calendar listing the programs offered by a department.
 parsePrograms :: [Tag T.Text] -> SqlPersistM ()
-parsePrograms _ = do
-    -- let elems = TS.partitions (TS.isTagOpenName "h3") _ -- TODO: complete this function
+parsePrograms programs = do
+    let elems = TS.partitions isPost programs 
+    mapM_ parseProgram elems
     return ()
+    where
+         isPost tag = tagOpenAttrNameLit "h3" "class" (T.isInfixOf "programs_view") tag
+
+parseProgram :: [Tag T.Text] -> SqlPersistM ()
+parseProgram program =
+    liftIO (print program)
 
 
 -- | Parse the section of the course calendar listing the courses offered by a department.

--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -40,7 +40,6 @@ parseArtSci = do
         liftIO $ putStrLn "Inserting departments"
         insertDepts $ map snd deptInfo
         mapM_ parseDepartment deptInfo
-        --parseDepartment ("/section/Computer-Science","Computer Science")
 
 -- | Converts the processed main page and extracts a list of department html pages
 -- and department names
@@ -82,7 +81,6 @@ parsePrograms :: [Tag T.Text] -> SqlPersistM ()
 parsePrograms programs = do
     let elems = TS.partitions isPost programs 
     mapM_ addPostToDatabase elems
-    return ()
     where
          isPost tag = tagOpenAttrNameLit "h3" "class" (T.isInfixOf "programs_view") tag
 

--- a/app/WebParsing/ParsecCombinators.hs
+++ b/app/WebParsing/ParsecCombinators.hs
@@ -44,7 +44,7 @@ postInfoParser fullPostName firstCourse = do
         Right (deptName, postType) -> do
             programDescription <- getRequirements firstCourse
             return $ Post (read $ T.unpack postType) deptName (T.pack " ") programDescription
-        Left _ -> return $ Post (read "Other") (T.pack " ") (T.pack " ") programDescription
+        Left _ -> return $ Post (read "Other") (T.pack " ") (T.pack " ") (T.pack " ")
 
 getDeptNameAndPostType :: Parser (T.Text, T.Text)
 getDeptNameAndPostType = do

--- a/app/WebParsing/ParsecCombinators.hs
+++ b/app/WebParsing/ParsecCombinators.hs
@@ -44,7 +44,7 @@ postInfoParser fullPostName firstCourse = do
         Right (deptName, postType) -> do
             programDescription <- getRequirements firstCourse
             return $ Post (read $ T.unpack postType) deptName (T.pack " ") programDescription
-        Left _ -> return $ Post (read "Specialist") (T.pack " ") (T.pack " ") programDescription
+        Left _ -> return $ Post (read "Other") (T.pack " ") (T.pack " ") programDescription
 
 getDeptNameAndPostType :: Parser (T.Text, T.Text)
 getDeptNameAndPostType = do

--- a/app/WebParsing/ParsecCombinators.hs
+++ b/app/WebParsing/ParsecCombinators.hs
@@ -15,6 +15,7 @@ import qualified Data.Text as T
 import Text.Parsec.Text (Parser)
 import Database.Tables (Post(Post))
 import Control.Monad (mapM)
+import Database.DataType
 
 getCourseFromTag :: T.Text -> T.Text
 getCourseFromTag courseTag =
@@ -44,7 +45,7 @@ postInfoParser fullPostName firstCourse = do
         Right (deptName, postType) -> do
             programDescription <- getRequirements firstCourse
             return $ Post (read $ T.unpack postType) deptName (T.pack " ") programDescription
-        Left _ -> return $ Post (read "Other") (T.pack " ") (T.pack " ") (T.pack " ")
+        Left _ -> return $ Post Other (fullPostName) (T.pack " ") (T.pack " ")
 
 getDeptNameAndPostType :: Parser (T.Text, T.Text)
 getDeptNameAndPostType = do

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -1,21 +1,16 @@
 module WebParsing.PostParser
     (addPostToDatabase) where
 
-import Network.HTTP
 import qualified Data.Text as T
 import Control.Monad.Trans (liftIO)
 import Text.HTML.TagSoup
 import Text.HTML.TagSoup.Match
-import Config (databasePath)
 import Database.Tables
-import Database.Persist.Sqlite (insert_, runMigration, runSqlite, SqlPersistM)
+import Database.Persist.Sqlite (insert_, SqlPersistM)
 import Database.Persist (insertUnique)
 import qualified Text.Parsec as P
 import WebParsing.ParsecCombinators (getCourseFromTag, generalCategoryParser, parseCategory,
     postInfoParser)
-
-fasCalendarURL :: String
-fasCalendarURL = "http://calendar.artsci.utoronto.ca/"
 
 failedString :: String
 failedString = "Failed."
@@ -60,7 +55,7 @@ categoryParser tags fullPostName firstCourse liPartitions = do
                 Just _ -> do
                     addPostCategoriesToDatabase categories
                 Nothing -> return ()
-        Left err -> do
+        Left _ -> do
             liftIO $ print failedString
             return ()
     where

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -1,5 +1,5 @@
 module WebParsing.PostParser
-    (getPost) where
+    (addPostToDatabase) where
 
 import Network.HTTP
 import qualified Data.Text as T
@@ -20,46 +20,59 @@ fasCalendarURL = "http://calendar.artsci.utoronto.ca/"
 failedString :: String
 failedString = "Failed."
 
-getPost :: T.Text -> IO ()
-getPost str = do
-    let path = fasCalendarURL ++ (T.unpack str)
-    rsp <- simpleHTTP (getRequest path)
-    body <- getResponseBody rsp
-    let tags = filter isNotComment $ parseTags body
-        postsSoup = secondH2 tags
-        posts = partitions isPostName postsSoup
-    runSqlite databasePath $ do
-        runMigration migrateAll
-        mapM_ addPostToDatabase posts
-    print $ "parsing " ++ (T.unpack str)
-    where
-        isNotComment (TagComment _) = False
-        isNotComment _ = True
-        secondH2 tags =
-            let sect = sections (isTagOpenName "h2") tags
-            in
-                if (length sect) < 2
-                then
-                    []
-                else
-                    takeWhile isNotCoursesSection tags
-        isNotCoursesSection tag = not (tagOpenAttrLit "a" ("name", "courses") tag)
-        isPostName tag = tagOpenAttrNameLit "a" "name" (\nameValue -> (length nameValue) == 9) tag
+--getPost :: T.Text -> IO ()
+--getPost str = do
+--    let path = fasCalendarURL ++ (T.unpack str)
+--    rsp <- simpleHTTP (getRequest path)
+--    body <- getResponseBody rsp
+--    let tags = filter isNotComment $ parseTags body
+--        postsSoup = secondH2 tags
+--        posts = partitions isPostName postsSoup
+--    runSqlite databasePath $ do
+--        runMigration migrateAll
+--        mapM_ addPostToDatabase posts
+--    print $ "parsing " ++ (T.unpack str)
+--    where
+--        isNotComment (TagComment _) = False
+--        isNotComment _ = True
+--        secondH2 tags =
+--            let sect = sections (isTagOpenName "h2") tags
+--            in
+--                if (length sect) < 2
+--                then
+--                    []
+--                else
+--                    takeWhile isNotCoursesSection tags
+--        isNotCoursesSection tag = not (tagOpenAttrLit "a" ("name", "courses") tag)
+--        isPostName tag = tagOpenAttrNameLit "a" "name" (\nameValue -> (length nameValue) == 9) tag
 
-addPostToDatabase :: [Tag String] -> SqlPersistM ()
-addPostToDatabase tags = do
-    let postCode_ = T.pack (fromAttrib "name" ((take 1 $ filter (isTagOpenName "a") tags) !! 0))
-        liPartitions = partitions isLiTag tags
-        programPrereqs = map getCourseFromTag $ map (T.pack . fromAttrib "href") $ filter isCourseTag tags
+addPostToDatabase :: [Tag T.Text] -> SqlPersistM ()
+addPostToDatabase programElements = do
+    --let postCode_ = T.pack (fromAttrib "name" ((take 1 $ filter (isTagOpenName "a") tags) !! 0))
+    --    liPartitions = partitions isLiTag tags
+    --    programPrereqs = map getCourseFromTag $ map (T.pack . fromAttrib "href") $ filter isCourseTag tags
+    --    firstCourse = if (null programPrereqs) then Nothing else (Just (head programPrereqs))
+    --categoryParser tags firstCourse postCode_ liPartitions
+    --where
+    --    isCourseTag tag = tagOpenAttrNameLit "a" "href" (\hrefValue -> (length hrefValue) >= 0) tag
+    --    isLiTag tag = isTagOpenName "li" tag
+
+    -- TODO: Remove Focuses from programElements
+    -- TODDO: Store name of post before we lose that information in the next line
+    let fullPostName = innerText $ take 1 $ filter isTagText programElements
+        requirements = last $ sections isRequirementSection programElements
+        liPartitions = partitions isLiTag requirements
+        programPrereqs = map getCourseFromTag $ map (fromAttrib "href") $ filter isCourseTag programElements
         firstCourse = if (null programPrereqs) then Nothing else (Just (head programPrereqs))
-    categoryParser tags firstCourse postCode_ liPartitions
+    categoryParser requirements fullPostName firstCourse liPartitions
     where
-        isCourseTag tag = tagOpenAttrNameLit "a" "href" (\hrefValue -> (length hrefValue) >= 0) tag
+        isRequirementSection element = tagOpenAttrLit "div" ("class", "field-content") element
+        isCourseTag tag = tagOpenAttrNameLit "a" "href" (\hrefValue -> T.isInfixOf "/course" hrefValue) tag
         isLiTag tag = isTagOpenName "li" tag
 
-addPostCategoriesToDatabase :: T.Text -> [T.Text] -> SqlPersistM ()
-addPostCategoriesToDatabase postCode_ categories = do
-    mapM_ (addCategoryToDatabase postCode_) (filter isCategory categories)
+addPostCategoriesToDatabase :: [T.Text] -> SqlPersistM ()
+addPostCategoriesToDatabase categories = do
+    mapM_ addCategoryToDatabase (filter isCategory categories)
     where
         isCategory text =
             let infixes = map (containsText text)
@@ -68,35 +81,38 @@ addPostCategoriesToDatabase postCode_ categories = do
                 ((T.length text) >= 7) && ((length $ filter (\bool -> bool) infixes) <= 0)
         containsText text subtext = T.isInfixOf subtext text
 
-addCategoryToDatabase :: T.Text -> T.Text -> SqlPersistM ()
-addCategoryToDatabase postCode_ category =
-    insert_ $ PostCategory category postCode_
+addCategoryToDatabase :: T.Text -> SqlPersistM ()
+addCategoryToDatabase category =
+    insert_ $ PostCategory category (T.pack "")
 
 
 -- Helpers
 
-categoryParser :: [Tag String] -> Maybe T.Text -> T.Text -> [[Tag String]] -> SqlPersistM ()
-categoryParser tags firstCourse postCode_ liPartitions = do
+categoryParser :: [Tag T.Text] -> T.Text -> Maybe T.Text -> [[Tag T.Text]] -> SqlPersistM ()
+categoryParser tags fullPostName firstCourse liPartitions = do
     case parsed of
         Right (post, categories) -> do
             postExist <- insertUnique post
             case postExist of
-                Just _ -> addPostCategoriesToDatabase postCode_ categories
+                Just _ -> do
+                    liftIO (print categories)
+                    addPostCategoriesToDatabase categories
                 Nothing -> return ()
-        Left _ -> do
-            liftIO $ print failedString
+        Left err -> do
+            --liftIO $ print failedString
+            liftIO $ print err
             return ()
     where
         parsed = case liPartitions of
-            [] -> P.parse (generalCategoryParser firstCourse postCode_) failedString (T.pack $ innerText tags)
+            [] -> P.parse (generalCategoryParser fullPostName firstCourse) failedString (innerText tags)
             partitionResults -> do
                 let categories = map parseLi partitionResults
-                post <- P.parse (postInfoParser firstCourse postCode_) failedString (T.pack $ innerText tags)
+                post <- P.parse (postInfoParser fullPostName firstCourse) failedString (innerText tags)
                 return (post, categories)
 
-parseLi :: [Tag String] -> T.Text
+parseLi :: [Tag T.Text] -> T.Text
 parseLi liPartition = do
-    let parsed = P.parse parseCategory failedString (T.pack $ innerText liPartition)
+    let parsed = P.parse parseCategory failedString (innerText liPartition)
     case parsed of
         Right category -> category
         Left _ -> ""

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -20,45 +20,9 @@ fasCalendarURL = "http://calendar.artsci.utoronto.ca/"
 failedString :: String
 failedString = "Failed."
 
---getPost :: T.Text -> IO ()
---getPost str = do
---    let path = fasCalendarURL ++ (T.unpack str)
---    rsp <- simpleHTTP (getRequest path)
---    body <- getResponseBody rsp
---    let tags = filter isNotComment $ parseTags body
---        postsSoup = secondH2 tags
---        posts = partitions isPostName postsSoup
---    runSqlite databasePath $ do
---        runMigration migrateAll
---        mapM_ addPostToDatabase posts
---    print $ "parsing " ++ (T.unpack str)
---    where
---        isNotComment (TagComment _) = False
---        isNotComment _ = True
---        secondH2 tags =
---            let sect = sections (isTagOpenName "h2") tags
---            in
---                if (length sect) < 2
---                then
---                    []
---                else
---                    takeWhile isNotCoursesSection tags
---        isNotCoursesSection tag = not (tagOpenAttrLit "a" ("name", "courses") tag)
---        isPostName tag = tagOpenAttrNameLit "a" "name" (\nameValue -> (length nameValue) == 9) tag
-
 addPostToDatabase :: [Tag T.Text] -> SqlPersistM ()
 addPostToDatabase programElements = do
-    --let postCode_ = T.pack (fromAttrib "name" ((take 1 $ filter (isTagOpenName "a") tags) !! 0))
-    --    liPartitions = partitions isLiTag tags
-    --    programPrereqs = map getCourseFromTag $ map (T.pack . fromAttrib "href") $ filter isCourseTag tags
-    --    firstCourse = if (null programPrereqs) then Nothing else (Just (head programPrereqs))
-    --categoryParser tags firstCourse postCode_ liPartitions
-    --where
-    --    isCourseTag tag = tagOpenAttrNameLit "a" "href" (\hrefValue -> (length hrefValue) >= 0) tag
-    --    isLiTag tag = isTagOpenName "li" tag
-
     -- TODO: Remove Focuses from programElements
-    -- TODDO: Store name of post before we lose that information in the next line
     let fullPostName = innerText $ take 1 $ filter isTagText programElements
         requirements = last $ sections isRequirementSection programElements
         liPartitions = partitions isLiTag requirements
@@ -85,7 +49,6 @@ addCategoryToDatabase :: T.Text -> SqlPersistM ()
 addCategoryToDatabase category =
     insert_ $ PostCategory category (T.pack "")
 
-
 -- Helpers
 
 categoryParser :: [Tag T.Text] -> T.Text -> Maybe T.Text -> [[Tag T.Text]] -> SqlPersistM ()
@@ -95,12 +58,10 @@ categoryParser tags fullPostName firstCourse liPartitions = do
             postExist <- insertUnique post
             case postExist of
                 Just _ -> do
-                    liftIO (print categories)
                     addPostCategoriesToDatabase categories
                 Nothing -> return ()
         Left err -> do
-            --liftIO $ print failedString
-            liftIO $ print err
+            liftIO $ print failedString
             return ()
     where
         parsed = case liPartitions of


### PR DESCRIPTION
This PR hooks the post parsing back in based on the new updated calendar.

A couple of notes
* There's a little hack for Post parsing failures and Focuses (since Focuses now follow the same structure and are at the same level as Posts, I need to remove those still), it gets inserted into the Post table with a Post Type of "Other" and everything else blank
* Since the unique post codes are no longer embedded within the HTML like they were before, I've left the Post Code column of the Post Category table blank. Only thing is we've lost the connections between the categories and what Post they belong to. We could use a Post ID instead to recreate that connection for now, but I haven't added that in yet.
* Need to fix the new warnings I introduced too.

Otherwise, the parsing now works properly again.