### PR TITLE
Removing redundant file path

### DIFF
--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -55,7 +55,6 @@ parsePrebuiltSvgs = runSqlite databasePath $ do
     performParse "Geography" "ggr2015.svg"
     performParse "Aboriginal" "abs2015.svg"
     performParse "German" "ger2015.svg"
-    performParse "Sample" "gen/sample_edited.svg"
 
 
 -- | The starting point for parsing a graph with a given title and file.


### PR DESCRIPTION
Line was causing errors when attempt to run `stack exec courseography graphs`, as file path was not part of repository