### PR TITLE
react-grid: Add table Times in database

### DIFF
--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -113,6 +113,26 @@ buildCourse fall spring year course = do
            (coursesCoreqs course)
            (coursesVideoUrls course)
 
+-- buildMeeting :: Meeting -> SqlPersistM MeetingData
+-- buildMeeting meeting = do
+--     allMeetingTimes <- getMeetingTimes (meetingTimes meeting)
+--     return $ MeetingData (meetingCode meeting)
+--         (meetingSession meeting)
+--         (meetingSection meeting)
+--         allMeetingTimes
+--         (meetingCap meeting)
+--         (meetingInstructor meeting)
+--         (meetingEnrol meeting)
+--         (meetingWait meeting)
+--         (meetingExtra meeting)
+--         (meetingTimeStr meeting)
+--         (meetingRoom meeting)
+
+-- getMeetingTimes :: Maybe [TimeId] -> SqlPersistM (Maybe [Time])
+-- getMeetingTimes Nothing = return Nothing
+-- getMeetingTimes (Just keys) = do
+--     maybeMeetingTimes <- map (\key -> entityVal (get key)) keys
+--     return $ fmap meetingTimes maybeMeetingTimes
 
 getDescriptionB :: Maybe (Key Breadth) -> SqlPersistM (Maybe T.Text)
 getDescriptionB Nothing = return Nothing

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -33,7 +33,6 @@ import Database.DataType
 import Svg.Builder
 import Control.Monad
 
-
 -- | Queries the database for all matching lectures, tutorials,
 --   or praticals of this course and construct MeetTimes with the
 --   Times corresponding to each lecture, tutorial or practial.
@@ -136,7 +135,6 @@ getDescriptionD (Just key) = do
     maybeDistribution <- get key
     return $ fmap distributionDescription maybeDistribution
 
-
 -- Filter each meeting's time here and construct session
 buildSession :: [MeetTimes] -> Tables.SessionTimes
 buildSession meetings =
@@ -151,7 +149,6 @@ buildMeetTimes meet = do
     allTimes :: [Entity Times] <- selectList [TimesMeeting ==. Just (entityKey meet)] []
     let allMeetingTimes = fmap entityVal allTimes
     return $ Tables.MeetTimes {meetingData = (entityVal meet), timesData = allMeetingTimes}
-
 
 -- ** Other queries
 

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -167,6 +167,7 @@ data SvgJSON =
               paths :: [Path]
             } deriving (Show, Generic)
 
