### PR TITLE
Make the meetingId attribute in Times required

### DIFF
--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -119,7 +119,7 @@ getDescriptionD (Just key) = do
     return $ fmap distributionDescription maybeDistribution
 
 
--- | Queries the database for all times corresponding to a given meeting.
+-- | Queries the database for all times corresponding to a given meeting and construct a MeetTime
 buildMeetTimes :: Entity Meeting -> SqlPersistM Tables.MeetTime
 buildMeetTimes meet = do
     allTimes :: [Entity Times] <- selectList [TimesMeeting ==. entityKey meet] []

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -113,7 +113,8 @@ getDescriptionD (Just key) = do
 buildMeetTimes :: Entity Meeting -> SqlPersistM Tables.MeetTime
 buildMeetTimes meet = do
     allTimes :: [Entity Times] <- selectList [TimesMeeting ==. entityKey meet] []
-    parsedTime <- mapM buildTimes' $ map entityVal allTimes
+    -- let allentvaltimes = map entityVal allTimes
+    let parsedTime = map buildTimes' $ map entityVal allTimes
     return $ Tables.MeetTime {meetData = entityVal meet, timeData = parsedTime}
 
 -- ** Other queries
@@ -217,7 +218,7 @@ getMeetingTime (meetingCode_, meetingSection_, meetingSession_) = do
                                         MeetingSession ==. meetingSession_]
                                        []
     allTimes <- selectList [TimesMeeting ==. fromJust (fmap entityKey maybeEntityMeetings)] []
-    parsedTime <- mapM buildTimes' $ map entityVal allTimes
+    let parsedTime = map buildTimes' $ map entityVal allTimes
     return parsedTime
 
 getMeetingSection :: T.Text -> T.Text

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -76,9 +76,9 @@ returnMeeting lowerStr sect session = do
     return $ head entityMeetings
 
 -- | Convert Times into Time
-buildTime :: Times -> SqlPersistM Time
+buildTime :: Times -> SqlPersistM Times'
 buildTime t =
-  return $ Time (timesWeekDay t)
+  return $ Times' (timesWeekDay t)
           (timesStartHour t)
           (timesEndHour t)
           (timesFirstRoom t)
@@ -219,7 +219,7 @@ queryGraphs = runSqlite databasePath $ do
 
 -- | Queries the database for all times regarding a specific meeting (lecture, tutorial or practial) for
 -- a @course@, returns a list of Time.
