### PR TITLE
Make running the os script step more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ First install both of the following.
 1. [Stack](https://docs.haskellstack.org/en/stable/README/)
 2. [ImageMagick](http://www.imagemagick.org/script/download.php)
 
-On Windows, install [Chocolatey](https://chocolatey.org/install); on Mac, install [Homebrew](https://brew.sh/).
-Then, open a terminal (in Windows, run as Administrator) and run `scripts/setup_<your os>`.
+On **Windows**, install [Chocolatey](https://chocolatey.org/install).
+
+On **Mac**, install [Homebrew](https://brew.sh/).
+
+Then, open a terminal (in Windows, run as Administrator) and run 
+```
+$ scripts/setup_<your os>
+```
+
 *Note*: this is a script intended for beginners; you may wish to read through the script and run modified commands to suit your own needs.
 
 #### Other Files


### PR DESCRIPTION
I completely missed this paragraph the first time I read the README and
I'm probably not the only one. Fixes #1002 because the os script
installs yarn and runs `yarn install`.