+-- change session to be lectures :: [(Meeting, [Times])], or perhaps MeetingTimes {meeting:: Meeting, times :; [Times]}
 data Session =
     Session { lectures :: [Meeting],
               tutorials :: [Meeting],

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -277,11 +277,14 @@ instance FromJSON Meeting where
 
 instance FromJSON Times where
   parseJSON = withObject "Expected Object for Times"$ \o -> do
-    meetingDay <- o .:? "meetingDay"
-    meetingStartTime <- o .:? "meetingStartTime"
-    meetingEndTime <- o .:? "meetingEndTime"
-    meetingRoom1 <- o .:? "assignedRoom1"
-    meetingRoom2 <- o .:? "assignedRoom2"
+    meetingDayStr <- o .:? "meetingDay" .!= "5.0"
+    meetingStartTimeStr <- o .:? "meetingStartTime" .!= "5.0"
+    meetingEndTimeStr <- o .:? "meetingEndTime" .!= "5.0"
+    meetingRoom1 <- o .:? "assignedRoom1" .!= Nothing
+    meetingRoom2 <- o .:? "assignedRoom2" .!= Nothing
+    let meetingDay = readMaybe meetingDayStr
+        meetingStartTime = readMaybe meetingStartTimeStr
+        meetingEndTime = readMaybe meetingEndTimeStr
     let (dayDbl, startDbl, endDbl) = getTimeDbls meetingDay meetingStartTime meetingEndTime
     return $ Times dayDbl startDbl endDbl Nothing meetingRoom1 meetingRoom2
 
@@ -331,6 +334,7 @@ getDayVal "TH" = 3.0
 getDayVal "FR" = 4.0
 getDayVal _    = 4.0
 
+-- | Takes a string representation of the weekday, start time and end time, and convert them to a tuple of doubles
 getTimeDbls :: Maybe String -> Maybe String -> Maybe String -> (Double, Double, Double)
 getTimeDbls (Just day) (Just start) (Just end) = do
     let dayDbl = getDayVal day
@@ -338,7 +342,6 @@ getTimeDbls (Just day) (Just start) (Just end) = do
         endDbl = getHourVal end
     (dayDbl, startDbl, endDbl)
 getTimeDbls _ _ _ = (5.0, 5.0, 5.0)
-
 
 -- | Takes a day and start/end times then generates a Time with the day and start/end times
 getTimeSlots :: Maybe String -> Maybe String -> Maybe String -> [Time]

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -37,7 +37,6 @@ import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 import Control.Applicative ((<|>))
 
-
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
 derivePersistField "Room"
 
@@ -162,6 +161,7 @@ data SvgJSON =
 data MeetTimes = MeetTimes { meetingData :: Meeting, timesData :: [Times] }
   deriving (Show, Generic)
 
+-- | Lists of MeetTimes for a particular course split up by lecture, tutorial and practical.
 data SessionTimes =
     SessionTimes { lectures :: [MeetTimes],
               tutorials :: [MeetTimes],

--- a/app/Export/GetImages.hs
+++ b/app/Export/GetImages.hs
@@ -64,14 +64,14 @@ list2tuple _ = undefined
 
 -- | Queries the database for times regarding all meetings (i.e. lectures, tutorials and praticals),
 -- returns a list of list of Time.
-getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Time]]
+getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Times]]
 getTimes selectedMeetings = runSqlite databasePath $
   mapM getMeetingTime selectedMeetings
 
 -- | Creates a schedule.
 -- It takes information about meetings (i.e. lectures, tutorials and praticals) and their corresponding time.
 -- Courses are added to schedule, based on their days and times.
-getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Time]] -> [[[T.Text]]]
+getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Times]] -> [[[T.Text]]]
 getScheduleByTime selectedMeetings mTimes =
   let meetingTimes_ = zip selectedMeetings mTimes
       schedule = replicate 13 $ replicate 5 []
@@ -79,12 +79,12 @@ getScheduleByTime selectedMeetings mTimes =
 
 -- | Take a list of Time and returns a list of tuples that correctly index
 -- into the 2-D table (for generating the image)
-convertTimeToArray :: [Time] -> [(Int, Int)]
-convertTimeToArray = concatMap (\x -> [(day, start) | day <- [floor $ weekDay x], start <- [(floor $ startHour x)..(floor $ (endHour x - 0.5))]])
+convertTimeToArray :: [Times] -> [(Int, Int)]
+convertTimeToArray = concatMap (\x -> [(day, start) | day <- [floor $ timesWeekDay x], start <- [(floor $ timesStartHour x)..(floor $ (timesEndHour x - 0.5))]])
 
-addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Time]) -> [[[T.Text]]]
+addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Times]) -> [[[T.Text]]]
 addCourseToSchedule schedule (course, courseTimes) =
