### PR TITLE
SVG Parser: path "d" attributes

### DIFF
--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -293,11 +293,10 @@ readAttr attr tag = fromMaybe
 -- Throws an exception on any parse errors.
 parseVal :: Parser a -> T.Text -> a
 parseVal parser input =
-    case P.parse parser "" strippedInput of
+    case P.parse parser "" $ T.unpack input of
         Left err ->
             error ("reading " ++ T.unpack input ++ ":" ++ show err)
         Right val -> val
-    where strippedInput = filter (not . isSpace) (T.unpack input)
 
 -- | Looks up an attribute value using the given parser.
 parseAttr :: Parser a -> T.Text     -- ^ The attribute's name.
@@ -312,13 +311,13 @@ digits = P.many1 P.digit
 -- | Parses a double value, ignoring units if present.
 double :: Parser Double
 double = do
-    sign <- P.option "" (P.string "-")
+    sign <- P.option ' ' (P.char '-')
     whole <- digits
     fractional <- P.option ".0" parseFractional
-    return (read $ sign ++ whole ++ fractional)
+    return (read $ sign : whole ++ fractional)
     where
         parseFractional = do
-            _ <- P.string "."
+            _ <- P.char '.'
             decimals <- digits
             return ("." ++ decimals)
 
@@ -354,7 +353,7 @@ parseTransform transform =
         parser = do
             _ <- P.string "translate("
             xPos <- double
-            _ <- P.string ","
+            _ <- P.char ','
             yPos <- double
             return (xPos, yPos)
 
@@ -365,7 +364,7 @@ parseCoord coord =
     where
         parser = do
             xPos <- double
-            _ <- P.string ","
+            _ <- P.char ','
             yPos <- double
             return (xPos, yPos)
 

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -410,12 +410,15 @@ parsePathD d = parseValWithState parser initialState d
                                   , mode = AbsoluteMove
                                   , currentPoint = (0, 0) }
 
+        parser :: P.Parsec String PathDState [Point]
         parser = do
             p <- parseStep
             -- Record the first point added.
             _ <- P.modifyState $ \st -> st { firstPoint = p, currentPoint = p }
             rest <- P.many parseStep
             return (p : rest)
+
+        parseStep :: P.Parsec String PathDState Point
         parseStep = do
             _ <- P.option () $ P.choice
                 [ bezier

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -448,8 +448,8 @@ parsePathD d = parseValWithState parser initialState d
         closeLoop = do
             _ <- (P.char 'Z' <|> P.char 'z')
             state <- P.getState
-            _ <- P.modifyState $ \st -> st { mode = AbsoluteMove }
-            return $ firstPoint state
+            _ <- setMode AbsoluteMove
+            return (firstPoint state)
         moveArg = do -- Read a movement argument (can be a point or a double).
             val <- double
             sep <- P.option ' ' $ P.char ','

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -368,7 +368,7 @@ parseTransform "" = (0, 0)
 parseTransform transform =
     parseVal parser transform
     where
-        parser = P.many1 (scale <|> rotate) >> translate
+        parser = P.many (scale <|> rotate) >> translate
         scale = P.string "scale(" >> double >> P.spaces >> P.option 0 double
             >> P.char ')' >> P.spaces
         rotate = P.string "rotate(" >> double >> P.char ')' >> P.spaces


### PR DESCRIPTION
As of these changes, the parser is able to successfully parse the dynamically generated sample graph. A/B Testing was performed via database dumps with all of the static graphs to ensure that the resulting path values were identical with the new path parser.

Additionally, one of the static graphs contained a single value in scientific notation, so this PR includes support for parsing those values.