### PR TITLE
Fix typo in test data

### DIFF
--- a/js/components/graph/__mocks__/testData.js
+++ b/js/components/graph/__mocks__/testData.js
@@ -148,7 +148,7 @@ export default {
       stroke: "",
       pos: [733.452148, 179.883608],
       fill: "#e68080",
-      id_: "aaa303CSC"
+      id_: "aaa303"
     },
     {
       graph: 1,
@@ -310,7 +310,7 @@ export default {
       fill: "none",
       id_: "p11",
       source: "bool1",
-      target: "aaa303CSC"
+      target: "aaa303"
     },
     {
       graph: 1,


### PR DESCRIPTION
Removing the "CSC" to the id of a node in the test data.
* I introduced this accidentally

This doesn't affect the tests.
* The tests only look for the text "AAA303" which is unchanged