-getMeetingTime :: (T.Text, T.Text, T.Text) -> SqlPersistM [Time]
+getMeetingTime :: (T.Text, T.Text, T.Text) -> SqlPersistM [Times']
 getMeetingTime (meetingCode_, meetingSection_, meetingSession_) = do
     maybeEntityMeetings <- selectFirst [MeetingCode ==. meetingCode_,
                                         MeetingSection ==. getMeetingSection meetingSection_,

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -118,7 +118,6 @@ getDescriptionD (Just key) = do
     maybeDistribution <- get key
     return $ fmap distributionDescription maybeDistribution
 
-
 -- | Queries the database for all times corresponding to a given meeting and construct a MeetTime
 buildMeetTimes :: Entity Meeting -> SqlPersistM Tables.MeetTime
 buildMeetTimes meet = do
@@ -217,7 +216,6 @@ queryGraphs :: IO Response
 queryGraphs = runSqlite databasePath $ do
     graphs :: [Entity Graph] <- selectList [] [Asc GraphTitle]
     return $ createJSONResponse graphs :: SqlPersistM Response
-
 
 -- | Queries the database for all times regarding a specific meeting (lecture, tutorial or practial) for
 -- a @course@, returns a list of Time.

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -35,7 +35,8 @@ import Data.Aeson ((.:?), (.!=), FromJSON(parseJSON), ToJSON(toJSON), Value(..),
 import Data.Aeson.Types (Parser, defaultOptions, Options(..))
 import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
-import Control.Applicative ((<|>))
+import Control.Applicative((<|>))
+
 
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
 derivePersistField "Room"
@@ -157,10 +158,6 @@ data SvgJSON =
               paths :: [Path]
             } deriving (Show, Generic)
 
--- | A Meeting with its associated Times.
-data MeetTimes = MeetTimes { meetingData :: Meeting, timesData :: [Times] }
-  deriving (Show, Generic)
-
 data Time =
   Time { weekDay :: Double,
           startingTime :: Double,
@@ -169,7 +166,8 @@ data Time =
           secRoom :: Maybe T.Text
 } deriving (Show, Generic)
 
-data MeetTime = MeetTime {meetData :: Meeting, meetTime :: [Time] }
+-- | A Meeting with its associated Times.
+data MeetTime = MeetTime {meetData :: Meeting, timeData :: [Time] }
   deriving (Show, Generic)
 
 -- | A Course. TODO: remove this data type (it's redundant).
@@ -190,7 +188,6 @@ data Course =
 
 instance ToJSON Course
 instance ToJSON Room
-instance ToJSON MeetTimes
 instance ToJSON Times
 instance ToJSON Time
 instance ToJSON MeetTime
@@ -273,6 +270,7 @@ instance FromJSON MeetTime where
     timeMap :: HM.HashMap T.Text Time <- o .:? "schedule" .!= HM.empty <|> return HM.empty
     return $ MeetTime meeting (HM.elems timeMap)
   parseJSON _ = fail "Invalid meeting"
+
 
 -- | Helpers for parsing JSON
 parseInstr :: Value -> Parser T.Text

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -37,7 +37,6 @@ import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 import Control.Applicative((<|>))
 
-
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
 derivePersistField "Room"
 
@@ -264,11 +263,9 @@ instance FromJSON Time where
 instance FromJSON MeetTime where
   parseJSON (Object o) = do
     meeting <- parseJSON (Object o)
-    -- meetingKey <- insert meeting
     timeMap :: HM.HashMap T.Text Time <- o .:? "schedule" .!= HM.empty <|> return HM.empty
     return $ MeetTime meeting (HM.elems timeMap)
   parseJSON _ = fail "Invalid meeting"
-
 
 -- | Helpers for parsing JSON
 parseInstr :: Value -> Parser T.Text

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -36,7 +36,7 @@ import Data.Aeson.Types (Parser, defaultOptions, Options(..))
 import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 import Control.Applicative((<|>))
-import Database.Persist.Sqlite( SqlPersistM, Key )
+import Database.Persist.Sqlite(Key)
 
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
 derivePersistField "Room"
@@ -302,19 +302,19 @@ getTimeVals (Just day) (Just start) (Just end) = do
 getTimeVals _ _ _ = (5.0, 25.0, 25.0)
 
 -- | Convert Times into Times'
-buildTimes' :: Times -> SqlPersistM Times'
+buildTimes' :: Times -> Times'
 buildTimes' t =
-  return $ Times' (timesWeekDay t)
-          (timesStartHour t)
-          (timesEndHour t)
-          (timesFirstRoom t)
-          (timesSecondRoom t)
+  Times' (timesWeekDay t)
+    (timesStartHour t)
+    (timesEndHour t)
+    (timesFirstRoom t)
+    (timesSecondRoom t)
 
-buildTimes :: Times' -> Key Meeting -> SqlPersistM Times
-buildTimes t meetingKey =
-  return $ Times (weekDay t)
-  (startingTime t)
-  (endingTime t)
-  meetingKey
-  (fstRoom t)
-  (secRoom t)
+buildTimes :: Key Meeting -> Times' -> Times
+buildTimes meetingKey t =
+  Times (weekDay t)
+    (startingTime t)
+    (endingTime t)
+    meetingKey
+    (fstRoom t)
+    (secRoom t)

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -156,8 +156,8 @@ data SvgJSON =
               paths :: [Path]
             } deriving (Show, Generic)
 
-data Time =
-  Time { weekDay :: Double,
+data Times' =
+  Times' { weekDay :: Double,
           startingTime :: Double,
           endingTime :: Double,
           fstRoom :: Maybe T.Text,
@@ -165,7 +165,7 @@ data Time =
 } deriving (Show, Generic)
 
 -- | A Meeting with its associated Times.
-data MeetTime = MeetTime {meetData :: Meeting, timeData :: [Time] }
+data MeetTime = MeetTime {meetData :: Meeting, timeData :: [Times'] }
   deriving (Show, Generic)
 
 -- | A Course. TODO: remove this data type (it's redundant).
@@ -186,7 +186,7 @@ data Course =
 
 instance ToJSON Course
 instance ToJSON Room
-instance ToJSON Time
+instance ToJSON Times'
 instance ToJSON MeetTime
 
 -- instance FromJSON required so that tables can be parsed into JSON,
@@ -250,7 +250,7 @@ instance FromJSON Meeting where
     else
       fail "Not a lecture, Tutorial or Practical"
 
-instance FromJSON Time where
+instance FromJSON Times' where
   parseJSON = withObject "Expected Object for Times" $ \o -> do
     meetingDayStr <- o .:? "meetingDay"
     meetingStartTimeStr <- o .:? "meetingStartTime"
@@ -258,12 +258,12 @@ instance FromJSON Time where
     meetingRoom1 <- o .:? "assignedRoom1" .!= Nothing
     meetingRoom2 <- o .:? "assignedRoom2" .!= Nothing
     let (meetingDay, meetingStartTime, meetingEndTime) = getTimeVals meetingDayStr meetingStartTimeStr meetingEndTimeStr
-    return $ Time meetingDay meetingStartTime meetingEndTime meetingRoom1 meetingRoom2
+    return $ Times' meetingDay meetingStartTime meetingEndTime meetingRoom1 meetingRoom2
 
 instance FromJSON MeetTime where
   parseJSON (Object o) = do
     meeting <- parseJSON (Object o)
-    timeMap :: HM.HashMap T.Text Time <- o .:? "schedule" .!= HM.empty <|> return HM.empty
+    timeMap :: HM.HashMap T.Text Times' <- o .:? "schedule" .!= HM.empty <|> return HM.empty
     return $ MeetTime meeting (HM.elems timeMap)
   parseJSON _ = fail "Invalid meeting"
 

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -86,7 +86,6 @@ Times
     meeting MeetingId
     firstRoom T.Text Maybe
     secondRoom T.Text Maybe
-    deriving Generic Show
 
 Breadth
     description T.Text
@@ -188,7 +187,6 @@ data Course =
 
 instance ToJSON Course
 instance ToJSON Room
-instance ToJSON Times
 instance ToJSON Time
 instance ToJSON MeetTime
 

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -36,6 +36,7 @@ import Data.Aeson.Types (Parser, defaultOptions, Options(..))
 import GHC.Generics
 import WebParsing.ReqParser (parseReqs)
 import Control.Applicative((<|>))
+import Database.Persist.Sqlite( SqlPersistM, Key )
 
 data Room = Room { roomField :: (T.Text, T.Text)} deriving (Show, Read, Eq, Generic)
 derivePersistField "Room"
@@ -299,3 +300,21 @@ getTimeVals (Just day) (Just start) (Just end) = do
         endDbl = getHourVal end
     (dayDbl, startDbl, endDbl)
 getTimeVals _ _ _ = (5.0, 25.0, 25.0)
+
+-- | Convert Times into Times'
+buildTimes' :: Times -> SqlPersistM Times'
+buildTimes' t =
+  return $ Times' (timesWeekDay t)
+          (timesStartHour t)
+          (timesEndHour t)
+          (timesFirstRoom t)
+          (timesSecondRoom t)
+
+buildTimes :: Times' -> Key Meeting -> SqlPersistM Times
+buildTimes t meetingKey =
+  return $ Times (weekDay t)
+  (startingTime t)
+  (endingTime t)
+  meetingKey
+  (fstRoom t)
+  (secRoom t)

--- a/app/Export/GetImages.hs
+++ b/app/Export/GetImages.hs
@@ -62,15 +62,15 @@ list2tuple [a, b, c] = (a, b, c)
 list2tuple _ = undefined
 
 -- | Queries the database for times regarding all meetings (i.e. lectures, tutorials and praticals),
--- returns a list of list of Time.
-getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Time]]
+-- returns a list of list of Times'.
+getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Times']]
 getTimes selectedMeetings = runSqlite databasePath $
   mapM getMeetingTime selectedMeetings
 
 -- | Creates a schedule.
 -- It takes information about meetings (i.e. lectures, tutorials and praticals) and their corresponding time.
 -- Courses are added to schedule, based on their days and times.
-getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Time]] -> [[[T.Text]]]
+getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Times']] -> [[[T.Text]]]
 getScheduleByTime selectedMeetings mTimes =
   let meetingTimes_ = zip selectedMeetings mTimes
       schedule = replicate 26 $ replicate 5 []
@@ -79,11 +79,11 @@ getScheduleByTime selectedMeetings mTimes =
 -- | Take a list of Time and returns a list of tuples that correctly index
 -- into the 2-D table (for generating the image).
 -- TODO: Make this support half-hour times.
-convertTimeToArray :: Time -> [(Int, Int)]
-convertTimeToArray Time {weekDay=day, startingTime=startTime, endingTime=endTime} =
+convertTimeToArray :: Times' -> [(Int, Int)]
+convertTimeToArray Times' {weekDay=day, startingTime=startTime, endingTime=endTime} =
     [(floor day, row) | row <- [(floor startTime - 8)..(floor endTime - 8) - 1]]
 
-addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Time]) -> [[[T.Text]]]
+addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Times']) -> [[[T.Text]]]
 addCourseToSchedule schedule (course, courseTimes) =
   let time' = filter (\t-> mod' (startingTime t) 1 == 0) courseTimes
       timeArray = concatMap convertTimeToArray time'

