### PR TITLE
react-grid: change representation of lecture times in Tables.hs to have more resemblance to the format needed to render the times to the timetable

### DIFF
--- a/app/Css/Timetable.hs
+++ b/app/Css/Timetable.hs
@@ -146,6 +146,16 @@ timetableCSS = do
             borderPink borderTop
             borderLeftStyle none
             borderRightStyle none
+        ".timetable-cell-tophalf" ? do
+            borderBottomStyle none
+            borderPink borderTop
+            borderLeftStyle none
+            borderRightStyle none
+        ".timetable-cell-bottomhalf" ? do
+            borderPink borderBottom
+            borderTopStyle none
+            borderLeftStyle none
+            borderRightStyle none
         ".timetable-edge" ? do
             borderPink borderTop
             borderBottomStyle none

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -37,14 +37,11 @@ import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 
 -- | A data type representing a time for the section of a course.
--- The list is comprised of three values: the date (represented as a number
--- of the week), the start time and the end time. The dates span Monday-Friday, beging represented
--- by 1-5 respectively. The start time and end time are numbers between 0-23.
--- TODO: Change this datatype. This datatype shouldn't be implemented with
--- a list, perhaps a tuple would be better.
-
---data Time = Time { timeField :: (Double, Double, Double) } deriving (Show, Read, Eq, Generic)
-data Time = Time { timeField :: [Double] } deriving (Show, Read, Eq, Generic)
+-- The record is comprised of three fields: weekDay (represented as a number
+-- of the week), startHour (the start time of the lecture) and endHour (the end time of the lecture).
+-- The dates span Monday-Friday, being represented by 0-4 respectively.
+-- The start time and end time are numbers between 0-23.
+data Time = Time { weekDay :: Double, startHour :: Double, endHour :: Double } deriving (Show, Read, Eq, Generic)
 derivePersistField "Time"
 
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
@@ -194,16 +191,16 @@ instance ToJSON Room
 -- not necessary otherwise.
 instance FromJSON SvgJSON
 
--- | Converts a Double to a T.Text.
+-- | Converts a Time to a T.Text.
 -- This removes the period from the double, as the JavaScript code,
 -- uses the output in an element's ID, which is then later used in
 -- jQuery. @.@ is a jQuery meta-character, and must be removed from the ID.
 convertTimeToString :: Time -> [T.Text]
-convertTimeToString (Time [day, startNum, endNum]) =
+convertTimeToString (Time day startNum endNum) =
   [T.pack . show $ (floor day :: Int),
    T.replace "." "-" . T.pack . show $ (show startNum ++ "-" ++ show endNum)]
 convertTimeToString _ = undefined
-
+-- ToDo: remove "pattern match is redundant warning" for line 202.
 
 -- JSON encoding/decoding
 instance FromJSON Courses where
@@ -311,5 +308,5 @@ getTimeSlots (Just day) (Just start) (Just end) = do
     let dayDbl = getDayVal day
         startDbl = getHourVal start
         endDbl = getHourVal end
-    [Time [dayDbl, startDbl, endDbl]]
+    [Time dayDbl startDbl endDbl]
 getTimeSlots _ _ _ = []

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -37,9 +37,9 @@ import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 
 -- | A data type representing a time for the section of a course.
--- The first list is comprised of two values: the date (represented as a number
--- of the week), and the time. The dates span Monday-Friday, being represented
--- by 1-5 respectively. The time is a number between 0-23.
+-- The list is comprised of three values: the date (represented as a number
+-- of the week), the start time and the end time. The dates span Monday-Friday, beging represented
+-- by 1-5 respectively. The start time and end time are numbers between 0-23.
 -- TODO: Change this datatype. This datatype shouldn't be implemented with
 -- a list, perhaps a tuple would be better.
 
@@ -201,7 +201,7 @@ instance FromJSON SvgJSON
 convertTimeToString :: Time -> [T.Text]
 convertTimeToString (Time [day, startNum, endNum]) =
   [T.pack . show $ (floor day :: Int),
-   T.replace "." "-" . T.pack . show $ startNum]
+   T.replace "." "-" . T.pack . show $ (show startNum ++ "-" ++ show endNum)]
 convertTimeToString _ = undefined
 
 
@@ -305,7 +305,7 @@ getDayVal "TH" = 3.0
 getDayVal "FR" = 4.0
 getDayVal _    = 4.0
 
--- | Takes a day and start/end times then generates a set of 30-minute timeslots
+-- | Takes a day and start/end times then generates a Time with the day and start/end times
 getTimeSlots :: Maybe String -> Maybe String -> Maybe String -> [Time]
 getTimeSlots (Just day) (Just start) (Just end) = do
     let dayDbl = getDayVal day

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -199,8 +199,6 @@ convertTimeToString :: Time -> [T.Text]
 convertTimeToString (Time day startNum endNum) =
   [T.pack . show $ (floor day :: Int),
    T.replace "." "-" . T.pack . show $ (show startNum ++ "-" ++ show endNum)]
-convertTimeToString _ = undefined
--- ToDo: remove "pattern match is redundant warning" for line 202.
 
 -- JSON encoding/decoding
 instance FromJSON Courses where

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -42,6 +42,8 @@ import WebParsing.ReqParser (parseReqs)
 -- by 1-5 respectively. The time is a number between 0-23.
 -- TODO: Change this datatype. This datatype shouldn't be implemented with
 -- a list, perhaps a tuple would be better.
