### PR TITLE
react-grid: connect CoursePanel and Row (the Timetable) + save selected courses/lectures to local storage

### DIFF
--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -9,6 +9,7 @@ export class Row extends React.Component {
       c => Array.prototype.concat.apply([], Object.values(c.lectures))
     );
     lectures = Array.prototype.concat.apply([], lectures);
+    console.log(lectures);
 
     // Organize the structure of the <fallSession> and <springSession> 2-D dictionaries
     let fallSession, springSession;
@@ -403,89 +404,4 @@ function storeWidths(session) {
 */
 function lectureConflict(courseList) {
   return courseList.length > 1;
-}
-
-
-/**
- * Renders everything wrapped inside the "Row" component.
- * Contains mock data; for illustrative purposes only.
-*/
-function drawTimetable() {
-  // Sample Course objects, constructed with sample attributes
-
-  // Note: W: [8, 12, 14, 15] denotes that this course runs on Wed from 8 to 12, and again on Wed from 14 - 15
-  let lecture1 = createNewCourse("CSC100 (L)", "F", {'M': [8, 12], 'W': [8, 12, 14, 16], 'F': [8, 12]});
-  let lecture2 = createNewCourse("CSC101 (L)", "F", {'M': [8, 11]});
-  let lecture3 = createNewCourse("CSC102 (L)", "F", {'M': [10, 13]});
-  let lecture4 = createNewCourse("CSC103 (L)", "F", {'M': [13, 14]});
-  let lecture5 = createNewCourse("CSC104 (L)", "F", {'M': [13, 14]});
-  let lecture6 = createNewCourse("CSC105 (L)", "F", {'M': [13, 14]});
-  let lecture7 = createNewCourse("CSC106 (L)", "F", {'M': [13, 14]});
-  let lecture8 = createNewCourse("CSC107 (L)", "F", {'M': [15, 19]});
-  let lecture9 = createNewCourse("CSC108 (L)", "F", {'M': [16, 18]});
-  let lecture10 = createNewCourse("CSC109 (L)", "F", {'M': [19, 20]});
-  let lecture11 = createNewCourse("CSC110 (L)", "F", {'M': [19, 20]});
-  let lecture12 = createNewCourse("CSC111 (L)", "F", {'M': [19, 20]});
-  let lecture13 = createNewCourse("CSC112 (L)", "F", {'M': [19, 20]});
-  let lecture14 = createNewCourse("CSC113 (L)", "F", {'M': [19, 21]});
-  let lectureList = [lecture1, lecture2, lecture3, lecture4, lecture5, lecture6, lecture7, lecture8, lecture9, lecture10, lecture11, lecture12, lecture13, lecture14];
-
-  // Render the React component inside the 'grid-body' HTML tag
-  ReactDOM.render(
-    <Row courses={lectureList}/>,
-    document.getElementById('grid-body').getElementsByClassName('col-md-8 col-xs-12 col-md-pull-2')[0]
-  );
-}
-
-/**
- * Constructor for a 'Course' object
- * @param {string} courseCode : Name of course
- * @param {string} session : Session of course
- * @param {dictionary} times : The days, and corresponding time-slot for which
-                                this course is active
-  * @return {dictionary} Represents a 'Course' object
-*/
-function createNewCourse(courseCode, session, times) {
-  let lectures = {};
-  let days = [];
-  // Store the active days of this Course, and for each active
-  // day, create and store a 'Lecture' object
-  for (let day in times) {
-    days.push(day);
-    lectures[day] = [];
-    // For the case where this lecture starts and ends more than once in one day
-    for (let i = 0; i< times[day].length; i+=2) {
-      let startEndTimes = [times[day][i], times[day][i+1]];
-      lectures[day].push(createNewLecture(courseCode, session, day, startEndTimes));
-    }
-  }
-
-  let courseObject = {};
-  courseObject.session = session;
-  courseObject.days = days;
-  courseObject.lectures = lectures;
-  return courseObject;
-}
-
-/**
- * Constructor for a 'Lecture' object. Represents a single period of time
- * in which this course is active. (for ex; on Monday from 2-4)
- * @param {string} courseCode : Name of Lecture
- * @param {string} session : Session of Lecture
- * @param {string} day: Day of activity
- * @param {list} timePeriod : Active start and end time
- * @return {dictionary} Represents a 'Lecture' object
-*/
-function createNewLecture(courseCode, session, day, timePeriod) {
-  let lectureObject = {};
-  lectureObject.courseCode = courseCode;
-  lectureObject.session = session;
-  lectureObject.day = day;
-  lectureObject.startTime = timePeriod[0];
-  lectureObject.endTime = timePeriod[1];
-  lectureObject.inConflict = false;
-  // The width of a lecture is the maximum number of conflicts it has while it's active;
-  //  if there are no conflicts, the width is 1.
-  lectureObject.width = 1;
-  return lectureObject;
 }

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -164,7 +164,7 @@ class TimetableRow extends React.Component {
       let previousLectures = this.props.previousLectures;
       let headColSpans = this.props.headColSpans;
 
-      days.forEach(function(day) {
+      days.forEach(day => {
         // Initialize attributes of the cell in this day-and-time slot
         let alreadyGenerated = false;
         let lectureCode = "";
@@ -186,11 +186,11 @@ class TimetableRow extends React.Component {
         let currentLectureList = currentLectures[day];
         let previousLectureList = previousLectures[day];
 
-        if (currentLectureList.length != 0) {
+        if (currentLectureList.length !== 0) {
           // Render every lecture at this day-time slot (there can be more than one in a conflict case)
-          currentLectureList.forEach(function(lecture) {
+          currentLectureList.forEach(lecture => {
             // Check if this lecture has been previously rendered
-            previousLectureList.forEach(function(lecturePrev) {
+            previousLectureList.forEach(lecturePrev => {
               if (lecturePrev.courseCode === lecture.courseCode){
                 alreadyGenerated = true;
               }
@@ -334,33 +334,27 @@ function initializeSessions(lectures) {
  */
 function setWidths(session) {
   let days = ['M', 'T', 'W', 'R', 'F'];
-  // Reset all widths back to 1 and inConflict to false
   for (let i = 8; i < 22; i++) {
     let timeRow = session[i];
-    days.forEach(function(day) {
+    // Reset all widths back to 1 and inConflict to false if this time slot is the startTime of
+    // the lecture
+    days.forEach(day => {
       let timeDaySlot = timeRow[day];
       timeDaySlot.forEach(lecture => {
-        lecture.width = 1;
-        lecture.inConflict = false;
-      });
-    });
-  }
-  // Iterate through every time-slot in the session
-  for (let i = 8; i < 22; i++) {
-    let timeRow = session[i];
-    days.forEach(function(day) {
-      let timeDaySlot = timeRow[day];
-      // If in this time-and-day slot there is a lecture conflict
-      if (lectureConflict(timeDaySlot)) {
-        // Readjust (if needed) the 'width's of the lectures at this slot
-        timeDaySlot.forEach(lecture => {
+        if (lecture.startTime === i) {
+          lecture.width = 1;
+          lecture.inConflict = false;
+        }
+        // If in this time-and-day slot there is a lecture conflict
+        if (lectureConflict(timeDaySlot)) {
+          // Readjust (if needed) the 'width's of the lectures at this slot
           if (lecture.width < timeDaySlot.length) {
             lecture.width = timeDaySlot.length;
           }
           // Also specify that this lecture is in conflict
           lecture.inConflict = true;
-        });
-      }
+        }
+      });
     });
   }
 }

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -6,10 +6,9 @@ export class Row extends React.Component {
     // From a list of Course objects, create a list of Lecture objects
     let courses = this.props.courses;
     let lectures = courses.map(
-      c => Array.prototype.concat.apply([c.course], Object.values(c.lectures))
+      c => Array.prototype.concat.apply([], Object.values(c.lectures))
     );
     lectures = Array.prototype.concat.apply([], lectures);
-    console.log(lectures);
 
     // Organize the structure of the <fallSession> and <springSession> 2-D dictionaries
     let fallSession, springSession;

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -6,7 +6,7 @@ export class Row extends React.Component {
     // From a list of Course objects, create a list of Lecture objects
     let courses = this.props.courses;
     let lectures = courses.map(
-      c => Array.prototype.concat.apply([], Object.values(c.lectures))
+      c => Array.prototype.concat.apply([c.course], Object.values(c.lectures))
     );
     lectures = Array.prototype.concat.apply([], lectures);
     console.log(lectures);
@@ -335,7 +335,17 @@ function initializeSessions(lectures) {
  */
 function setWidths(session) {
   let days = ['M', 'T', 'W', 'R', 'F'];
-
+  // Reset all widths back to 1 and inConflict to false
+  for (let i = 8; i < 22; i++) {
+    let timeRow = session[i];
+    days.forEach(function(day) {
+      let timeDaySlot = timeRow[day];
+      timeDaySlot.forEach(lecture => {
+        lecture.width = 1;
+        lecture.inConflict = false;
+      });
+    });
+  }
   // Iterate through every time-slot in the session
   for (let i = 8; i < 22; i++) {
     let timeRow = session[i];

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -115,16 +115,17 @@ class Course extends React.Component {
   render() {
     return (
       <li key={this.props.courseCode} id={this.props.courseCode + "-li"} className={"ui-accordion ui-widget ui-helper-reset"}>
-        <h3>
+        <div className="ui-accordion-header ui-helper-reset ui-state-default ui-accordion-icons ui-accordion-header-active ui-state-active ui-corner-top"
+              id={"ui-accordion-" + this.props.courseCode + "-li-header-0"}>
           <div className="icon-div">
               <img src="static/res/ico/delete.png" className="close-icon" onClick={this.removeCourse}/>
           </div>
-          <div onClick={this.toggleSelect}>
+          <h3 onClick={this.toggleSelect}>
             {this.props.courseCode}
-          </div>
-        </h3>
+          </h3>
+        </div>
         { this.state.selected &&
-          <div className="sections ui-accordion-content"
+          <div className="sections ui-accordion-content ui-helper-reset ui-widget-content ui-corner-bottom ui-accordion-content-active"
                 id={"ui-accordion-" + this.props.courseCode + "-li-panel-0"}>
             <SectionList courseCode={this.props.courseCode}
                           session="Y"

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -39,7 +39,12 @@ class Course extends React.Component {
     )
     .then(response => response.json()) //datatype
     .then(data => {
-        let course = {courseCode: "", F: [], S:[], Y:[]}
+        let course = {
+          courseCode: "",
+          F: [],
+          S:[],
+          Y:[]
+        };
         course.courseCode = data.name;
         course.F = course.F.concat(this.parseLectures(data.fallSession.lectures),
                                     this.parseLectures(data.fallSession.tutorials));
@@ -54,43 +59,45 @@ class Course extends React.Component {
   parseLectures(lectures) {
     // Remove duplicated lecture sections
     let allLectures = lectures.filter((lecture, index, lectures) => {
-      return (lectures.map(lect => lect.section).indexOf(lecture.section) == index)
+      return (lectures.map(lect => lect.section).indexOf(lecture.section) === index)
     });
     let parsedLectures = [];
 
     let days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
     // Loop through the lecture sections to get each section's session code and lecture times
-    for (let i=0; i < allLectures.length; i++) {
+    allLectures.forEach( lectureInfo => {
       // Check to make sure its not a restricted section. Restricted sections have enrollment
       // restricted for a particular group of students, but happens at the same time and place as a regular
       // lecture/tutorial section.
-      if (allLectures[i].section.charAt(3) !== '2' && allLectures[i].times !== 'Online Web Version') {
-        let lecture = {courseName: allLectures[i].code.substring(0, 6) + " (" + allLectures[i].section.substring(0,1) + ")",
-                       lectureCode: allLectures[i].section.substring(0, 1) + allLectures[i].section.substring(3),
-                       times: {}};
-        let allTimes = allLectures[i].times;
+      if (lectureInfo.section.charAt(3) !== '2' && lectureInfo.times !== 'Online Web Version') {
+        let lecture = {
+          courseName: lectureInfo.code.substring(0, 6) + " (" + lectureInfo.section.substring(0,1) + ")",
+          lectureCode: lectureInfo.section.substring(0, 1) + lectureInfo.section.substring(3),
+          times: {}
+        };
+        let allTimes = lectureInfo.times;
         // The times in the original data are arrays of form [day, startTime], where day is an integer
         // between 0 and 4 that corresponds to days Monday to Friday. Eg: [0, 14] is a Monday lecture that
         // starts are 2PM. Every half hour is an individual array.
         // Loop through each individual time array and add the start time to the corresponding day.
-        for (let j=0; j < allTimes.length; j++) {
-          let day = days[(allTimes[j].timeField[0])];
+        allTimes.forEach( time => {
+          let day = days[(time.timeField[0])];
           if (!lecture.times[day]) {
-            lecture.times[day] = [allTimes[j].timeField[1]];
+            lecture.times[day] = [time.timeField[1]];
           }
           else {
-            lecture.times[day].push(allTimes[j].timeField[1]);
+            lecture.times[day].push(time.timeField[1]);
           }
-        }
+        });
         // Loop through each day of the week and remove the half hour increments.
         // Only keep start time and end time in the array.
         for (let weekday in lecture.times) {
           let times = []
           if (lecture.times.hasOwnProperty(weekday)) {
             times.push(lecture.times[weekday][0]);
-            for (let hour=1; hour < lecture.times[weekday].length; hour++) {
+            for (let hour = 1; hour < lecture.times[weekday].length; hour++) {
               if (hour+1 >= lecture.times[weekday].length ||
-                lecture.times[weekday][hour+1] != lecture.times[weekday][hour] + 0.5) {
+                lecture.times[weekday][hour+1] !== lecture.times[weekday][hour] + 0.5) {
                 times.push(lecture.times[weekday][hour] + 0.5);
               }
             }
@@ -99,8 +106,8 @@ class Course extends React.Component {
         }
         parsedLectures.push(lecture);
       }
-    }
-    parsedLectures.sort(function (lec1, lec2) {return lec1.lectureCode > lec2.lectureCode});
+    });
+    parsedLectures.sort((lec1, lec2) => {return lec1.lectureCode > lec2.lectureCode});
     return parsedLectures;
   }
 
@@ -154,14 +161,14 @@ class Course extends React.Component {
 
 class SectionList extends React.Component {
   render() {
-    const lectureSections = this.props.lectures.map(
-      lecture => <LectureSection key={this.props.courseCode + lecture.lectureCode + this.props.section}
-                                  session={this.props.session}
-                                  courseCode={this.props.courseCode}
-                                  lecture={lecture}
-                                  addSelectedLecture={this.props.addSelectedLecture}
-                                  selectedLectures={this.props.selectedLectures}
-                                  removeSelectedLecture={this.props.removeSelectedLecture}/>)
+    const lectureSections = this.props.lectures.map(lecture =>
+      <LectureSection key={this.props.courseCode + lecture.lectureCode + this.props.section}
+                      session={this.props.session}
+                      courseCode={this.props.courseCode}
+                      lecture={lecture}
+                      addSelectedLecture={this.props.addSelectedLecture}
+                      selectedLectures={this.props.selectedLectures}
+                      removeSelectedLecture={this.props.removeSelectedLecture}/>);
     return(
       <ul className={"sectionList-" + this.props.session} id="lecture-list">
         {lectureSections}
@@ -179,16 +186,17 @@ class LectureSection extends React.Component {
   // Check whether the course is already in the selectCourses list.
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
-    let index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName);
-
-    while (index != -1 && (this.props.selectedLectures[index].lectureCode !== this.props.lecture.lectureCode ||
-          this.props.session !== this.props.selectedLectures[index].session)) {
-      index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName, index + 1);
+    let sameLecture = this.props.selectedLectures.filter((lecture) => {
+      return lecture.course === this.props.lecture.courseName && lecture.session === this.props.session &&
+        lecture.lectureCode === this.props.lecture.lectureCode
+    });
+    // If sameLecture is not an empty array, then this lecture is already selected and should be removed
+    if (sameLecture.length > 0) {
+      this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.session);
+    } else {
+      this.props.addSelectedLecture(this.props.lecture.courseName, this.props.session,
+                                    this.props.lecture.lectureCode, this.props.lecture.times);
     }
-    // If index != -1, then the while loop stopped because the lectureCode and session both matched
-    (index != -1) ? this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.session) :
-                    this.props.addSelectedLecture(this.props.lecture.courseName, this.props.session,
-                                                      this.props.lecture.lectureCode, this.props.lecture.times);
   }
 
   render() {

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -41,16 +41,13 @@ class Course extends React.Component {
     .then(data => {
         let course = {courseCode: "", F: [], S:[], Y:[]}
         course.courseCode = data.name;
-        let fallLectures = this.parseLectures(data.fallSession.lectures);
-        course.F = fallLectures.concat(this.parseLectures(data.fallSession.tutorials));
-
-        let springLectures = this.parseLectures(data.springSession.lectures);
-        course.S = springLectures.concat(this.parseLectures(data.springSession.tutorials));
-
-        let yearLectures = this.parseLectures(data.yearSession.lectures);
-        course.Y = yearLectures.concat(this.parseLectures(data.yearSession.tutorials));
+        course.F = course.F.concat(this.parseLectures(data.fallSession.lectures),
+                                    this.parseLectures(data.fallSession.tutorials));
+        course.S = course.S.concat(this.parseLectures(data.springSession.lectures),
+                                    this.parseLectures(data.springSession.tutorials));
+        course.Y = course.Y.concat(this.parseLectures(data.yearSession.lectures),
+                                    this.parseLectures(data.yearSession.tutorials));
         this.setState({courseInfo: course});
-        console.log(this.state.courseInfo)
     });
   }
 
@@ -130,19 +127,19 @@ class Course extends React.Component {
           <div className="sections ui-accordion-content"
                 id={"ui-accordion-" + this.props.courseCode + "-li-panel-0"}>
             <SectionList courseCode={this.props.courseCode}
-                          section="Y"
+                          session="Y"
                           lectures={this.state.courseInfo.Y}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
                           removeSelectedLecture={this.props.removeSelectedLecture}/>
             <SectionList courseCode={this.props.courseCode}
-                          section="F"
+                          session="F"
                           lectures={this.state.courseInfo.F}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
                           removeSelectedLecture={this.props.removeSelectedLecture}/>
             <SectionList courseCode={this.props.courseCode}
-                          section="S"
+                          session="S"
                           lectures={this.state.courseInfo.S}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
@@ -158,14 +155,14 @@ class SectionList extends React.Component {
   render() {
     const lectureSections = this.props.lectures.map(
       lecture => <LectureSection key={this.props.courseCode + lecture.lectureCode + this.props.section}
-                                  section={this.props.section}
+                                  session={this.props.session}
                                   courseCode={this.props.courseCode}
                                   lecture={lecture}
                                   addSelectedLecture={this.props.addSelectedLecture}
                                   selectedLectures={this.props.selectedLectures}
                                   removeSelectedLecture={this.props.removeSelectedLecture}/>)
     return(
-      <ul className={"sectionList-" + this.props.section} id="lecture-list">
+      <ul className={"sectionList-" + this.props.session} id="lecture-list">
         {lectureSections}
       </ul>
     )
@@ -182,21 +179,20 @@ class LectureSection extends React.Component {
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
     let index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName);
-    const selectedLecturesCodes = this.props.selectedLectures.map(lecture => lecture.lectureCode);
 
-    while (index != -1 && (selectedLecturesCodes[index] !== this.props.lecture.lectureCode ||
-          this.props.section !== this.props.selectedLectures[index].session)) {
+    while (index != -1 && (this.props.selectedLectures[index].lectureCode !== this.props.lecture.lectureCode ||
+          this.props.session !== this.props.selectedLectures[index].session)) {
       index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName, index + 1);
     }
-    // If index != -1, then the while loop stopped because the lectureCode and section both matched
-    (index != -1) ? this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.lecture) :
-                    this.props.addSelectedLecture(this.props.lecture.courseName, this.props.section,
+    // If index != -1, then the while loop stopped because the lectureCode and session both matched
+    (index != -1) ? this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.session) :
+                    this.props.addSelectedLecture(this.props.lecture.courseName, this.props.session,
                                                       this.props.lecture.lectureCode, this.props.lecture.times);
   }
 
   render() {
     return(
-      <li id={this.props.courseCode + "-" + this.props.lecture.lectureCode + "-" + this.props.section}
+      <li id={this.props.courseCode + "-" + this.props.lecture.lectureCode + "-" + this.props.session}
           onClick={this.selectLecture}>
         {this.props.lecture.lectureCode}
       </li>

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -6,7 +6,7 @@ export class CoursePanel extends React.Component {
                         courseCode={course}
                         removeCourse={this.props.removeCourse}
                         addSelectedLecture={this.props.addSelectedLecture}
-                        removeSelectedLecture={this.removeSelectedLecture}/>)
+                        removeSelectedLecture={this.props.removeSelectedLecture}/>)
 
     return (
       <div id="course-select-wrapper" className="col-md-2 col-xs-6">
@@ -39,7 +39,6 @@ class Course extends React.Component {
     )
     .then(response => response.json()) //datatype
     .then(data => {
-        console.log(data)
         let course = {courseCode: "", F: [], S:[], Y:[]}
         course.courseCode = data.name;
         let fallLectures = this.parseLectures(data.fallSession.lectures);
@@ -51,6 +50,7 @@ class Course extends React.Component {
         let yearLectures = this.parseLectures(data.yearSession.lectures);
         course.Y = yearLectures.concat(this.parseLectures(data.yearSession.tutorials));
         this.setState({courseInfo: course});
+        console.log(this.state.courseInfo)
     });
   }
 
@@ -68,7 +68,9 @@ class Course extends React.Component {
       // restricted for a particular group of students, but happens at the same time and place as a regular
       // lecture/tutorial section.
       if (allLectures[i].section.charAt(3) !== '2' && allLectures[i].times !== 'Online Web Version') {
-        let lecture = {lectureCode: allLectures[i].section, times: {}};
+        let lecture = {courseName: allLectures[i].code.substring(0, 6) + " (" + allLectures[i].section.substring(0,1) + ")",
+                       lectureCode: allLectures[i].section.substring(0, 1) + allLectures[i].section.substring(3),
+                       times: {}};
         let allTimes = allLectures[i].times;
         // The times in the original data are arrays of form [day, startTime], where day is an integer
         // between 0 and 4 that corresponds to days Monday to Friday. Eg: [0, 14] is a Monday lecture that
@@ -131,19 +133,19 @@ class Course extends React.Component {
                           lectures={this.state.courseInfo.Y}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
-                          removeSelectedLecture={this.removeSelectedLecture}/>
+                          removeSelectedLecture={this.props.removeSelectedLecture}/>
             <SectionList courseCode={this.props.courseCode}
                           section="F"
                           lectures={this.state.courseInfo.F}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
-                          removeSelectedLecture={this.removeSelectedLecture}/>
+                          removeSelectedLecture={this.props.removeSelectedLecture}/>
             <SectionList courseCode={this.props.courseCode}
                           section="S"
                           lectures={this.state.courseInfo.S}
                           addSelectedLecture={this.props.addSelectedLecture}
                           selectedLectures={this.props.selectedLectures}
-                          removeSelectedLecture={this.removeSelectedLecture}/>
+                          removeSelectedLecture={this.props.removeSelectedLecture}/>
           </div>
         }
       </li>
@@ -160,7 +162,7 @@ class SectionList extends React.Component {
                                   lecture={lecture}
                                   addSelectedLecture={this.props.addSelectedLecture}
                                   selectedLectures={this.props.selectedLectures}
-                                  removeSelectedLecture={this.removeSelectedLecture}/>)
+                                  removeSelectedLecture={this.props.removeSelectedLecture}/>)
     return(
       <ul className={"sectionList-" + this.props.section} id="lecture-list">
         {lectureSections}
@@ -170,18 +172,6 @@ class SectionList extends React.Component {
 }
 
 class LectureSection extends React.Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.toggleLecture = this.toggleLecture.bind(this);
-  //   this.state = {
-  //     lectureSelected: false
-  //   }
-  // }
-
-  // toggleLecture() {
-  //   this.setState({lectureSelected: !this.state.selected});
-  // }
-
   constructor(props) {
     super(props);
     this.selectLecture = this.selectLecture.bind(this);
@@ -190,8 +180,12 @@ class LectureSection extends React.Component {
   // Check whether the course is already in the selectCourses list.
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
-    this.props.selectedLectures.indexOf(this.props.lecture) != -1 ? this.props.removeSelectedLecture(this.props.lecture) :
-                        this.props.addSelectedLecture(this.props.lecture);
+    const index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName);
+    const selectedLecturesCodes = this.props.selectedLectures.map(lecture => lecture.lectureCode);
+    (index != -1 && selectedLecturesCodes[index] === this.props.lecture.lectureCode && this.props.section === this.props.selectedLectures[index].session) ?
+                        this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.lecture) :
+                        this.props.addSelectedLecture(this.props.lecture.courseName, this.props.section,
+                                                      this.props.lecture.lectureCode, this.props.lecture.times);
   }
 
   render() {

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -103,6 +103,7 @@ class Course extends React.Component {
         parsedLectures.push(lecture);
       }
     }
+    parsedLectures.sort(function (lec1, lec2) {return lec1.lectureCode > lec2.lectureCode});
     return parsedLectures;
   }
 
@@ -116,7 +117,7 @@ class Course extends React.Component {
 
   render() {
     return (
-      <li key={this.props.courseCode} id={this.props.courseCode + "-li"} >
+      <li key={this.props.courseCode} id={this.props.courseCode + "-li"} className={"ui-accordion ui-widget ui-helper-reset"}>
         <h3>
           <div className="icon-div">
               <img src="static/res/ico/delete.png" className="close-icon" onClick={this.removeCourse}/>
@@ -180,11 +181,16 @@ class LectureSection extends React.Component {
   // Check whether the course is already in the selectCourses list.
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
-    const index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName);
+    let index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName);
     const selectedLecturesCodes = this.props.selectedLectures.map(lecture => lecture.lectureCode);
-    (index != -1 && selectedLecturesCodes[index] === this.props.lecture.lectureCode && this.props.section === this.props.selectedLectures[index].session) ?
-                        this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.lecture) :
-                        this.props.addSelectedLecture(this.props.lecture.courseName, this.props.section,
+
+    while (index != -1 && (selectedLecturesCodes[index] !== this.props.lecture.lectureCode ||
+          this.props.section !== this.props.selectedLectures[index].session)) {
+      index = this.props.selectedLectures.map(lecture => lecture.course).indexOf(this.props.lecture.courseName, index + 1);
+    }
+    // If index != -1, then the while loop stopped because the lectureCode and section both matched
+    (index != -1) ? this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.lecture) :
+                    this.props.addSelectedLecture(this.props.lecture.courseName, this.props.section,
                                                       this.props.lecture.lectureCode, this.props.lecture.times);
   }
 

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -10,22 +10,20 @@ class Grid extends React.Component {
     this.clearSelectedCourses = this.clearSelectedCourses.bind(this);
     this.addSelectedLecture = this.addSelectedLecture.bind(this);
     this.removeSelectedLecture = this.removeSelectedLecture.bind(this);
+    this.createNewCourse = this.createNewCourse.bind(this);
+    this.createNewLecture = this.createNewLecture.bind(this);
     this.state = {
       selectedLectures: [],
       selectedCourses: []
     };
   }
 
-  componentDidMount() {
-    this.setState({ selectedLectures: generateData() });
-  }
-
   // Method passed to child component SearchPanel to add a course to selectedCourses.
   // Move into child didMount
   addSelectedCourse(courseCode) {
-      let updatedCourses = this.state.selectedCourses;
-      updatedCourses.push(courseCode);
-      this.setState({ selectedCourses: updatedCourses });
+    let updatedCourses = this.state.selectedCourses;
+    updatedCourses.push(courseCode);
+    this.setState({selectedCourses: updatedCourses});
   }
 
   // Method passed to child components, SearchPanel and CoursePanel to remove a course from selectedCourses.
@@ -33,25 +31,91 @@ class Grid extends React.Component {
     let updatedCourses = this.state.selectedCourses;
     const index = updatedCourses.indexOf(courseCode);
     updatedCourses.splice(index, 1);
-    this.setState({selectedCourses: updatedCourses})
+    this.setState({selectedCourses: updatedCourses});
+
+    let updatedLectures = this.state.selectedLectures.filter(lecture =>
+                          !lecture.course.includes(courseCode.substring(0, 6)));
+    this.setState({selectedLectures: updatedLectures});
   }
 
   // Method passed to child component CoursePanel to clear all the courses in selectedCourses.
   clearSelectedCourses() {
     this.setState({selectedCourses: []});
+    this.setState({selectedLectures: []});
   }
 
-  addSelectedLecture(lectureSession) {
+  addSelectedLecture(courseCode, session, lectureCode, lectureTimes) {
     let updatedLectures = this.state.selectedLectures;
+    if (this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode) != -1) {
+      const index = this.state.selectedLectures.map(lecture => lecture.lectures.course).indexOf(courseCode);
+      updatedLectures.splice(index, 1);
+    }
+    let lectureSession = this.createNewCourse(courseCode, session, lectureCode, lectureTimes);
     updatedLectures.push(lectureSession);
     this.setState({selectedLectures: updatedLectures});
+    console.log(this.state.selectedLectures)
   }
 
-  removeSelectedLecture(lectureSession) {
+  removeSelectedLecture(courseCode, lectureSession) {
     let updatedLectures = this.state.selectedLectures;
-    const index = updatedLectures.indexOf(lectureSession);
+    const index = updatedLectures.map(lecture => lecture.courseCode).indexOf(courseCode);
     updatedLectures.splice(index, 1);
     this.setState({selectedLectures: updatedLectures})
+  }
+
+    /**
+   * Constructor for a 'Course' object
+   * @param {string} courseCode : Name of course
+   * @param {string} session : Session of course
+   * @param {dictionary} times : The days, and corresponding time-slot for which
+                                  this course is active
+   * @return {dictionary} Represents a 'Course' object
+  */
+  createNewCourse(courseCode, session, lectureCode, times) {
+    let lectures = {};
+    let days = [];
+    // Store the active days of this Course, and for each active
+    // day, create and store a 'Lecture' object
+    for (let day in times) {
+      days.push(day);
+      lectures[day] = [];
+      // For the case where this lecture starts and ends more than once in one day
+      for(let i = 0; i< times[day].length; i+=2){
+        let startEndTimes = [times[day][i], times[day][i+1]];
+        lectures[day].push(this.createNewLecture(courseCode, session, day, startEndTimes));
+      }
+    }
+
+    let courseObject = {};
+    courseObject.course = courseCode;
+    courseObject.lectureCode = lectureCode;
+    courseObject.session = session;
+    courseObject.days = days;
+    courseObject.lectures = lectures;
+    return courseObject;
+  }
+
+  /**
+   * Constructor for a 'Lecture' object. Represents a single period of time
+   * in which this course is active. (for ex; on Monday from 2-4)
+   * @param {string} courseCode : Name of Lecture
+   * @param {string} session : Session of Lecture
+   * @param {string} day: Day of activity
+   * @param {list} timePeriod : Active start and end time
+   * @return {dictionary} Represents a 'Lecture' object
+  */
+  createNewLecture(courseCode, session, day, timePeriod) {
+    let lectureObject = {};
+    lectureObject.courseCode = courseCode;
+    lectureObject.session = session;
+    lectureObject.day = day;
+    lectureObject.startTime = timePeriod[0];
+    lectureObject.endTime = timePeriod[1];
+    lectureObject.inConflict = false;
+    // The width of a lecture is the maximum number of conflicts it has while it's active;
+    //  if there are no conflicts, the width is 1.
+    lectureObject.width = 1;
+    return lectureObject;
   }
 
   render() {
@@ -81,87 +145,3 @@ ReactDOM.render(
   <Grid />,
   document.getElementById('grid-body')
 );
-
-
-/******************************************************************************
- * TODO: Remove the sample data generation below.
- *****************************************************************************/
-
-/**
- * Generates mock data; for illustrative purposes only.
-*/
-export function generateData() {
-  // Sample Course objects, constructed with sample attributes
-
-  // Note: W: [8, 12, 14, 15] denotes that this course runs on Wed from 8 to 12, and again on Wed from 14 - 15
-  let lecture1 = createNewCourse("CSC100 (L)", "F", {'M': [8, 12], 'W': [8, 12, 14, 16], 'F': [8, 12]});
-  let lecture2 = createNewCourse("CSC101 (L)", "F", {'M': [8, 11]});
-  let lecture3 = createNewCourse("CSC102 (L)", "F", {'M': [10, 13]});
-  let lecture4 = createNewCourse("CSC103 (L)", "F", {'M': [13, 14]});
-  let lecture5 = createNewCourse("CSC104 (L)", "F", {'M': [13, 14]});
-  let lecture6 = createNewCourse("CSC105 (L)", "F", {'M': [13, 14]});
-  let lecture7 = createNewCourse("CSC106 (L)", "F", {'M': [13, 14]});
-  let lecture8 = createNewCourse("CSC107 (L)", "F", {'M': [15, 19]});
-  let lecture9 = createNewCourse("CSC108 (L)", "F", {'M': [16, 18]});
-  let lecture10 = createNewCourse("CSC109 (L)", "F", {'M': [19, 20]});
-  let lecture11 = createNewCourse("CSC110 (L)", "F", {'M': [19, 20]});
-  let lecture12 = createNewCourse("CSC111 (L)", "F", {'M': [19, 20]});
-  let lecture13 = createNewCourse("CSC112 (L)", "F", {'M': [19, 20]});
-  let lecture14 = createNewCourse("CSC113 (L)", "F", {'M': [19, 21]});
-  let lectureList = [lecture1, lecture2, lecture3, lecture4, lecture5, lecture6, lecture7, lecture8, lecture9, lecture10, lecture11, lecture12, lecture13, lecture14];
-
-  return lectureList;
-}
-
-/**
- * Constructor for a 'Course' object
- * @param {string} courseCode : Name of course
- * @param {string} session : Session of course
- * @param {dictionary} times : The days, and corresponding time-slot for which
-                                this course is active
- * @return {dictionary} Represents a 'Course' object
-*/
-function createNewCourse(courseCode, session, times) {
-  let lectures = {};
-  let days = [];
-  // Store the active days of this Course, and for each active
-  // day, create and store a 'Lecture' object
-  for (let day in times) {
-    days.push(day);
-    lectures[day] = [];
-    // For the case where this lecture starts and ends more than once in one day
-    for(let i = 0; i< times[day].length; i+=2){
-      let startEndTimes = [times[day][i], times[day][i+1]];
-      lectures[day].push(createNewLecture(courseCode, session, day, startEndTimes));
-    }
-  }
-
-  let courseObject = {};
-  courseObject.session = session;
-  courseObject.days = days;
-  courseObject.lectures = lectures;
-  return courseObject;
-}
-
-/**
- * Constructor for a 'Lecture' object. Represents a single period of time
- * in which this course is active. (for ex; on Monday from 2-4)
- * @param {string} courseCode : Name of Lecture
- * @param {string} session : Session of Lecture
- * @param {string} day: Day of activity
- * @param {list} timePeriod : Active start and end time
- * @return {dictionary} Represents a 'Lecture' object
-*/
-function createNewLecture(courseCode, session, day, timePeriod) {
-  let lectureObject = {};
-  lectureObject.courseCode = courseCode;
-  lectureObject.session = session;
-  lectureObject.day = day;
-  lectureObject.startTime = timePeriod[0];
-  lectureObject.endTime = timePeriod[1];
-  lectureObject.inConflict = false;
-  // The width of a lecture is the maximum number of conflicts it has while it's active;
-  //  if there are no conflicts, the width is 1.
-  lectureObject.width = 1;
-  return lectureObject;
-}

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -19,11 +19,45 @@ class Grid extends React.Component {
     };
   }
 
+  // get the previously selected courses and lecture sections from local storage
+  componentDidMount() {
+    let selectedCoursesLocalStorage = localStorage.getItem('selectedCourses');
+    let selectedLecturesLocalStorage = localStorage.getItem('selectedLectures');
+
+    if (!selectedLecturesLocalStorage) {
+      selectedLecturesLocalStorage = [];
+    } else {
+      try {
+        this.setState({selectedLectures: JSON.parse(selectedLecturesLocalStorage)});
+      }
+      catch (e) {
+        console.log(e)
+      }
+    }
+
+    if (!selectedCoursesLocalStorage) {
+      selectedCoursesLocalStorage = [];
+    } else {
+      selectedCoursesLocalStorage = selectedCoursesLocalStorage.split('_');
+      selectedCoursesLocalStorage.forEach((courseCode) => {
+        try {
+          this.addSelectedCourse(courseCode);
+        }
+        catch (e) {
+          console.log('Removed bad course from local storage' + courseCode);
+          console.log(e);
+        }
+      });
+    }
+  }
+
   // Method passed to child component SearchPanel to add a course to selectedCourses.
   addSelectedCourse(courseCode) {
     let updatedCourses = this.state.selectedCourses;
     updatedCourses.push(courseCode);
     this.setState({selectedCourses: updatedCourses});
+
+    localStorage.setItem("selectedCourses", updatedCourses.join('_'));
   }
 
   // Method passed to child components, SearchPanel and CoursePanel to remove a course from selectedCourses.
@@ -36,12 +70,19 @@ class Grid extends React.Component {
     let updatedLectures = this.state.selectedLectures.filter(lecture =>
                           !lecture.course.includes(courseCode.substring(0, 6)));
     this.setState({selectedLectures: updatedLectures});
+
+    localStorage.setItem("selectedCourses", updatedCourses.join('_'));
+    localStorage.setItem("selectedLectures", JSON.stringify(updatedLectures));
+    console.log(JSON.stringify(updatedLectures));
   }
 
   // Method passed to child component CoursePanel to clear all the courses in selectedCourses.
   clearSelectedCourses() {
     this.setState({selectedCourses: []});
     this.setState({selectedLectures: []});
+
+    localStorage.setItem("selectedCourses", "");
+    localStorage.setItem("selectedLectures", "");
   }
 
   // Method passed to child component CoursePanel to add a lecture to selectedLectures
@@ -59,6 +100,8 @@ class Grid extends React.Component {
     updatedLectures.push(lectureSession);
     this.setState({selectedLectures: updatedLectures});
     console.log(this.state.selectedLectures)
+
+    localStorage.setItem("selectedLectures", JSON.stringify(updatedLectures));
   }
 
   // Method passed to child component CoursePanel to remove a lecture from selectedLectures
@@ -72,6 +115,8 @@ class Grid extends React.Component {
       index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode, index + 1);
     }
     this.setState({selectedLectures: updatedLectures})
+
+    localStorage.setItem("selectedLectures", JSON.stringify(updatedLectures));
   }
 
   /**

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -8,6 +8,7 @@ class Grid extends React.Component {
     this.addSelectedCourse = this.addSelectedCourse.bind(this);
     this.removeSelectedCourse = this.removeSelectedCourse.bind(this);
     this.clearSelectedCourses = this.clearSelectedCourses.bind(this);
+
     this.addSelectedLecture = this.addSelectedLecture.bind(this);
     this.removeSelectedLecture = this.removeSelectedLecture.bind(this);
     this.createNewCourse = this.createNewCourse.bind(this);
@@ -46,9 +47,13 @@ class Grid extends React.Component {
 
   addSelectedLecture(courseCode, session, lectureCode, lectureTimes) {
     let updatedLectures = this.state.selectedLectures;
-    if (this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode) != -1) {
-      const index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode);
-      updatedLectures.splice(index, 1);
+    // The maximum number of courses in the lecture list with the same code is 3, one for each session (F, S, Y)
+    let index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode);
+    while (index != -1) {
+      if (this.state.selectedLectures[index].session === session) {
+        updatedLectures.splice(index, 1);
+      }
+      index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode, index + 1);
     }
     let lectureSession = this.createNewCourse(courseCode, session, lectureCode, lectureTimes);
     updatedLectures.push(lectureSession);
@@ -58,7 +63,13 @@ class Grid extends React.Component {
 
   removeSelectedLecture(courseCode, lectureSession) {
     let updatedLectures = this.state.selectedLectures;
-    const index = updatedLectures.map(lecture => lecture.course).indexOf(courseCode);
+    let index = updatedLectures.map(lecture => lecture.course).indexOf(courseCode);
+    while (index != -1) {
+      if (this.state.selectedLectures[index].session === lectureSession.session) {
+        updatedLectures.splice(index, 1);
+      }
+      index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode, index + 1);
+    }
     updatedLectures.splice(index, 1);
     this.setState({selectedLectures: updatedLectures})
   }
@@ -85,7 +96,6 @@ class Grid extends React.Component {
         lectures[day].push(this.createNewLecture(courseCode, session, day, startEndTimes));
       }
     }
-
     let courseObject = {};
     courseObject.course = courseCode;
     courseObject.lectureCode = lectureCode;

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -47,7 +47,7 @@ class Grid extends React.Component {
   addSelectedLecture(courseCode, session, lectureCode, lectureTimes) {
     let updatedLectures = this.state.selectedLectures;
     if (this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode) != -1) {
-      const index = this.state.selectedLectures.map(lecture => lecture.lectures.course).indexOf(courseCode);
+      const index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode);
       updatedLectures.splice(index, 1);
     }
     let lectureSession = this.createNewCourse(courseCode, session, lectureCode, lectureTimes);
@@ -58,7 +58,7 @@ class Grid extends React.Component {
 
   removeSelectedLecture(courseCode, lectureSession) {
     let updatedLectures = this.state.selectedLectures;
-    const index = updatedLectures.map(lecture => lecture.courseCode).indexOf(courseCode);
+    const index = updatedLectures.map(lecture => lecture.course).indexOf(courseCode);
     updatedLectures.splice(index, 1);
     this.setState({selectedLectures: updatedLectures})
   }

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -20,7 +20,6 @@ class Grid extends React.Component {
   }
 
   // Method passed to child component SearchPanel to add a course to selectedCourses.
-  // Move into child didMount
   addSelectedCourse(courseCode) {
     let updatedCourses = this.state.selectedCourses;
     updatedCourses.push(courseCode);
@@ -45,10 +44,11 @@ class Grid extends React.Component {
     this.setState({selectedLectures: []});
   }
 
+  // Method passed to child component CoursePanel to add a lecture to selectedLectures
   addSelectedLecture(courseCode, session, lectureCode, lectureTimes) {
     let updatedLectures = this.state.selectedLectures;
     // The maximum number of courses in the lecture list with the same code is 3, one for each session (F, S, Y)
-    let index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode);
+    let index = updatedLectures.map(lecture => lecture.course).indexOf(courseCode);
     while (index != -1) {
       if (this.state.selectedLectures[index].session === session) {
         updatedLectures.splice(index, 1);
@@ -61,20 +61,20 @@ class Grid extends React.Component {
     console.log(this.state.selectedLectures)
   }
 
-  removeSelectedLecture(courseCode, lectureSession) {
+  // Method passed to child component CoursePanel to remove a lecture from selectedLectures
+  removeSelectedLecture(courseCode, session) {
     let updatedLectures = this.state.selectedLectures;
     let index = updatedLectures.map(lecture => lecture.course).indexOf(courseCode);
     while (index != -1) {
-      if (this.state.selectedLectures[index].session === lectureSession.session) {
+      if (this.state.selectedLectures[index].session === session) {
         updatedLectures.splice(index, 1);
       }
       index = this.state.selectedLectures.map(lecture => lecture.course).indexOf(courseCode, index + 1);
     }
-    updatedLectures.splice(index, 1);
     this.setState({selectedLectures: updatedLectures})
   }
 
-    /**
+  /**
    * Constructor for a 'Course' object
    * @param {string} courseCode : Name of course
    * @param {string} session : Session of course

--- a/js/components/grid/search_panel.js.jsx
+++ b/js/components/grid/search_panel.js.jsx
@@ -117,8 +117,12 @@ class CourseEntry extends React.Component {
   // Check whether the course is already in the selectCourses list.
   // Remove the course if it is, or add the course if it is not.
   select() {
-    this.props.selectedCourses.indexOf(this.props.course) != -1 ? this.props.removeCourse(this.props.course) :
-                        this.props.selectCourse(this.props.course);
+    if (this.props.selectedCourses.indexOf(this.props.course) != -1) {
+      this.props.removeCourse(this.props.course);
+    }
+    else {
+      this.props.selectCourse(this.props.course);
+    }
   }
 
   render() {


### PR DESCRIPTION
Previously, lecture section information (ie lecture section codes and lecture section times) did not appear in the coursePanel, and coursePanel did not communicate with component Row to display the selected lectures on the timetable. 

Now, the lecture sections appear in coursePanel and clicking a lecture section will add it to (or remove it from) the timetable. 
![sidebarfix](https://user-images.githubusercontent.com/33272137/42180848-c1598e24-7e06-11e8-90c9-810b73df1a8b.png)

Courses on the timetable are red when they are in conflict. After the conflict is removed, they turn back to blue. 
![conflictremovedsidebarfix](https://user-images.githubusercontent.com/33272137/42180895-e8e5ed3e-7e06-11e8-87d1-d8d67d7a0844.png)
 
For a single course, users can select 1 lecture section and 1 tutorial section per semester to display in the timetable. The user can select lecture sections and tutorial sections in different semesters (Fall, Spring and Year) at the same time. 
(For example, for CSC148, the user can select a Fall lecture section and a Spring lecture section at the same time)
Also removed the hardcoded lecture generating function "generateData" in grid.js, and functions "drawTimetable", "createNewCourse" and "createNewLecture" in calendar.js because they are not used. 

Selected courses and lectures are now saved to local storage. So when the user refreshes (or close then reopen) the page, the previously selected courses and lectures will remain on the page.  