--- a/app/Export/GetImages.hs
+++ b/app/Export/GetImages.hs
@@ -63,14 +63,14 @@ list2tuple _ = undefined
 
 -- | Queries the database for times regarding all meetings (i.e. lectures, tutorials and praticals),
 -- returns a list of list of Time.
-getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Times]]
+getTimes :: [(T.Text, T.Text, T.Text)] -> IO [[Time]]
 getTimes selectedMeetings = runSqlite databasePath $
   mapM getMeetingTime selectedMeetings
 
 -- | Creates a schedule.
 -- It takes information about meetings (i.e. lectures, tutorials and praticals) and their corresponding time.
 -- Courses are added to schedule, based on their days and times.
-getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Times]] -> [[[T.Text]]]
+getScheduleByTime :: [(T.Text, T.Text, T.Text)] -> [[Time]] -> [[[T.Text]]]
 getScheduleByTime selectedMeetings mTimes =
   let meetingTimes_ = zip selectedMeetings mTimes
       schedule = replicate 26 $ replicate 5 []
@@ -79,13 +79,13 @@ getScheduleByTime selectedMeetings mTimes =
 -- | Take a list of Time and returns a list of tuples that correctly index
 -- into the 2-D table (for generating the image).
 -- TODO: Make this support half-hour times.
