### PR TITLE
Clear localStorage after each test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,14 +11,12 @@
     "$": "readonly",
     "getURLParameter": "readonly"
   },
-  "overrides": [
-    {
-      "files": ["*.test.js"],
-      "env": {
-        "jest": true
-      }
+  "overrides": [{
+    "files": ["*.js"],
+    "env": {
+      "jest": true
     }
-  ],
+  }],
   "parser": "babel-eslint",
   "rules": {
     "no-console": "off",

--- a/js/components/graph/__tests__/Bool.test.js
+++ b/js/components/graph/__tests__/Bool.test.js
@@ -1,10 +1,8 @@
 import React from "react";
 import { shallow } from "enzyme";
 import Bool from "../Bool";
-import { cleanup, fireEvent } from "react-testing-library";
+import { fireEvent } from "react-testing-library";
 import setupGraph from "./setupGraph";
-
-afterEach(cleanup);
 
 describe("Bool", () => {
   it("should already have two classes when instantated by Graph", async () => {

--- a/js/components/graph/__tests__/Node.test.js
+++ b/js/components/graph/__tests__/Node.test.js
@@ -1,10 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { cleanup } from "react-testing-library";
 import Node from "../Node";
 import setupGraph from "./setupGraph";
-
-afterEach(cleanup);
 
 describe("Hybrid Node", () => {
   it("node", () => {

--- a/js/components/graph/__tests__/cleanup-after-each.js
+++ b/js/components/graph/__tests__/cleanup-after-each.js
@@ -1,0 +1,6 @@
+import { cleanup } from "react-testing-library";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
-      "<rootDir>/js/components/graph/__tests__/setupGraph.js"
+      "<rootDir>/js/components/graph/__tests__/setupGraph.js",
+      "<rootDir>/js/components/graph/__tests__/cleanup-after-each.js"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/js/components/graph/__tests__/cleanup-after-each.js"
     ]
   },
   "husky": {


### PR DESCRIPTION
**Why this PR exists**
* Bool tests are failing
* WHY: localStorage is persistent across tests
	* tests create side effects.
* This bug existed before
	* only visible now because Node is being initialized with a state now.

**Why change `.eslintrc.json`**
* `cleanup-after-each.js` uses a jest global variable
* eslint sees an undeclared variable being used
* setting the Jest environment for JS files lets ESLint know about Jest globals

**Bool.test.js and Node.test.js**
* `cleanup-after-each.js` creates an `afterEach()` that does the cleanup
* I removed the cleanup in each individual file. 

**cleanup-after-each.js**
* calls React Testing Library's cleanup() which "unmounts React trees"
* also clears the localStorage

**package.json**
* `setupFilesAfterEnv`: Adds the `afterEach()` to the jest environment instead of adding this snippet to every test file.
* I set jest to ignore `cleanup-after-each.js` because jest requires that all files in a `__tests__` folder have at least one test