+
+--data Time = Time { timeField :: (Double, Double, Double) } deriving (Show, Read, Eq, Generic)
 data Time = Time { timeField :: [Double] } deriving (Show, Read, Eq, Generic)
 derivePersistField "Time"
 
@@ -197,9 +199,9 @@ instance FromJSON SvgJSON
 -- uses the output in an element's ID, which is then later used in
 -- jQuery. @.@ is a jQuery meta-character, and must be removed from the ID.
 convertTimeToString :: Time -> [T.Text]
-convertTimeToString (Time [day, timeNum]) =
+convertTimeToString (Time [day, startNum, endNum]) =
   [T.pack . show $ (floor day :: Int),
-   T.replace "." "-" . T.pack . show $ timeNum]
+   T.replace "." "-" . T.pack . show $ startNum]
 convertTimeToString _ = undefined
 
 
@@ -309,5 +311,5 @@ getTimeSlots (Just day) (Just start) (Just end) = do
     let dayDbl = getDayVal day
         startDbl = getHourVal start
         endDbl = getHourVal end
-    [Time [dayDbl, timeDbl] | timeDbl <- [startDbl, (startDbl + 0.5) .. (endDbl - 0.5)]]
+    [Time [dayDbl, startDbl, endDbl]]
 getTimeSlots _ _ _ = []

--- a/app/Export/GetImages.hs
+++ b/app/Export/GetImages.hs
@@ -80,11 +80,11 @@ getScheduleByTime selectedMeetings mTimes =
 -- | Take a list of Time and returns a list of tuples that correctly index
 -- into the 2-D table (for generating the image)
 convertTimeToArray :: [Time] -> [(Int, Int)]
-convertTimeToArray = map (\x -> (floor $ head (timeField x), floor $ timeField x !! 1 - 8))
+convertTimeToArray = concatMap (\x -> [(day, start) | day <- [floor $ weekDay x], start <- [(floor $ startHour x)..(floor $ (endHour x - 0.5))]])
 
 addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Time]) -> [[[T.Text]]]
 addCourseToSchedule schedule (course, courseTimes) =
