### PR TITLE
Change version from 0.2.0.0 to 0.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "courseography",
-  "version": "0.2.0.0",
+  "version": "0.2.0",
   "repository": "git@github.com:Courseography/courseography.git",
   "author": "David Liu <david@cs.toronto.edu>",
   "license": "GPL-3.0",


### PR DESCRIPTION
The npm command can now be used and will no longer complain about.

This will be useful for future students who have a habit of typing "npm"
rather than yarn.

We can also start following semantic versioning if we choose to do so.