-  let time' = filter (\t-> mod' (startHour t) 1 == 0) courseTimes
+  let time' = filter (\t-> mod' (timesStartHour t) 1 == 0) courseTimes
       timeArray = convertTimeToArray time'
   in foldl (addCourseHelper course) schedule timeArray
 

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -11,7 +11,7 @@ import Database.Persist.Sqlite (runSqlite, (==.), entityVal, selectList, entityK
 import Database.CourseQueries (returnMeeting)
 import qualified Data.Text as T
 import Text.Read (readMaybe)
-import Database.Tables hiding (Session)
+import Database.Tables
 import Config (firstMondayFall,
                lastWednesdayFall,
                firstMondayWinter,

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -7,7 +7,7 @@ import Data.Ord (comparing)
 import Data.Time (Day, addDays, formatTime, getCurrentTime, defaultTimeLocale)
 import Happstack.Server (ServerPart, Response, toResponse)
 import Control.Monad.IO.Class (liftIO)
-import Database.Persist.Sqlite (runSqlite)
+import Database.Persist.Sqlite (runSqlite, (==.), entityVal, selectList, entityKey)
 import Database.CourseQueries (returnMeeting)
 import qualified Data.Text as T
 import Text.Read (readMaybe)
@@ -69,24 +69,25 @@ getCoursesInfo courses = map courseInfo allCourses
         allCourses = map (T.splitOn "-") (T.splitOn "_" courses)
 
 -- | Pulls either a Lecture, Tutorial or Pratical from the database.
-pullDatabase :: (Code, Section, Session) -> IO (Maybe Meeting)
-pullDatabase (code, section, session) = runSqlite databasePath $
-    returnMeeting code fullSection session
+pullDatabase :: (Code, Section, Session) -> IO (MeetTimes)
+pullDatabase (code, section, session) = runSqlite databasePath $ do
+    meet <- returnMeeting code fullSection session
+    allTimes <- selectList [TimesMeeting ==. Just (entityKey meet)] []
+    return $ MeetTimes {meetingData = (entityVal meet), timesData = map entityVal allTimes}
     where
-        fullSection
-            | T.isPrefixOf "L" section = T.append "LEC" sectCode
-            | T.isPrefixOf "T" section = T.append "TUT" sectCode
-            | T.isPrefixOf "P" section = T.append "PRA" sectCode
-            | otherwise                = section
-        sectCode = T.tail section
+    fullSection
+        | T.isPrefixOf "L" section = T.append "LEC" sectCode
+        | T.isPrefixOf "T" section = T.append "TUT" sectCode
+        | T.isPrefixOf "P" section = T.append "PRA" sectCode
+        | otherwise                = section
+    sectCode = T.tail section
 
 -- | The current date and time as obtained from the system.
 type SystemTime = String
 
 -- | Creates all the events for a course.
-getEvents :: SystemTime -> Maybe Meeting -> Events
-getEvents _ Nothing = []
-getEvents systemTime (Just lect) =
+getEvents :: SystemTime -> MeetTimes -> Events
+getEvents systemTime (lect) =
     concatMap eventsByDate (zip' (third courseInfo)
                                  (fourth courseInfo)
                                  (fifth courseInfo))
@@ -120,16 +121,17 @@ type DatesByDay = [(StartDate, EndDate)]
 
 -- | Obtains all the necessary information to create events for a course,
 -- such as code, section, start times, end times and dates.
-getCourseInfo :: Meeting
-              -> (Code, Section, StartTimesByDay, EndTimesByDay, DatesByDay)
-getCourseInfo meeting = (code, sect, start, end, dates)
-    where
-        code = meetingCode meeting
-        sect = meetingSection meeting
-        dataInOrder = orderTimeFields $ meetingTimes meeting
-        start = startTimesByCourse dataInOrder (meetingSession meeting)
-        end = endTimesByCourse dataInOrder (meetingSession meeting)
-        dates = getDatesByCourse dataInOrder (meetingSession meeting)
+getCourseInfo :: MeetTimes -> (Code, Section, StartTimesByDay, EndTimesByDay, DatesByDay)
+getCourseInfo meeting =
+    let meet = meetingData meeting
+        allTimes = timesData meeting
+        code = meetingCode meet
+        sect = meetingSection meet
+        dataInOrder = orderTimeFields allTimes
+        start = startTimesByCourse dataInOrder (meetingSession meet)
+        end = endTimesByCourse dataInOrder (meetingSession meet)
+        dates = getDatesByCourse dataInOrder (meetingSession meet)
+    in (code, sect, start, end, dates)
 
 -- ** Functions that deal with tuples
 
@@ -164,13 +166,13 @@ fifth (_, _, _, _, dates) = dates
 -- ** Ordering data
 
 -- | A list of the information within the time fields ordered by day.
-type InfoTimeFieldsByDay = [[Time]]
+type InfoTimeFieldsByDay = [[Times]]
 
 -- | Orders by day the start and endtimes obtained from the database.
-orderTimeFields :: [Time] -> InfoTimeFieldsByDay
-orderTimeFields timeFields = groupBy (\x y -> weekDay x == weekDay y) sortedList
+orderTimeFields :: [Times] -> InfoTimeFieldsByDay
+orderTimeFields timeFields = groupBy (\x y -> timesWeekDay x == timesWeekDay y) sortedList
     where
-        sortedList = sortBy (comparing weekDay) timeFields
+        sortedList = sortBy (comparing timesWeekDay) timeFields
 
 -- ** Start time
 
@@ -185,7 +187,7 @@ startTime :: InfoTimeFieldsByDay -> StartTimesByDay
 startTime =
     map (\dataByDay -> map formatTimes (timesOrdered dataByDay))
     where
-        timesOrdered dataDay = sort $ map startHour dataDay
+        timesOrdered dataDay = sort $ map timesStartHour dataDay
 
 -- ** End time
 
@@ -200,7 +202,7 @@ endTime :: InfoTimeFieldsByDay -> EndTimesByDay
 endTime =
     map (\dataByDay -> map formatTimes (timesOrdered dataByDay))
     where
-        timesOrdered dataDay = sort $ map endHour dataDay
+        timesOrdered dataDay = sort $ map timesEndHour dataDay
 
 -- ** Functions that work for both start and end times
 
@@ -247,10 +249,10 @@ type EndDate = String
 
 -- | Gives the appropiate starting and ending dates for each day,in which the
 -- course takes place, depending on the course session.
-getDatesByDay :: Session -> [Time] -> (StartDate, EndDate)
+getDatesByDay :: Session -> [Times] -> (StartDate, EndDate)
 getDatesByDay session dataByDay
-    | session ==  "F" = formatDates $ getDatesFall $ weekDay $ head dataByDay
-    | otherwise = formatDates $ getDatesWinter $ weekDay $ head dataByDay
+    | session ==  "F" = formatDates $ getDatesFall $ timesWeekDay $ head dataByDay
+    | otherwise = formatDates $ getDatesWinter $ timesWeekDay $ head dataByDay
 
 -- | Formats the date in the following way: YearMonthDayT.
 -- For instance, 20150720T corresponds to July 20th, 2015.

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -50,7 +50,6 @@ insertAllMeetings org = do
 
 -- | Store a meeting's data and times.
 insertMeeting :: MeetTimes -> SqlPersistM ()
--- insertMeeting meet{meetingData = meetData, timesData = meetTimes} = do
 insertMeeting meet = do
     -- Check that the meeting belongs to a course that exists
     let code = meetingCode $ meetingData meet

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -3,16 +3,17 @@ module WebParsing.UtsgJsonParser
       getOrgs,
       insertAllCourses) where
 
-import Data.Aeson ((.:?), (.!=), decode, FromJSON(parseJSON), Value(..), Object)
+import Data.Aeson ((.:?), (.!=), decode, FromJSON(parseJSON), Value(..), Object, withObject)
 import Data.Maybe (catMaybes)
 import qualified Data.Text as T
 import qualified Data.HashMap.Strict as HM
 import Control.Monad.IO.Class (liftIO)
 import Network.HTTP.Conduit (simpleHttp)
 import Config (databasePath)
-import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..))
+import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), EntityField(MeetingCode), EntityField(MeetingSection), EntityField(MeetingSession), Times(..))
 import Database.Persist.Sqlite (runSqlite, insert_, SqlPersistM, selectKeysList, (==.))
 import Database.Persist.Class (Key)
