### PR TITLE
react-grid: import error when importing Modal from react-modal into course_panel

### DIFF
--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -1,3 +1,5 @@
+import {Modal} from '../../../public/js/common/react_modal.js';
+
 export class CoursePanel extends React.Component {
   render() {
     const courses = this.props.selectedCourses.map(
@@ -126,6 +128,7 @@ class Course extends React.Component {
               id={"ui-accordion-" + this.props.courseCode + "-li-header-0"}>
           <div className="icon-div">
               <img src="static/res/ico/delete.png" className="close-icon" onClick={this.removeCourse}/>
+              <img src="static/res/ico/about.png" className="close-icon"/>
           </div>
           <h3 onClick={this.toggleSelect}>
             {this.props.courseCode}

--- a/public/js/common/react_modal.js
+++ b/public/js/common/react_modal.js
@@ -1,4 +1,4 @@
-import * as ReactModal from 'vendor/react-modal';
+import * as ReactModal from '../vendor/react-modal';
 
 var ModalContent = React.createClass({
     render: function() {


### PR DESCRIPTION
This error occurs when importing Modal from react_modal into course_panel
![screenshot from 2018-07-09 00-38-20](https://user-images.githubusercontent.com/33272137/42460066-fba96ba8-836a-11e8-86a2-178b6823eee8.png)

![screenshot from 2018-07-09 11-38-42](https://user-images.githubusercontent.com/33272137/42460748-af8dd9be-836c-11e8-8f31-384c67d90ef0.png)


In js/common/react_modal.js:
`import * as ReactModal from 'vendor/react-modal'` 
results in an error: Cannot find module "vendor/react-modal". So it is changed to:
`import * as ReactModal from '../vendor/react-modal'`