-convertTimeToArray :: Times -> [(Int, Int)]
-convertTimeToArray Times{timesWeekDay=weekDay, timesStartHour=startHour, timesEndHour=endHour} =
-    [(floor weekDay, row) | row <- [(floor startHour - 8)..(floor endHour - 8) - 1]]
+convertTimeToArray :: Time -> [(Int, Int)]
+convertTimeToArray Time {weekDay=day, startingTime=startTime, endingTime=endTime} =
+    [(floor day, row) | row <- [(floor startTime - 8)..(floor endTime - 8) - 1]]
 
-addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Times]) -> [[[T.Text]]]
+addCourseToSchedule :: [[[T.Text]]] -> ((T.Text, T.Text, T.Text), [Time]) -> [[[T.Text]]]
 addCourseToSchedule schedule (course, courseTimes) =
-  let time' = filter (\t-> mod' (timesStartHour t) 1 == 0) courseTimes
+  let time' = filter (\t-> mod' (startingTime t) 1 == 0) courseTimes
       timeArray = concatMap convertTimeToArray time'
   in foldl (addCourseHelper course) schedule timeArray
 

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -167,10 +167,10 @@ fifth (_, _, _, _, dates) = dates
 -- ** Ordering data
 
 -- | A list of the information within the time fields ordered by day.