+--import Text.Parsec.Text (Parser)
 
 
 -- | URLs for the Faculty of Arts and Science API
@@ -47,7 +48,7 @@ insertAllCourses org = do
         -- only sections are currently stored here.
         (_, sections) = unzip courseData
         meetings = concat sections
-    mapM_ insertCourse meetings
+    mapM_ insertMeeting meetings
 
 getCourseKey :: T.Text -> SqlPersistM (Maybe (Key Courses))
 getCourseKey code = do
@@ -56,35 +57,81 @@ getCourseKey code = do
         [] -> Nothing
         _ -> Just (head keyListCourse)
 
-insertCourse :: Meeting -> SqlPersistM ()
-insertCourse meet = do
-    courseKey <- getCourseKey (meetingCode meet)
+
+getMeetingKey :: T.Text -> T.Text -> T.Text -> SqlPersistM (Maybe (Key Meeting))
+getMeetingKey meetCode meetSession meetSection = do
+  keyListMeeting :: [Key Meeting] <- selectKeysList [ (MeetingCode ==. meetCode), (MeetingSection ==. meetSection), (MeetingSession ==. meetSession)] []
+  return $ case keyListMeeting of
+    [] -> Nothing
+    _ -> Just (head keyListMeeting)
+
+insertMeeting :: MeetingTimes -> SqlPersistM ()
+insertMeeting meet = do
+    let meetingInfo = meetingData meet
+    courseKey <- getCourseKey (meetingCode meetingInfo)
     case courseKey of
