### PR TITLE
Merge Post Parsing and Reqs

### DIFF
--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -10,6 +10,7 @@ import Database.Tables
 import Database.Persist.Sqlite (insert_, SqlPersistM)
 import Database.Persist (insertUnique)
 import qualified Text.Parsec as P
+import WebParsing.ReqParser (parseReqs)
 import WebParsing.ParsecCombinators (getCourseFromTag, parseCategory,
     postInfoParser)
 
@@ -78,7 +79,8 @@ categoryParser tags requirements fullPostName firstCourse = do
 
 addPostCategoriesToDatabase :: PostId -> [T.Text] -> SqlPersistM ()
 addPostCategoriesToDatabase key categories = do
-    mapM_ (insert_ . PostCategory key) (filter isCategory categories)
+    let filtered = map (parseReqs . T.unpack) $ filter isCategory categories
+    mapM_ (insert_ . PostCategory key) (map (T.pack . show) filtered) 
     where
         isCategory text = T.length text >= 7
 


### PR DESCRIPTION
This pull request merges my post parsing with @RyanDJLee 's Req type. Now, in the PostCategory table, the string form of the parsed Req is stored instead of the unparsed string. 

Example of what the data in the PostCategory table now looks like:
![screen shot 2018-01-09 at 11 17 20 pm](https://user-images.githubusercontent.com/5077973/34755690-b68c0e28-f593-11e7-8ab9-15349721bc24.png)

Nothing seemed to faIl - anything that didn't match just got caught by the RAW parser.