### PR TITLE
Fix bug in Node constructor

### DIFF
--- a/js/components/graph/Node.js
+++ b/js/components/graph/Node.js
@@ -6,8 +6,8 @@ export default class Node extends React.Component {
   constructor(props) {
     super(props);
     var state = localStorage.getItem(this.props.JSON.id_);
-    if (!this.props.editMode) {
-      state = "";
+    if (this.props.editMode) {
+      state = ""; // TODO: define what editMode is
     } else if (state === null) {
       state = this.props.parents.length === 0 ? "takeable" : "inactive";
     }

--- a/js/components/graph/__tests__/__snapshots__/Node.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/Node.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Course Node should match shallow snapshot 1`] = `
 <g
-  className="node "
+  className="node takeable"
   id="csc108"
   onClick={[MockFunction]}
   onMouseEnter={[MockFunction]}
@@ -34,7 +34,7 @@ exports[`Course Node should match shallow snapshot 1`] = `
 
 exports[`Hybrid Node node 1`] = `
 <g
-  className="hybrid "
+  className="hybrid takeable"
   id="h46"
   onKeyDown={[MockFunction]}
   shapeRendering="geometricPrecision"


### PR DESCRIPTION
The CSS classes of Nodes (both types: hybrid and node) weren't being initialized properly.

**Before**
![image1](https://user-images.githubusercontent.com/11246258/58348476-d8a81400-7e2e-11e9-8ea1-fe73693bc9d9.png)

**After**
![image2](https://user-images.githubusercontent.com/11246258/58348482-dd6cc800-7e2e-11e9-9b29-528cd747655e.png)