-        Just _ -> insert_ meet
+        Just _ -> do
+          insert_ meetingInfo
+          meetingKey <- getMeetingKey (meetingCode meetingInfo) (meetingSession meetingInfo) (meetingSection meetingInfo)
+          case meetingKey of
+              Just _ -> do
+                mapM_ (\t -> insert_ $ t {timesMeeting = meetingKey}) $ times meet
+              Nothing -> return ()
         Nothing -> return ()
 
-newtype DB = DB { dbData :: (Courses, [Meeting]) }
+
+newtype DB = DB { dbData :: (Courses, [MeetingTimes]) }
   deriving Show
+
+-- parseMeetingTimes :: Value -> Parser (Meeting, [AllTimes])
+-- parseMeetingTimes (Object obj) = do
+--     meetingData <- parseJSON(Object obj)
+--     timeMap :: HM.HashMap T.Text AllTimes <- o .:? "schedule" .!= HM.empty
+--     return (meetingData, timeMap)
+-- parseMeetingTimes _ = return (Nothing, [])
+
+parseMeetingTimes:: (T.Text, T.Text, Meeting, [Times]) -> MeetingTimes
+parseMeetingTimes (code, session, meetTimes, allTimes) =
+    MeetingTimes {meetingData = meetTimes {meetingCode = code, meetingSession = session}, times = allTimes }
 
 instance FromJSON DB where
     parseJSON (Object o) = do
       course <- parseJSON (Object o)
       session :: T.Text <- o .:? "section" .!= "F"
-      meetingMap :: HM.HashMap T.Text Meetings <- o .:? "meetings" .!= HM.empty
-      let meetings = map (setCode (coursesCode course) session . meeting) (HM.elems meetingMap)
+      meetingTimesMap :: HM.HashMap T.Text MeetingTimes <- o .:? "meetings" .!= HM.empty
+      let allMeetingsTimes = map (\meetTime -> parseMeetingTimes ((coursesCode course), session, (meetingData meetTime), (times meetTime))) (HM.elems meetingTimesMap)
           -- Fix manualTutorialEnrolment and manualPracticalEnrolment
-          manTut = any (T.isPrefixOf "TUT" . meetingSection) meetings
-          manPra = any (T.isPrefixOf "PRA" . meetingSection) meetings
+          manTut = any (T.isPrefixOf "TUT" . meetingSection) $ map (\m -> meetingData m) allMeetingsTimes
+          manPra = any (T.isPrefixOf "PRA" . meetingSection) $ map (\m -> meetingData m) allMeetingsTimes
       return $ DB (course { coursesManualTutorialEnrolment = Just manTut,
                             coursesManualPracticalEnrolment = Just manPra },
-                   meetings)
-      where
-          setCode code session m =
-            m {meetingCode = code, meetingSession = session}
+                  allMeetingsTimes)
+      -- where
+      --     setCode code session m =
+      --       MeetingTimes {meetingData = meetingData m {meetingCode = code, meetingSession = session}, times=times m}
     parseJSON _ = fail "Invalid section"
 
-newtype Meetings = Meetings { meeting :: Meeting }
+-- newtype Meetings = Meetings { meeting :: Meeting }
+--   deriving Show
+
+-- instance FromJSON Meetings where
+--   parseJSON x = fmap Meetings (parseJSON x)
+
+newtype AllTimes = AllTimes { timesData :: Times }
   deriving Show
 
-instance FromJSON Meetings where
-  parseJSON x = fmap Meetings (parseJSON x)
+instance FromJSON MeetingTimes where
+  parseJSON = withObject "meetingtimes" $ \o -> do
+    meeting <- parseJSON (Object o)
+    timeMap :: HM.HashMap T.Text AllTimes <- o .:? "schedule" .!= HM.empty
+    let allTimes = map (toTime timesData) (HM.elems timeMap)
+    return $ MeetingTimes meeting allTimes
+    where
+      toTime time =
+        time
+
+data MeetingTimes = MeetingTimes { meetingData :: Meeting, times :: [Times] }
+  deriving Show
+
+instance FromJSON AllTimes where
+  parseJSON x = fmap AllTimes (parseJSON x)

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -49,14 +49,14 @@ insertAllMeetings org = do
 
 -- | Store a meeting's data and times.
 insertMeeting :: MeetTimes -> SqlPersistM ()