-type InfoTimeFieldsByDay = [[Time]]
+type InfoTimeFieldsByDay = [[Times']]
 
 -- | Orders by day the start and endtimes obtained from the database.
-orderTimeFields :: [Time] -> InfoTimeFieldsByDay
+orderTimeFields :: [Times'] -> InfoTimeFieldsByDay
 orderTimeFields timeFields = groupBy (\x y -> weekDay x == weekDay y) sortedList
     where
         sortedList = sortBy (comparing weekDay) timeFields
@@ -250,7 +250,7 @@ type EndDate = String
 
 -- | Gives the appropiate starting and ending dates for each day,in which the
 -- course takes place, depending on the course session.
-getDatesByDay :: Session -> [Time] -> (StartDate, EndDate)
+getDatesByDay :: Session -> [Times'] -> (StartDate, EndDate)
 getDatesByDay session dataByDay
     | session ==  "F" = formatDates $ getDatesFall $ weekDay $ head dataByDay
     | otherwise = formatDates $ getDatesWinter $ weekDay $ head dataByDay

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -73,7 +73,7 @@ pullDatabase :: (Code, Section, Session) -> IO (MeetTime)
 pullDatabase (code, section, session) = runSqlite databasePath $ do
     meet <- returnMeeting code fullSection session
     allTimes <- selectList [TimesMeeting ==. entityKey meet] []
-    parsedTime <- mapM buildTimes' $ map entityVal allTimes
+    let parsedTime = map buildTimes' $ map entityVal allTimes
     return $ MeetTime {meetData = entityVal meet, timeData = parsedTime}
     where
     fullSection

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -72,7 +72,7 @@ getCoursesInfo courses = map courseInfo allCourses
 pullDatabase :: (Code, Section, Session) -> IO (MeetTimes)
 pullDatabase (code, section, session) = runSqlite databasePath $ do
     meet <- returnMeeting code fullSection session
-    allTimes <- selectList [TimesMeeting ==. Just (entityKey meet)] []
+    allTimes <- selectList [TimesMeeting ==. entityKey meet] []
     return $ MeetTimes {meetingData = entityVal meet, timesData = map entityVal allTimes}
     where
     fullSection

--- a/app/Response/Calendar.hs
+++ b/app/Response/Calendar.hs
@@ -8,7 +8,7 @@ import Data.Time (Day, addDays, formatTime, getCurrentTime, defaultTimeLocale)
 import Happstack.Server (ServerPart, Response, toResponse)
 import Control.Monad.IO.Class (liftIO)
 import Database.Persist.Sqlite (runSqlite, (==.), entityVal, selectList, entityKey)
-import Database.CourseQueries (returnMeeting, buildTime)
+import Database.CourseQueries (returnMeeting, buildTimes')
 import qualified Data.Text as T
 import Text.Read (readMaybe)
 import Database.Tables
@@ -73,7 +73,7 @@ pullDatabase :: (Code, Section, Session) -> IO (MeetTime)
 pullDatabase (code, section, session) = runSqlite databasePath $ do
     meet <- returnMeeting code fullSection session
     allTimes <- selectList [TimesMeeting ==. entityKey meet] []
-    parsedTime <- mapM buildTime $ map entityVal allTimes
+    parsedTime <- mapM buildTimes' $ map entityVal allTimes
     return $ MeetTime {meetData = entityVal meet, timeData = parsedTime}
     where
     fullSection

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -55,7 +55,7 @@ insertMeeting (MeetTime meetingData meetingTime) = do
     case courseKey of
         Just _ -> do
           meetingKey <- insert meetingData
-          allTimes <- mapM (\t-> buildTimes t meetingKey) meetingTime
+          let allTimes = map (buildTimes meetingKey) meetingTime
           mapM_ insert_ allTimes
         Nothing -> return ()
 

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -10,7 +10,7 @@ import qualified Data.HashMap.Strict as HM
 import Control.Monad.IO.Class (liftIO)
 import Network.HTTP.Conduit (simpleHttp)
 import Config (databasePath)
-import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), Times(..), Times'(..), MeetTime(..))
+import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), MeetTime(..), buildTimes)
 import Database.Persist.Sqlite (runSqlite, insert_, SqlPersistM, (==.), insert, selectFirst)
 
 -- | URLs for the Faculty of Arts and Science API
@@ -55,7 +55,8 @@ insertMeeting (MeetTime meetingData meetingTime) = do
     case courseKey of
         Just _ -> do
           meetingKey <- insert meetingData
-          mapM_ (\t -> insert_ $ Times (weekDay t) (startingTime t) (endingTime t) meetingKey (fstRoom t) (secRoom t)) meetingTime
+          allTimes <- mapM (\t-> buildTimes t meetingKey) meetingTime
+          mapM_ insert_ allTimes
         Nothing -> return ()
 
 newtype DB = DB { dbData :: (Courses, [MeetTime]) }

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -46,6 +46,7 @@ insertAllMeetings org = do
         meetings = concat sections
     mapM_ insertMeeting meetings
 
+-- insert a meeting and its corresponding Times into the database
 insertMeeting :: MeetTime -> SqlPersistM ()
 insertMeeting (MeetTime meetingData meetingTime) = do
     -- Check that the meeting belongs to a course that exists
@@ -60,7 +61,6 @@ insertMeeting (MeetTime meetingData meetingTime) = do
 newtype DB = DB { dbData :: (Courses, [MeetTime]) }
   deriving Show
 
--- keep times a string then decode it from the string after meeting is inserted
 instance FromJSON DB where
     parseJSON (Object o) = do
       course <- parseJSON (Object o)

--- a/app/WebParsing/UtsgJsonParser.hs
+++ b/app/WebParsing/UtsgJsonParser.hs
@@ -10,7 +10,7 @@ import qualified Data.HashMap.Strict as HM
 import Control.Monad.IO.Class (liftIO)
 import Network.HTTP.Conduit (simpleHttp)
 import Config (databasePath)
-import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), Times(..), Time(..), MeetTime(..))
+import Database.Tables (Courses(..), EntityField(CoursesCode), Meeting(..), Times(..), Times'(..), MeetTime(..))
 import Database.Persist.Sqlite (runSqlite, insert_, SqlPersistM, (==.), insert, selectFirst)
 
 -- | URLs for the Faculty of Arts and Science API

--- a/js/components/common/react_modal.js.jsx
+++ b/js/components/common/react_modal.js.jsx
@@ -31,17 +31,13 @@ class Modal extends React.Component {
     if (newCourse === this.state.courseId) {
       this.setState({ modalIsOpen: true });
     } else {
-      let formatted = formatCourseName(newCourse);
-      getCourse(formatted[0])
+      getCourse(newCourse)
         .then(course => {
-          //This is getting the session times
-          let sessions = course.fallSession.lectures
-            .concat(course.springSession.lectures)
-            .concat(course.yearSession.lectures);
             //Tutorials don't have a timeStr to print, so I've currently omitted them
           this.setState({
             course: course,
-            sessions: sessions,
+            sessions: course.allMeetingTimes.sort((firstLec, secondLec) =>
+              firstLec.meetData.session > secondLec.meetData.session ? 1 : -1),
             modalIsOpen: true,
             courseId: newCourse,
             courseTitle: `${newCourse.toUpperCase()} ${course.title}`
@@ -89,7 +85,7 @@ class Description extends React.Component {
         <p><strong>Breadth Requirement: </strong>{this.props.course.breadth}</p>
         <p><strong>Timetable: </strong></p>
         {this.props.sessions.map(function (lecture, i) {
-          return <p key={i}>{lecture.code + lecture.session + '-' + lecture.section}</p>;
+          return <p key={i}>{lecture.meetData.code + lecture.meetData.session + '-' + lecture.meetData.section}</p>;
         })}
         {/*<Video urls={this.props.course.videoUrls} />*/}
       </div>

--- a/js/components/grid/calendar.js.jsx
+++ b/js/components/grid/calendar.js.jsx
@@ -362,9 +362,9 @@ function createNewLectures(lectureSection, index, lectureSections) {
     return {
       courseCode: lectureSection.courseCode,
       session: lectureSection.session,
-      day: time.timesWeekDay,
-      startTime: time.timesStartHour,
-      endTime: time.timesEndHour,
+      day: time.weekDay,
+      startTime: time.startingTime,
+      endTime: time.endingTime,
       inConflict: false,
       width: 1,
       dataSatisfied: lectureSection.dataSatisfied

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -153,7 +153,7 @@ class Course extends React.Component {
   }
 
   displayInfo() {
-    this.modal.openModal(this.state.courseInfo.courseCode.substring(0, 6));
+    this.modal.openModal(this.props.courseCode);
   }
 
   containsSelectedLecture() {

--- a/js/components/grid/course_panel.js.jsx
+++ b/js/components/grid/course_panel.js.jsx
@@ -131,13 +131,12 @@ class Course extends React.Component {
       // Check to make sure its not an online section (online sections have course codes beginning with 9) or
       // restricted section. Restricted sections have enrollment restricted for a particular group of students,
       // but happens at the same time and place as a regular lecture/tutorial section.
-      if (lectureInfo.meetingData.section.charAt(3) !== '2' && lectureInfo.meetingData.section.charAt(3) !== '9' &&
-        lectureInfo.meetingData.times !== 'Online Web Version') {
+      if (lectureInfo.meetData.section.charAt(3) !== '2' && lectureInfo.meetData.section.charAt(3) !== '9') {
         let lecture = {
-          courseCode: lectureInfo.meetingData.code + " (" + lectureInfo.meetingData.section.substring(0,1) + ")",
-          lectureCode: lectureInfo.meetingData.section.substring(0, 1) + lectureInfo.meetingData.section.substring(3),
-          session: lectureInfo.meetingData.session,
-          times: lectureInfo.timesData,
+          courseCode: lectureInfo.meetData.code + " (" + lectureInfo.meetData.section.substring(0,1) + ")",
+          lectureCode: lectureInfo.meetData.section.substring(0, 1) + lectureInfo.meetData.section.substring(3),
+          session: lectureInfo.meetData.session,
+          times: lectureInfo.timeData,
         };
         parsedLectures.push(lecture);
       }

--- a/public/js/common/utilities/util.js
+++ b/public/js/common/utilities/util.js
@@ -196,6 +196,6 @@ function removeDuplicateLectures(lectures) {
     'use strict'
 
     return lectures.filter((lecture, index, lectures) =>
-            lectures.map(lect => lect.meetingData.section).indexOf(lecture.meetingData.section) === index)
-        .sort((lec1, lec2) => lec1.meetingData.section > lec2.meetingData.section);
+            lectures.map(lect => lect.meetData.section).indexOf(lecture.meetData.section) === index)
+        .sort((lec1, lec2) => lec1.meetData.section > lec2.meetData.section);
 }


### PR DESCRIPTION
Update the insert and query functions to make the meetingId attribute in the Times table a required attribute.

To do this, the data type Time was added, its attributes mirror the Times attributes, but it does not have the meetingId attribute. Times is now only used as a database table; when working with meeting time related data, Time is used instead of Times.