-  let time' = filter (\t-> mod' (timeField t !! 1) 1 == 0) courseTimes
+  let time' = filter (\t-> mod' (startHour t) 1 == 0) courseTimes
       timeArray = convertTimeToArray time'
   in foldl (addCourseHelper course) schedule timeArray
 

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -27,6 +27,7 @@ export class Row extends React.Component {
     let springColSpans = {'M': 0, 'T': 0, 'W': 0, 'R': 0, 'F': 0};
     storeColSpans(fallSession, fallColSpans);
     storeColSpans(springSession, springColSpans);
+    console.log(springSession)
 
     // Generate a container for each of the Fall and Spring timetables individually
     return (
@@ -120,7 +121,7 @@ class TimetableBody extends React.Component {
   render() {
     let rows = [];
     // For each row from 8 o'clock to 22 o'clock, there is an 'Hour' and 'Half hour' row
-    for (let i = 8; i < 22; i++) {
+    for (let i = 8; i < 22; i+=0.5) {
       rows.push(
         <TimetableRow
           session={this.props.session}
@@ -128,16 +129,6 @@ class TimetableBody extends React.Component {
           key={'timetable-row-' + i + this.props.session}
           currentLectures={this.props.lectures[i]}
           previousLectures={this.props.lectures[i-0.5]}
-          headColSpans={this.props.headColSpans}
-        />
-      );
-      rows.push(
-        <TimetableRow
-          session={this.props.session}
-          time={i+0.5}
-          key={'timetable-row-' + (i+0.5) + this.props.session}
-          currentLectures={this.props.lectures[i+0.5]}
-          previousLectures={this.props.lectures[i]}
           headColSpans={this.props.headColSpans}
         />
       );
@@ -311,27 +302,23 @@ class TimetableRow extends React.Component {
 function initializeSessions(lectures) {
   let fallSession = {};
   let springSession = {};
-  for (let i = 7; i < 22; i++) {
+  for (let i = 7; i < 22; i+=0.5) {
     fallSession[i] = {"M": [], "T": [], "W": [], "R": [], "F": []};
-    fallSession[i+0.5] = {"M": [], "T": [], "W": [], "R": [], "F": []};
     springSession[i] = {"M": [], "T": [], "W": [], "R": [], "F": []};
-    springSession[i+0.5] = {"M": [], "T": [], "W": [], "R": [], "F": []};
   }
 
   lectures.forEach(lecture => {
     if (lecture.session === 'F' || lecture.session === 'Y') {
-      for (let i = lecture.startTime; i < lecture.endTime; i++) {
+      for (let i = lecture.startTime; i < lecture.endTime; i+=0.5) {
         // Store this Lecture in its active time-slot (denoted by <i>),
         // and in the list in its active day slot (denoted by <lecture.day>), in <fallSession>.
         fallSession[i][lecture.day].push(lecture);
-        fallSession[i+0.5][lecture.day].push(lecture);
       }
     }
     if (lecture.session === 'S' || lecture.session === 'Y') {
       // Same process as above for spring lectures in <springSession>
-      for (let i = lecture.startTime; i < lecture.endTime; i++) {
+      for (let i = lecture.startTime; i < lecture.endTime; i+=0.5) {
         springSession[i][lecture.day].push(lecture);
-        springSession[i+0.5][lecture.day].push(lecture);
       }
     }
   });
@@ -345,7 +332,7 @@ function initializeSessions(lectures) {
  */
 function setWidths(session) {
   let days = ['M', 'T', 'W', 'R', 'F'];
-  for (let i = 8; i < 22; i++) {
+  for (let i = 8; i < 22; i+=0.5) {
     let timeRow = session[i];
     // Reset all widths back to 1 and inConflict to false if this time slot is the startTime of
     // the lecture
@@ -397,7 +384,7 @@ function storeWidths(session) {
   // Iterate through every time-day slot in the session
   days.forEach(day => {
     widths[day] = [];
-    for (let i = 8; i < 22; i++) {
+    for (let i = 8; i < 22; i+=0.5) {
       let timeRow = session[i];
       let timeDaySlot = timeRow[day];
       // If there are lectures running at this time-day slot

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -1,9 +1,9 @@
-/* Holds the containers of the Fall and Spring timetables,
- * and performs some pre-processing steps with a list of 'Lecture' objects
- */
 import React from 'react';
 
-
+/*
+ * Holds the containers of the Fall and Spring timetables,
+ * and performs some pre-processing steps with a list of 'Lecture' objects
+ */
 export class Row extends React.Component {
   render() {
     // Create a list of lecture objects

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -6,11 +6,11 @@ import React from 'react';
 
 export class Row extends React.Component {
   render() {
-    // From a list of Course objects, create a list of Lecture objects
-    let courses = this.props.courses;
+    let lectureSections = this.props.lectureSections;
+    // Create a list of lecture objects
     let lectures = [];
-    courses.forEach(course => {
-      lectures = lectures.concat(createNewCourse(course))
+    lectureSections.forEach(lectureSection => {
+      lectures = lectures.concat(createNewLectures(lectureSection))
     })
 
     // Organize the structure of the <fallSession> and <springSession> 2-D dictionaries
@@ -27,7 +27,6 @@ export class Row extends React.Component {
     let springColSpans = {'M': 0, 'T': 0, 'W': 0, 'R': 0, 'F': 0};
     storeColSpans(fallSession, fallColSpans);
     storeColSpans(springSession, springColSpans);
-    console.log(springSession)
 
     // Generate a container for each of the Fall and Spring timetables individually
     return (
@@ -189,7 +188,6 @@ class TimetableRow extends React.Component {
           currentLectureList.forEach(lecture => {
             // Check if this lecture has been previously rendered
             previousLectureList.forEach(lecturePrev => {
-              //if (lecturePrev.courseCode === lecture.courseCode){
               if (lecturePrev === lecture){
                 alreadyGenerated = true;
               }
@@ -409,23 +407,23 @@ function lectureConflict(courseList) {
   return courseList.length > 1;
 }
 
-  /**
-   * Constructor for a 'Course' object
-   * @param {Object} lecture : Represents a lecture with time periods in which the lecture
-   *                            takes place
-   * @return {array} An array of objects representing each disconnected time period the given
-   *                  lecture occurs in
-  */
-function createNewCourse(lecture) {
+/**
+ * Create a list of lecture objects representing each separate time a given lecture section takes place
+ * @param {Object} lectureSection : Represents a lecture section for a course with time periods in which the lecture
+ *                            takes place
+ * @return {array} An array of objects representing each disconnected time period the given
+ *                  lecture occurs in
+*/
+function createNewLectures(lectureSection) {
     let lectures = [];
     let days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
-    for (let i = 0; i < lecture.times.length; i++) {
+    for (let i = 0; i < lectureSection.times.length; i++) {
       let lectureObject = {
-        courseCode: lecture.courseCode,
-        session: lecture.session,
-        day: days[lecture.times[i].timeField[0]],
-        startTime: lecture.times[i].timeField[1],
-        endTime: lecture.times[i].timeField[2],
+        courseCode: lectureSection.courseCode,
+        session: lectureSection.session,
+        day: days[lectureSection.times[i].timeField[0]],
+        startTime: lectureSection.times[i].timeField[1],
+        endTime: lectureSection.times[i].timeField[2],
         inConflict: false,
         width: 1
       };

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -189,34 +189,21 @@ class TimetableRow extends React.Component {
           // from all the lectures generated
           totalColSpans += lecColSpan;
         });
-
-        // In the case where there are not enough cells to fill the headerColSpan
-        // of this time-day cell, generate remaining number of empty cells
-        for (let i = totalColSpans; i < headerColSpan; i++) {
-          tableData.push(
-            <td id={'' + day + currTime + '-0' + i + currSess}
-              key={'' + day + currTime + '-0' + i + currSess}
-              data-in-conflict="false"
-              data-satisfied="true"
-              rowSpan="1"
-              className="timetable-cell">
-            </td>
-          );
-        }
-      } else {
-        // No courses to be generated at this day-time cell
-        // Generate the number of empty cells to fill the header colSpan
-        for (let i = 0; i < headerColSpan; i++) {
-          tableData.push(
-            <td id={'' + day + currTime + '-0' + i + currSess}
-              key={'' + day + currTime + '-0' + i + currSess}
-              data-in-conflict="false"
-              data-satisfied="true"
-              rowSpan="1"
-              className="timetable-cell">
-            </td>
-          );
-        }
+      }
+      // In the case where there are not enough cells to fill the headerColSpan
+      // of this time-day cell or if there are no courses to be generated at this time-day cell,
+      // generate remaining number of empty cells
+      // Note: totalColSpans is 0 if there are no courses to be generated at this time-day cell
+      for (let i = totalColSpans; i < headerColSpan; i++) {
+        tableData.push(
+          <td id={'' + day + currTime + '-0' + i + currSess}
+            key={'' + day + currTime + '-0' + i + currSess}
+            data-in-conflict="false"
+            data-satisfied="true"
+            rowSpan="1"
+            className={currTime % 1 === 0 ? "timetable-cell-tophalf" : "timetable-cell-bottomhalf"}>
+          </td>
+        );
       }
     });
 

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -6,9 +6,8 @@ import React from 'react';
 
 export class Row extends React.Component {
   render() {
-    let lectureSections = this.props.lectureSections;
     // Create a list of lecture objects
-    let lectures = lectureSections.map(lectureSection => createNewLectures(lectureSection));
+    let lectures = this.props.lectureSections.map(lectureSection => createNewLectures(lectureSection));
     lectures = [].concat.apply([], lectures);
 
     // Organize the structure of the <fallSession> and <springSession> 2-D dictionaries
@@ -69,8 +68,8 @@ class Timetable extends React.Component {
  */
 class TimetableHeader extends React.Component {
   render() {
-    let days = ['M', 'T', 'W', 'R', 'F'];
-    let dayStrings = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+    const days = ['M', 'T', 'W', 'R', 'F'];
+    const dayStrings = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
     let colSpans = this.props.headColSpans;
 
     let dayCells = [];
@@ -128,7 +127,6 @@ class TimetableBody extends React.Component {
         />
       );
     }
-
     return <tbody>{rows}</tbody>;
   }
 }
@@ -140,23 +138,23 @@ class TimetableBody extends React.Component {
 class TimetableRow extends React.Component {
   render() {
     let tableData = [];
-    let days = ['M', 'T', 'W', 'R', 'F'];
-    let dummyCell = <td key="timetable-dummy-cell" className="timetable-dummy-cell"></td>;
-    let currTime = this.props.time;
-    let currSess = this.props.session;
+    const days = ['M', 'T', 'W', 'R', 'F'];
+    const dummyCell = <td key="timetable-dummy-cell" className="timetable-dummy-cell"></td>;
+    const currTime = this.props.time;
+    const currSess = this.props.session;
 
-    // The dictionary of lectures for this hour, and the hour before
-    let currentLectures = this.props.currentLectures;
-    let headColSpans = this.props.headColSpans;
+    // The dictionary of lectures for this hour
+    const currentLectures = this.props.currentLectures;
+    const headColSpans = this.props.headColSpans;
 
     days.forEach(day => {
       // Variables for calculations
-      let headerColSpan = headColSpans[day];
+      const headerColSpan = headColSpans[day];
       let totalColSpans = 0;
 
       // Get the list of lectures at this time-day slot, as well as the list of lectures
       // occuring one hour prior this time-day slot
-      let currentLectureList = currentLectures[day];
+      const currentLectureList = currentLectures[day];
 
       if (currentLectureList.length !== 0) {
         // Render every lecture at this day-time slot (there can be more than one in a conflict case)
@@ -165,10 +163,10 @@ class TimetableRow extends React.Component {
           // The 'colSpan' of the cells taken by this lecture, in this time-day slot
           // This should always be an integer value, since headerColSpan is the product of all
           // possible lecture widths in that day.
-          let lecColSpan = headerColSpan / lecture.width;
+          const lecColSpan = headerColSpan / lecture.width;
 
           if (lecture.startTime === currTime) {
-            let rowSpan = 2 * (lecture.endTime - lecture.startTime);
+            const rowSpan = 2 * (lecture.endTime - lecture.startTime);
             tableData.push(
               <td id={'' + day + currTime + '-0' + totalColSpans + currSess}
                 key={'' + day + currTime + '-0' + totalColSpans + currSess}
@@ -209,8 +207,8 @@ class TimetableRow extends React.Component {
 
     if (currTime % 1 === 0) {
       // Convert <time> to a 12-hour clock system
-      let adjustedTime = (currTime === 12 ? 12 : currTime % 12) + ':00';
-      let timeCell = <td key="timetable-time" className="timetable-time" rowSpan="2">{adjustedTime}</td>
+      const adjustedTime = (currTime === 12 ? 12 : currTime % 12) + ':00';
+      const timeCell = <td key="timetable-time" className="timetable-time" rowSpan="2">{adjustedTime}</td>
 
       // Adjust the order at which these cells are rendered
       if (currSess === 'F') {
@@ -268,13 +266,13 @@ function initializeSessions(lectures) {
  * @param {dictionary} session : 2-D Dictionary storing lectures active in the session
  */
 function setWidths(session) {
-  let days = ['M', 'T', 'W', 'R', 'F'];
+  const days = ['M', 'T', 'W', 'R', 'F'];
   for (let i = 8; i < 22; i+=0.5) {
-    let timeRow = session[i];
+    const timeRow = session[i];
     // Reset all widths back to 1 and inConflict to false if this time slot is the startTime of
     // the lecture
     days.forEach(day => {
-      let timeDaySlot = timeRow[day];
+      const timeDaySlot = timeRow[day];
       timeDaySlot.forEach(lecture => {
         // Do not set the width back to 1 if there is already a conflict (this situation applies to
         // 'Y' session lectures)
@@ -301,7 +299,7 @@ function setWidths(session) {
  * @param {dictionary} colSpans : Dictionary storing the 'colSpan' attribute value for each day
  */
 function storeColSpans(session, colSpans) {
-  let days = ['M', 'T', 'W', 'R', 'F'];
+  const days = ['M', 'T', 'W', 'R', 'F'];
   // For each day, stores all possible 'width' values every lecture at that day could have
   let widths = storeWidths(session);
   days.forEach(day => {
@@ -316,18 +314,18 @@ function storeColSpans(session, colSpans) {
  * @param {dictionary} session : 2-D Dictionary storing lectures active in the session
  */
 function storeWidths(session) {
-  let days = ['M', 'T', 'W', 'R', 'F'];
+  const days = ['M', 'T', 'W', 'R', 'F'];
   let widths = {};
   // Iterate through every time-day slot in the session
   days.forEach(day => {
     widths[day] = [];
     for (let i = 8; i < 22; i+=0.5) {
-      let timeRow = session[i];
-      let timeDaySlot = timeRow[day];
+      const timeRow = session[i];
+      const timeDaySlot = timeRow[day];
       // If there are lectures running at this time-day slot
       if (timeDaySlot.length > 0) {
         // Retrieve a lecture width at this time-day slot
-        let width = timeDaySlot[0].width;
+        const width = timeDaySlot[0].width;
         // Store the width of this lecture, if it hasn't already been stored
         if (widths[day].indexOf(width) < 0) {
           widths[day].push(width);
@@ -354,20 +352,18 @@ function lectureConflict(courseList) {
  *                  lecture occurs in
 */
 function createNewLectures(lectureSection) {
-    let lectures = [];
-    let days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
+  const days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
 
-    for (let i = 0; i < lectureSection.times.length; i++) {
-      let lectureObject = {
-        courseCode: lectureSection.courseCode,
-        session: lectureSection.session,
-        day: days[lectureSection.times[i].weekDay],
-        startTime: lectureSection.times[i].startHour,
-        endTime: lectureSection.times[i].endHour,
-        inConflict: false,
-        width: 1
-      };
-      lectures.push(lectureObject);
+  const lectures = lectureSection.times.map(time => {
+    return {
+      courseCode: lectureSection.courseCode,
+      session: lectureSection.session,
+      day: days[time.weekDay],
+      startTime: time.startHour,
+      endTime: time.endHour,
+      inConflict: false,
+      width: 1
     }
-    return lectures;
-  }
+  });
+  return lectures;
+}

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -68,17 +68,15 @@ class Timetable extends React.Component {
  */
 class TimetableHeader extends React.Component {
   render() {
-    const days = ['M', 'T', 'W', 'R', 'F'];
     const dayStrings = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
     let colSpans = this.props.headColSpans;
 
     let dayCells = [];
     for (let i = 0; i < 5; i++) {
-      let dayKey = days[i];
       let dayString = dayStrings[i];
       // Store the React element for this day-cell
       dayCells.push(
-        <th scope="col" colSpan={colSpans[dayKey]}
+        <th scope="col" colSpan={colSpans[i]}
           key={"day-header-" + i}>
           {dayString}
         </th>
@@ -138,7 +136,6 @@ class TimetableBody extends React.Component {
 class TimetableRow extends React.Component {
   render() {
     let tableData = [];
-    const days = ['M', 'T', 'W', 'R', 'F'];
     const dummyCell = <td key="timetable-dummy-cell" className="timetable-dummy-cell"></td>;
     const currTime = this.props.time;
     const currSess = this.props.session;
@@ -147,7 +144,7 @@ class TimetableRow extends React.Component {
     const currentLectures = this.props.currentLectures;
     const headColSpans = this.props.headColSpans;
 
-    days.forEach(day => {
+    for (let day = 0; day < 5; day++) {
       // Variables for calculations
       const headerColSpan = headColSpans[day];
       let totalColSpans = 0;
@@ -168,8 +165,8 @@ class TimetableRow extends React.Component {
           if (lecture.startTime === currTime) {
             const rowSpan = 2 * (lecture.endTime - lecture.startTime);
             tableData.push(
-              <td id={'' + day + currTime + '-0' + totalColSpans + currSess}
-                key={'' + day + currTime + '-0' + totalColSpans + currSess}
+              <td id={'' + day.toString() + currTime + '-0' + totalColSpans + currSess}
+                key={'' + day.toString() + currTime + '-0' + totalColSpans + currSess}
                 data-in-conflict={lecture.inConflict}
                 data-satisfied={"true"}
                 rowSpan={rowSpan}
@@ -194,8 +191,8 @@ class TimetableRow extends React.Component {
       // Note: totalColSpans is 0 if there are no courses to be generated at this time-day cell
       for (let i = totalColSpans; i < headerColSpan; i++) {
         tableData.push(
-          <td id={'' + day + currTime + '-0' + i + currSess}
-            key={'' + day + currTime + '-0' + i + currSess}
+          <td id={'' + day.toString() + currTime + '-0' + i + currSess}
+            key={'' + day.toString() + currTime + '-0' + i + currSess}
             data-in-conflict="false"
             data-satisfied="true"
             rowSpan="1"
@@ -203,7 +200,7 @@ class TimetableRow extends React.Component {
           </td>
         );
       }
-    });
+    }
 
     if (currTime % 1 === 0) {
       // Convert <time> to a 12-hour clock system
@@ -238,8 +235,8 @@ function initializeSessions(lectures) {
   let fallSession = {};
   let springSession = {};
   for (let i = 7; i < 22; i+=0.5) {
-    fallSession[i] = {"M": [], "T": [], "W": [], "R": [], "F": []};
-    springSession[i] = {"M": [], "T": [], "W": [], "R": [], "F": []};
+    fallSession[i] = {0: [], 1: [], 2: [], 3: [], 4: []};
+    springSession[i] = {0: [], 1: [], 2: [], 3: [], 4: []};
   }
 
   lectures.forEach(lecture => {
@@ -266,12 +263,11 @@ function initializeSessions(lectures) {
  * @param {dictionary} session : 2-D Dictionary storing lectures active in the session
  */
 function setWidths(session) {
-  const days = ['M', 'T', 'W', 'R', 'F'];
   for (let i = 8; i < 22; i+=0.5) {
     const timeRow = session[i];
     // Reset all widths back to 1 and inConflict to false if this time slot is the startTime of
     // the lecture
-    days.forEach(day => {
+    for (let day = 0; day < 5; day++) {
       const timeDaySlot = timeRow[day];
       timeDaySlot.forEach(lecture => {
         // Do not set the width back to 1 if there is already a conflict (this situation applies to
@@ -290,7 +286,7 @@ function setWidths(session) {
           lecture.inConflict = true;
         }
       });
-    });
+    }
   }
 }
 
@@ -299,14 +295,13 @@ function setWidths(session) {
  * @param {dictionary} colSpans : Dictionary storing the 'colSpan' attribute value for each day
  */
 function storeColSpans(session, colSpans) {
-  const days = ['M', 'T', 'W', 'R', 'F'];
   // For each day, stores all possible 'width' values every lecture at that day could have
   let widths = storeWidths(session);
-  days.forEach(day => {
+  for (let day = 0; day < 5; day++) {
     // The 'colSpan' attribute of a header day cell is defined as the product of all
     // possible widths that could occur at that day
     colSpans[day] = widths[day].reduce((a, b) => a * b, 1);
-  });
+  }
 }
 
 /**
@@ -314,10 +309,9 @@ function storeColSpans(session, colSpans) {
  * @param {dictionary} session : 2-D Dictionary storing lectures active in the session
  */
 function storeWidths(session) {
-  const days = ['M', 'T', 'W', 'R', 'F'];
   let widths = {};
   // Iterate through every time-day slot in the session
-  days.forEach(day => {
+  for (let day = 0; day < 5; day++) {
     widths[day] = [];
     for (let i = 8; i < 22; i+=0.5) {
       const timeRow = session[i];
@@ -332,7 +326,7 @@ function storeWidths(session) {
         }
       }
     }
-  });
+  }
   return widths;
 }
 
@@ -352,13 +346,11 @@ function lectureConflict(courseList) {
  *                  lecture occurs in
 */
 function createNewLectures(lectureSection) {
-  const days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
-
   const lectures = lectureSection.times.map(time => {
     return {
       courseCode: lectureSection.courseCode,
       session: lectureSection.session,
-      day: days[time.weekDay],
+      day: time.weekDay,
       startTime: time.startHour,
       endTime: time.endHour,
       inConflict: false,

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { Modal } from '../common/react_modal.js.jsx';
 
+/**
+ * Holds courses selected from the search bar, and lists of their F, S and Y lecture, tutorial,
+ * and practical sections.
+ */
 export class CoursePanel extends React.Component {
   constructor(props) {
     super(props);
     this.clearAllCourses = this.clearAllCourses.bind(this);
   }
 
+  // Only clear all selected courses if the user confirms in the alert
+  // pop up window.
   clearAllCourses() {
     if (window.confirm("Clear all selected courses?")) {
       this.props.clearCourses();
@@ -35,6 +41,12 @@ export class CoursePanel extends React.Component {
   }
 }
 
+/**
+ * A selected course with a delete button, and info button, which displays information
+ * about the course when clicked.
+ * Also retrieves the course information. It holds list of F, S and Y lecture, tutorial
+ * and practical sections for the course.
+ */
 class Course extends React.Component {
   constructor(props) {
     super(props);
@@ -47,6 +59,7 @@ class Course extends React.Component {
     this.removeCourse = this.removeCourse.bind(this);
     this.parseLectures = this.parseLectures.bind(this);
     this.displayInfo = this.displayInfo.bind(this);
+    this.containsSelectedLecture = this.containsSelectedLecture.bind(this);
   }
 
   componentDidMount() {
@@ -108,6 +121,17 @@ class Course extends React.Component {
     this.modal.openModal(this.state.courseInfo.courseCode.substring(0, 6));
   }
 
+  containsSelectedLecture() {
+    // Only use method subString on the value of this.state.courseInfo.courseCode if
+    // if the this.state.courseInfo.courseCode exists (ie the course information has already been fetched)
+    if (this.state.courseInfo.courseCode) {
+      const lectures = this.props.selectedLectures.map(lecture => lecture.courseCode.substring(0, 6));
+      const courseCode = (this.state.courseInfo.courseCode)
+      return lectures.indexOf(courseCode.substring(0, 6)) >= 0;
+    }
+    return false;
+  }
+
   render() {
     return (
       <li key={this.props.courseCode} id={this.props.courseCode + "-li"} className={"ui-accordion ui-widget ui-helper-reset"}>
@@ -118,7 +142,7 @@ class Course extends React.Component {
             <img src="static/res/ico/delete.png" className="close-icon" onClick={this.removeCourse}/>
             <img src="static/res/ico/about.png" className="close-icon" onClick={this.displayInfo}/>
           </div>
-          <h3 onClick={this.toggleSelect}>
+          <h3 onClick={this.toggleSelect} data-satisfied="true" taken={this.containsSelectedLecture() ? "true" : "false"}>
             {this.props.courseCode}
           </h3>
         </div>
@@ -150,6 +174,10 @@ class Course extends React.Component {
   }
 }
 
+/**
+ * A list of lecture, tutorial and practical sections for the specified course for the specified
+ * session.
+ */
 class SectionList extends React.Component {
   render() {
     const lectureSections = this.props.lectures.map(lecture =>
@@ -168,6 +196,10 @@ class SectionList extends React.Component {
   }
 }
 
+/**
+ * A lecture, tutorial or practical section for the specified course in the specified
+ * session. The section is added to or removed from a list of selected lecture upon click.
+ */
 class LectureSection extends React.Component {
   constructor(props) {
     super(props);

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -66,7 +66,6 @@ class Course extends React.Component {
     let allLectures = removeDuplicateLectures(lectures);
     let parsedLectures = [];
 
-    let days = {0: 'M', 1: 'T', 2: 'W', 3: 'R', 4: 'F'};
     // Loop through the lecture sections to get each section's session code and lecture times
     allLectures.forEach( lectureInfo => {
       // Check to make sure its not a restricted section. Restricted sections have enrollment
@@ -74,39 +73,11 @@ class Course extends React.Component {
       // lecture/tutorial section.
       if (lectureInfo.section.charAt(3) !== '2' && lectureInfo.times !== 'Online Web Version') {
         let lecture = {
-          courseName: lectureInfo.code.substring(0, 6) + " (" + lectureInfo.section.substring(0,1) + ")",
+          courseCode: lectureInfo.code.substring(0, 6) + " (" + lectureInfo.section.substring(0,1) + ")",
           lectureCode: lectureInfo.section.substring(0, 1) + lectureInfo.section.substring(3),
-          times: {}
+          session: lectureInfo.session,
+          times: lectureInfo.times
         };
-        let allTimes = lectureInfo.times;
-        // The times in the original data are arrays of form [day, startTime], where day is an integer
-        // between 0 and 4 that corresponds to days Monday to Friday. Eg: [0, 14] is a Monday lecture that
-        // starts are 2PM. Every half hour is an individual array.
-        // Loop through each individual time array and add the start time to the corresponding day.
-        allTimes.forEach( time => {
-          let day = days[(time.timeField[0])];
-          if (!lecture.times[day]) {
-            lecture.times[day] = [time.timeField[1]];
-          }
-          else {
-            lecture.times[day].push(time.timeField[1]);
-          }
-        });
-        // Loop through each day of the week and remove the half hour increments.
-        // Only keep start time and end time in the array.
-        for (let weekday in lecture.times) {
-          let times = []
-          if (lecture.times.hasOwnProperty(weekday)) {
-            times.push(lecture.times[weekday][0]);
-            for (let hour = 1; hour < lecture.times[weekday].length; hour++) {
-              if (hour+1 >= lecture.times[weekday].length ||
-                lecture.times[weekday][hour+1] !== lecture.times[weekday][hour] + 0.5) {
-                times.push(lecture.times[weekday][hour] + 0.5);
-              }
-            }
-            lecture.times[weekday] = times;
-          }
-        }
         parsedLectures.push(lecture);
       }
     });
@@ -195,15 +166,14 @@ class LectureSection extends React.Component {
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
     let sameLecture = this.props.selectedLectures.filter((lecture) => {
-      return lecture.course === this.props.lecture.courseName && lecture.session === this.props.session &&
+      return lecture.courseCode === this.props.lecture.courseCode && lecture.session === this.props.session &&
         lecture.lectureCode === this.props.lecture.lectureCode
     });
     // If sameLecture is not an empty array, then this lecture is already selected and should be removed
     if (sameLecture.length > 0) {
-      this.props.removeSelectedLecture(this.props.lecture.courseName, this.props.session);
+      this.props.removeSelectedLecture(this.props.lecture.courseCode, this.props.session);
     } else {
-      this.props.addSelectedLecture(this.props.lecture.courseName, this.props.session,
-                                    this.props.lecture.lectureCode, this.props.lecture.times);
+      this.props.addSelectedLecture(this.props.lecture);
     }
   }
 

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -63,7 +63,7 @@ class Course extends React.Component {
 
   parseLectures(lectures) {
     // Remove duplicated lecture sections
-    let allLectures = removeDuplicateLectures(lectures);
+    const allLectures = removeDuplicateLectures(lectures);
     let parsedLectures = [];
 
     // Loop through the lecture sections to get each section's session code and lecture times
@@ -165,7 +165,7 @@ class LectureSection extends React.Component {
   // Check whether the course is already in the selectCourses list.
   // Remove the course if it is, or add the course if it is not.
   selectLecture() {
-    let sameLecture = this.props.selectedLectures.filter((lecture) => {
+    const sameLecture = this.props.selectedLectures.filter((lecture) => {
       return lecture.courseCode === this.props.lecture.courseCode && lecture.session === this.props.session &&
         lecture.lectureCode === this.props.lecture.lectureCode
     });

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -5,7 +5,10 @@ import { CoursePanel } from './course_panel.js.jsx';
 import { SearchPanel } from './search_panel.js.jsx';
 import { Row } from './calendar.js.jsx';
 
-
+/**
+ * Renders the course panel, the Fall and Spring timetable grids and search panel.
+ * Also keeps track of all the selected courses and lectures.
+ */
 class Grid extends React.Component {
   constructor(props) {
     super(props);

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -20,8 +20,6 @@ class Grid extends React.Component {
 
     this.addSelectedLecture = this.addSelectedLecture.bind(this);
     this.removeSelectedLecture = this.removeSelectedLecture.bind(this);
-    this.createNewCourse = this.createNewCourse.bind(this);
-    this.createNewLecture = this.createNewLecture.bind(this);
   }
 
   // get the previously selected courses and lecture sections from local storage
@@ -82,7 +80,7 @@ class Grid extends React.Component {
     this.setState({selectedCourses: updatedCourses});
 
     let updatedLectures = this.state.selectedLectures.filter(lecture =>
-                          !lecture.course.includes(courseCode.substring(0, 6)));
+                          !lecture.courseCode.includes(courseCode.substring(0, 6)));
     this.setState({selectedLectures: updatedLectures});
   }
 
@@ -95,76 +93,21 @@ class Grid extends React.Component {
   }
 
   // Method passed to child component CoursePanel to add a lecture to selectedLectures
-  addSelectedLecture(courseCode, session, lectureCode, lectureTimes) {
+  addSelectedLecture(newLecture) {
     // The maximum number of courses in the lecture list with the same code is 3, one for each session (F, S, Y)
     let updatedLectures = this.state.selectedLectures.filter((lecture) => {
-      return lecture.course !== courseCode || lecture.session !== session
+      return lecture.courseCode !== newLecture.courseCode || lecture.session !== newLecture.session
     });
-    let lectureSession = this.createNewCourse(courseCode, session, lectureCode, lectureTimes);
-    updatedLectures.push(lectureSession);
+    updatedLectures.push(newLecture);
     this.setState({selectedLectures: updatedLectures});
   }
 
   // Method passed to child component CoursePanel to remove a lecture from selectedLectures
   removeSelectedLecture(courseCode, session) {
     let updatedLectures = this.state.selectedLectures.filter((lecture) => {
-      return lecture.course !== courseCode || lecture.session !== session
+      return lecture.courseCode !== courseCode || lecture.session !== session
     });
     this.setState({selectedLectures: updatedLectures})
-  }
-
-  /**
-   * Constructor for a 'Course' object
-   * @param {string} courseCode : Name of course
-   * @param {string} session : Session of course
-   * @param {dictionary} times : The days, and corresponding time-slot for which
-                                  this course is active
-   * @return {dictionary} Represents a 'Course' object
-  */
-  createNewCourse(courseCode, session, lectureCode, times) {
-    let lectures = {};
-    let days = [];
-    // Store the active days of this Course, and for each active
-    // day, create and store a 'Lecture' object
-    for (let day in times) {
-      days.push(day);
-      lectures[day] = [];
-      // For the case where this lecture starts and ends more than once in one day
-      for(let i = 0; i < times[day].length; i+=2){
-        let startEndTimes = [times[day][i], times[day][i+1]];
-        lectures[day].push(this.createNewLecture(courseCode, session, day, startEndTimes));
-      }
-    }
-    let courseObject = {};
-    courseObject.course = courseCode;
-    courseObject.lectureCode = lectureCode;
-    courseObject.session = session;
-    courseObject.days = days;
-    courseObject.lectures = lectures;
-    return courseObject;
-  }
-
-  /**
-   * Constructor for a 'Lecture' object. Represents a single period of time
-   * in which this course is active. (for ex; on Monday from 2-4)
-   * @param {string} courseCode : Name of Lecture
-   * @param {string} session : Session of Lecture
-   * @param {string} day: Day of activity
-   * @param {list} timePeriod : Active start and end time
-   * @return {dictionary} Represents a 'Lecture' object
-  */
-  createNewLecture(courseCode, session, day, timePeriod) {
-    let lectureObject = {};
-    lectureObject.courseCode = courseCode;
-    lectureObject.session = session;
-    lectureObject.day = day;
-    lectureObject.startTime = timePeriod[0];
-    lectureObject.endTime = timePeriod[1];
-    lectureObject.inConflict = false;
-    // The width of a lecture is the maximum number of conflicts it has while it's active;
-    //  if there are no conflicts, the width is 1.
-    lectureObject.width = 1;
-    return lectureObject;
   }
 
   render() {

--- a/js/components/grid/grid.js.jsx
+++ b/js/components/grid/grid.js.jsx
@@ -121,7 +121,7 @@ class Grid extends React.Component {
           addSelectedLecture={this.addSelectedLecture}
           removeSelectedLecture={this.removeSelectedLecture}
         />
-        <Row courses={this.state.selectedLectures}/>
+        <Row lectureSections={this.state.selectedLectures}/>
         <SearchPanel
           selectedCourses={this.state.selectedCourses}
           selectCourse={this.addSelectedCourse}

--- a/js/components/grid/search_panel.js.jsx
+++ b/js/components/grid/search_panel.js.jsx
@@ -127,7 +127,7 @@ class CourseEntry extends React.Component {
   }
 
   render() {
-    let classes = this.props.selectedCourses.indexOf(this.props.course) != -1 ? 'starred-course' : '';
+    const classes = this.props.selectedCourses.indexOf(this.props.course) != -1 ? 'starred-course' : '';
     return (
       <li id={this.props.course + '-search'}
           className={classes}


### PR DESCRIPTION
A list of Times with the format [day, time], where time is every half hour that a given lecture runs is no longer being generated. The Time data type is now a record with fields weekDay, startHour and endHour.

Because of this, the code to parse lecture times to obtain lecture start and end times after fetching the course data is removed since it is no longer necessary. 
Also removed the creation of Course Objects (has the lectures attribute with a list of lecture objects) when a lecture is selected. Now, just generate the list of lecture objects after in lecture is selected (happens in component Row) without generating the Course object.

TimetableRow is modified to allow for lectures that begin and/or end on a half hour. 

![beginendhalf](https://user-images.githubusercontent.com/33272137/43759297-d5227d42-99ec-11e8-8ca3-026185a93157.png)