-insertMeeting meet = do
+insertMeeting (MeetTimes meetData meetTimes) = do
     -- Check that the meeting belongs to a course that exists
-    let code = meetingCode $ meetingData meet
+    let code = meetingCode meetData
     courseKey <- selectFirst [ CoursesCode ==. code ] []
     case courseKey of
         Just _ -> do
-          meetingKey <- insert $ meetingData meet
-          mapM_ (\t -> insert_ $ t {timesMeeting = Just meetingKey}) $ timesData meet
+          meetingKey <- insert meetData
+          mapM_ (\t -> insert_ $ t {timesMeeting = Just meetingKey}) meetTimes
         Nothing -> return ()
 
 newtype DB = DB { dbData :: (Courses, [MeetTimes]) }

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -13,6 +13,7 @@ import Config (databasePath)
 import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), EntityField(MeetingCode), EntityField(MeetingSection), EntityField(MeetingSession), Times(..))
 import Database.Persist.Sqlite (runSqlite, insert_, SqlPersistM, selectKeysList, (==.))
 import Database.Persist.Class (Key)
+import Control.Applicative ((<|>))
 
 
 -- | URLs for the Faculty of Arts and Science API
@@ -41,19 +42,15 @@ insertAllMeetings :: T.Text -> SqlPersistM ()
 insertAllMeetings org = do
     liftIO . print $ T.append "parsing JSON data from: " org
     resp <- liftIO . simpleHttp $ T.unpack (T.append timetableURL org)
-    -- Issue with Maybe here? Need Maybe because decode gives maybe
     let coursesLst :: Maybe (HM.HashMap T.Text (Maybe DB)) = decode resp
-    -- looks up the each DB, catMaybes throws out the Nothing values
         courseData = maybe [] (map dbData . catMaybes . HM.elems) coursesLst
-    --liftIO . print $ coursesCode $ fst $ head courseData
         -- courseData contains courses and sections;
         -- only sections are currently stored here.
         (_, sections) = unzip courseData
         meetings = concat sections
-    --liftIO . print $ meetingCode $ meetingData $ head meetings
-    -- Eg. for ENVMT, meetings is an empty list
     mapM_ insertMeeting meetings
 
+-- | Retrieve the key for the course with the given course code.
 getCourseKey :: T.Text -> SqlPersistM (Maybe (Key Courses))
 getCourseKey code = do
     keyListCourse :: [Key Courses] <- selectKeysList [ CoursesCode ==. code ] []
@@ -61,7 +58,7 @@ getCourseKey code = do
         [] -> Nothing
         _ -> Just (head keyListCourse)
 
-
+-- | Retrieve the key for the meeting with the given meeting code, session and section.
 getMeetingKey :: T.Text -> T.Text -> T.Text -> SqlPersistM (Maybe (Key Meeting))
 getMeetingKey meetCode meetSession meetSection = do
   keyListMeeting :: [Key Meeting] <- selectKeysList [ (MeetingCode ==. meetCode), (MeetingSection ==. meetSection), (MeetingSession ==. meetSession)] []
@@ -69,33 +66,26 @@ getMeetingKey meetCode meetSession meetSection = do
     [] -> Nothing
     _ -> Just (head keyListMeeting)
 
+-- | Store a meeting's data and times.
 insertMeeting :: MeetingTimes -> SqlPersistM ()
 insertMeeting meet = do
+    -- Check that the meeting belongs to exists
     courseKey <- getCourseKey (meetingCode $ meetingData meet)
     case courseKey of
         Just _ -> do
           insert_ $ meetingData meet
-          -- liftIO . print $ meetingCode $ meetingData meet
           meetingKey <- getMeetingKey (meetingCode $ meetingData meet) (meetingSession $ meetingData meet) (meetingSection $ meetingData meet)
           case meetingKey of
               Just _ -> mapM_ (\t -> insert_ $ t {timesMeeting = meetingKey}) $ times meet
               Nothing -> return ()
         Nothing -> return ()
 
-
-newtype DB = DB { dbData :: (Courses, [MeetingTimes]) }
-  deriving Show
-
--- parseMeetingTimes :: Value -> Parser (Meeting, [AllTimes])
--- parseMeetingTimes (Object obj) = do
---     meetingData <- parseJSON(Object obj)
---     timeMap :: HM.HashMap T.Text AllTimes <- o .:? "schedule" .!= HM.empty
---     return (meetingData, timeMap)
--- parseMeetingTimes _ = return (Nothing, [])
-
 parseMeetingTimes:: T.Text -> T.Text -> Meeting -> [Times] -> MeetingTimes
 parseMeetingTimes code session meetTimes allTimes =
     MeetingTimes {meetingData = meetTimes {meetingCode = code, meetingSession = session}, times = allTimes }
+
+newtype DB = DB { dbData :: (Courses, [MeetingTimes]) }
+  deriving Show
 
 instance FromJSON DB where
     parseJSON (Object o) = do
@@ -111,26 +101,12 @@ instance FromJSON DB where
                   allMeetingsTimes)
     parseJSON _ = fail "Invalid section"
 
--- newtype Meetings = Meetings { meeting :: Meeting }
---   deriving Show
-
--- instance FromJSON Meetings where
---   parseJSON x = fmap Meetings (parseJSON x)
-
--- newtype AllTimes = AllTimes { timesData :: Times }
---   deriving Show
-
-instance FromJSON MeetingTimes where
-  -- parseJSON = withObject "Expected Object for Meeting and Times" $ \o -> do
-  parseJSON (Object o) = do
-    meeting <- parseJSON (Object o)
-    timeMap :: HM.HashMap T.Text Times <- o .:? "schedule" .!= HM.empty
-    return $ MeetingTimes meeting (HM.elems timeMap)
-  parseJSON _ = fail "Invalid meeting"
-
-
 data MeetingTimes = MeetingTimes { meetingData :: Meeting, times :: [Times] }
   deriving Show
 
--- instance FromJSON AllTimes where
---   parseJSON x = fmap AllTimes (parseJSON x)
+instance FromJSON MeetingTimes where
+  parseJSON (Object o) = do
+    meeting <- parseJSON (Object o)
+    timeMap :: HM.HashMap T.Text Times <- o .:? "schedule" .!= HM.empty <|> return HM.empty
+    return $ MeetingTimes meeting (HM.elems timeMap)
+  parseJSON _ = fail "Invalid meeting"

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -13,7 +13,6 @@ import Config (databasePath)
 import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), Times(..), MeetTimes(..))
 import Database.Persist.Sqlite (runSqlite, insert_, SqlPersistM, (==.), insert, selectFirst)
 
-
 -- | URLs for the Faculty of Arts and Science API
 timetableURL :: T.Text
 timetableURL = "https://timetable.iit.artsci.utoronto.ca/api/20189/courses?org="

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -169,7 +169,7 @@ class TimetableRow extends React.Component {
               <td id={'' + day.toString() + currTime + '-0' + totalColSpans + currSess}
                 key={'' + day.toString() + currTime + '-0' + totalColSpans + currSess}
                 data-in-conflict={lecture.inConflict}
-                data-satisfied={lecture.data_satisfied}
+                data-satisfied={lecture.dataSatisfied}
                 rowSpan={rowSpan}
                 colSpan={lecColSpan}
                 className="timetable-cell timetable-edge"
@@ -347,16 +347,16 @@ function lectureConflict(courseList) {
  *                  lecture occurs in
 */
 function createNewLectures(lectureSection, index, lectureSections) {
-  // data_satisfied is false if a tutorial or practical for a course is selected in a particular session(F or S) and there
+  // dataSatisfied is false if a tutorial or practical for a course is selected in a particular session(F or S) and there
   // is no lecture selected for that course in the given session.
-  lectureSection.data_satisfied = false;
+  lectureSection.dataSatisfied = false;
   const lectureSelected = lectureSections.filter((lecture) => {
       return lecture.lectureCode.substring(0, 1) === "L" &&
         lecture.courseCode.substring(0, 6) === lectureSection.courseCode.substring(0, 6) &&
         lecture.session === lectureSection.session
   });
   if (lectureSelected.length > 0) {
-    lectureSection.data_satisfied = true;
+    lectureSection.dataSatisfied = true;
   }
   const lectures = lectureSection.times.map(time => {
     return {
@@ -367,7 +367,7 @@ function createNewLectures(lectureSection, index, lectureSections) {
       endTime: time.endHour,
       inConflict: false,
       width: 1,
-      data_satisfied: lectureSection.data_satisfied
+      dataSatisfied: lectureSection.dataSatisfied
     }
   });
   return lectures;

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -349,16 +349,15 @@ function lectureConflict(courseList) {
 function createNewLectures(lectureSection, index, lectureSections) {
   // data_satisfied is false if a tutorial or practical for a course is selected in a particular session(F or S) and there
   // is no lecture selected for that course in the given session.
-  let data_satisfied = false;
+  lectureSection.data_satisfied = false;
   const lectureSelected = lectureSections.filter((lecture) => {
       return lecture.lectureCode.substring(0, 1) === "L" &&
         lecture.courseCode.substring(0, 6) === lectureSection.courseCode.substring(0, 6) &&
         lecture.session === lectureSection.session
   });
   if (lectureSelected.length > 0) {
-    data_satisfied = true;
+    lectureSection.data_satisfied = true;
   }
-  lectureSection.data_satisfied = data_satisfied;
   const lectures = lectureSection.times.map(time => {
     return {
       courseCode: lectureSection.courseCode,

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -362,9 +362,9 @@ function createNewLectures(lectureSection, index, lectureSections) {
     return {
       courseCode: lectureSection.courseCode,
       session: lectureSection.session,
-      day: time.weekDay,
-      startTime: time.startHour,
-      endTime: time.endHour,
+      day: time.timesWeekDay,
+      startTime: time.timesStartHour,
+      endTime: time.timesEndHour,
       inConflict: false,
       width: 1,
       dataSatisfied: lectureSection.dataSatisfied

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -65,6 +65,7 @@ class Course extends React.Component {
   componentDidMount() {
     getCourse(this.props.courseCode)
       .then(data => {
+        console.log(data);
         let course = {
           courseCode: "",
           F: [],
@@ -95,13 +96,13 @@ class Course extends React.Component {
       // Check to make sure its not an online section (online sections have course codes beginning with 9) or
       // restricted section. Restricted sections have enrollment restricted for a particular group of students,
       // but happens at the same time and place as a regular lecture/tutorial section.
-      if (lectureInfo.section.charAt(3) !== '2' && lectureInfo.section.charAt(3) !== '9' &&
-        lectureInfo.times !== 'Online Web Version') {
+      if (lectureInfo.meetingData.section.charAt(3) !== '2' && lectureInfo.meetingData.section.charAt(3) !== '9' &&
+        lectureInfo.meetingData.times !== 'Online Web Version') {
         let lecture = {
-          courseCode: lectureInfo.code.substring(0, 6) + " (" + lectureInfo.section.substring(0,1) + ")",
-          lectureCode: lectureInfo.section.substring(0, 1) + lectureInfo.section.substring(3),
-          session: lectureInfo.session,
-          times: lectureInfo.times,
+          courseCode: lectureInfo.meetingData.code.substring(0, 6) + " (" + lectureInfo.meetingData.section.substring(0,1) + ")",
+          lectureCode: lectureInfo.meetingData.section.substring(0, 1) + lectureInfo.meetingData.section.substring(3),
+          session: lectureInfo.meetingData.session,
+          times: lectureInfo.timesData,
         };
         parsedLectures.push(lecture);
       }

--- a/public/js/common/utilities/util.js
+++ b/public/js/common/utilities/util.js
@@ -196,6 +196,6 @@ function removeDuplicateLectures(lectures) {
     'use strict'
 
     return lectures.filter((lecture, index, lectures) =>
-            lectures.map(lect => lect.section).indexOf(lecture.section) === index)
-        .sort((lec1, lec2) => lec1.section > lec2.section);
+            lectures.map(lect => lect.meetingData.section).indexOf(lecture.meetingData.section) === index)
+        .sort((lec1, lec2) => lec1.meetingData.section > lec2.meetingData.section);
 }


### PR DESCRIPTION
Added table Times in the database, containing information for the start and end times of the lecture, tutorial or practical, as well as the rooms and a reference to the meeting it is associated with. 
Also updated json parsers to insert into the Times table. 