### PR TITLE
Add fake aaa course info for AAA100.

### DIFF
--- a/js/components/graph/__mocks__/aaa100-course-info.js
+++ b/js/components/graph/__mocks__/aaa100-course-info.js
@@ -1,2 +1,377 @@
-export default
-{"prereqString":null,"springSession":{"lectures":[{"room":[{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]}],"cap":196,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[4,12]},{"timeField":[4,12.5]},{"timeField":[0,12]},{"timeField":[0,12.5]}],"section":"LEC0201"},{"room":[{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]}],"cap":196,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[4,11]},{"timeField":[4,11.5]},{"timeField":[0,11]},{"timeField":[0,11.5]}],"section":"LEC0101"}],"tutorials":[{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":92,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[2,12]},{"timeField":[2,12.5]}],"section":"TUT0301"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":100,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[2,15]},{"timeField":[2,15.5]}],"section":"TUT0401"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":120,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[2,11]},{"timeField":[2,11.5]}],"section":"TUT0201"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":120,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"S","times":[{"timeField":[2,10]},{"timeField":[2,10.5]}],"section":"TUT0101"}],"practicals":[]},"distribution":"Science","yearSession":{"lectures":[],"tutorials":[],"practicals":[]},"manualPracticalEnrolment":null,"videoUrls":[],"breadth":"The Physical and Mathematical Universes (5)","name":"CSC104H1","exclusions":"Any Computer Science course","title":"Computational Thinking","manualTutorialEnrolment":null,"description":"Humans have solved problems for millennia on computing devices by representing data as diverse numbers, text, images, sound and genomes, and then transforming the data. A gentle introduction to designing programs (recipes) for systematically solving problems that crop up in diverse domains such as science, literature, and graphics. Social and intellectual issues raised by computing. Algorithms, hardware, software, operating systems, the limits of computation.Note: you may not take this course concurrently with any Computer Science course, but you may take CSC108H1/CSC148H1 after CSC104H1.","coreqs":null,"fallSession":{"lectures":[{"room":[{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]}],"cap":196,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[4,12]},{"timeField":[4,12.5]},{"timeField":[0,12]},{"timeField":[0,12.5]}],"section":"LEC0201"},{"room":[{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]}],"cap":196,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[0,15]},{"timeField":[0,15.5]},{"timeField":[4,15]},{"timeField":[4,15.5]}],"section":"LEC0301"},{"room":[{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]},{"roomField":["",""]}],"cap":196,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[0,11]},{"timeField":[0,11.5]},{"timeField":[4,11]},{"timeField":[4,11.5]}],"section":"LEC0101"}],"tutorials":[{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":120,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[2,15]},{"timeField":[2,15.5]}],"section":"TUT0501"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":97,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[2,13]},{"timeField":[2,13.5]}],"section":"TUT0301"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":100,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[2,14]},{"timeField":[2,14.5]}],"section":"TUT0401"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":150,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[2,12]},{"timeField":[2,12.5]}],"section":"TUT0201"},{"room":[{"roomField":["",""]},{"roomField":["",""]}],"cap":150,"extra":0,"instructor":"","timeStr":"","wait":0,"enrol":0,"code":"CSC104H1","session":"F","times":[{"timeField":[2,11]},{"timeField":[2,11.5]}],"section":"TUT0101"}],"practicals":[]}}
+export default {
+  prereqString: null,
+  distribution: "Science",
+  allMeetingTimes: [
+    {
+      timeData: [
+        {
+          endingTime: 14,
+          secRoom: null,
+          startingTime: 12,
+          fstRoom: "MY 150",
+          weekDay: 1
+        },
+        {
+          endingTime: 14,
+          secRoom: null,
+          startingTime: 13,
+          fstRoom: "MY 150",
+          weekDay: 3
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "J. Campbell",
+        wait: 0,
+        enrol: 192,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC0102"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 15,
+          secRoom: null,
+          startingTime: 13,
+          fstRoom: "BA 1160",
+          weekDay: 2
+        },
+        {
+          endingTime: 14,
+          secRoom: null,
+          startingTime: 13,
+          fstRoom: "BA 1160",
+          weekDay: 4
+        }
+      ],
+      meetData: {
+        cap: 196,
+        extra: 0,
+        instructor: "T. Fairgrieve",
+        wait: 0,
+        enrol: 184,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC0201"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 21,
+          secRoom: null,
+          startingTime: 18,
+          fstRoom: "MY 150",
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "J. Smith",
+        wait: 0,
+        enrol: 174,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC5102"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 14,
+          secRoom: null,
+          startingTime: 13,
+          fstRoom: "MY 150",
+          weekDay: 3
+        },
+        {
+          endingTime: 14,
+          secRoom: null,
+          startingTime: 12,
+          fstRoom: "MY 150",
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "J. Campbell",
+        wait: 0,
+        enrol: 177,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC0101"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 21,
+          secRoom: null,
+          startingTime: 18,
+          fstRoom: "MY 150",
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "J. Smith",
+        wait: 0,
+        enrol: 173,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC5101"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 25,
+          secRoom: null,
+          startingTime: 25,
+          fstRoom: null,
+          weekDay: 5
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "J. Smith",
+        wait: 0,
+        enrol: 171,
+        code: "AAA100H1",
+        session: "F",
+        section: "LEC9901"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 14,
+          secRoom: "MY 150",
+          startingTime: 13,
+          fstRoom: null,
+          weekDay: 4
+        },
+        {
+          endingTime: 15,
+          secRoom: "MY 150",
+          startingTime: 13,
+          fstRoom: null,
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "T. Fairgrieve",
+        wait: 0,
+        enrol: 195,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC0102"
+      }
+    },
+    {
+      timeData: [],
+      meetData: {
+        cap: -1,
+        extra: 0,
+        instructor: "",
+        wait: 0,
+        enrol: 0,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC0201"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 17,
+          secRoom: "Contact Dept",
+          startingTime: 16,
+          fstRoom: null,
+          weekDay: 0
+        }
+      ],
+      meetData: {
+        cap: 36,
+        extra: 0,
+        instructor: "",
+        wait: 0,
+        enrol: 17,
+        code: "AAA100H1",
+        session: "S",
+        section: "TUT0301"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 16,
+          secRoom: "MY 315",
+          startingTime: 13,
+          fstRoom: null,
+          weekDay: 3
+        }
+      ],
+      meetData: {
+        cap: 72,
+        extra: 0,
+        instructor: "P. Gries",
+        wait: 0,
+        enrol: 67,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC0301"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 21,
+          secRoom: "MY 150",
+          startingTime: 18,
+          fstRoom: null,
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "P. Gries",
+        wait: 0,
+        enrol: 186,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC5102"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 15,
+          secRoom: "MY 150",
+          startingTime: 13,
+          fstRoom: null,
+          weekDay: 1
+        },
+        {
+          endingTime: 14,
+          secRoom: "MY 150",
+          startingTime: 13,
+          fstRoom: null,
+          weekDay: 4
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "T. Fairgrieve",
+        wait: 0,
+        enrol: 190,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC0101"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 21,
+          secRoom: "MY 150",
+          startingTime: 18,
+          fstRoom: null,
+          weekDay: 1
+        }
+      ],
+      meetData: {
+        cap: 200,
+        extra: 0,
+        instructor: "P. Gries",
+        wait: 0,
+        enrol: 192,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC5101"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 17,
+          secRoom: "Contact Dept",
+          startingTime: 16,
+          fstRoom: null,
+          weekDay: 4
+        }
+      ],
+      meetData: {
+        cap: 36,
+        extra: 0,
+        instructor: "",
+        wait: 0,
+        enrol: 20,
+        code: "AAA100H1",
+        session: "S",
+        section: "TUT0303"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 25,
+          secRoom: null,
+          startingTime: 25,
+          fstRoom: null,
+          weekDay: 5
+        }
+      ],
+      meetData: {
+        cap: 196,
+        extra: 0,
+        instructor: "J. Williams",
+        wait: 0,
+        enrol: 182,
+        code: "AAA100H1",
+        session: "S",
+        section: "LEC9901"
+      }
+    },
+    {
+      timeData: [
+        {
+          endingTime: 17,
+          secRoom: "Contact Dept",
+          startingTime: 16,
+          fstRoom: null,
+          weekDay: 2
+        }
+      ],
+      meetData: {
+        cap: 36,
+        extra: 0,
+        instructor: "",
+        wait: 0,
+        enrol: 29,
+        code: "AAA100H1",
+        session: "S",
+        section: "TUT0302"
+      }
+    }
+  ],
+  videoUrls: [],
+  breadth: "The Physical and Mathematical Universes (5)",
+  name: "AAA100H1",
+  exclusions: "",
+  title: "Introduction to AAA Thinking",
+  description:
+    "AAA100H1 is about learning about all things triple A. We literally memorize a list of AAA acronyms from here: https://acronyms.thefreedictionary.com/AAA",
+  coreqs: null
+};


### PR DESCRIPTION
Why this PR
-------------
1. Uses the more recent format (has `allMeetingTimes`) so it works as a mock.
2. Replace the description to custom AAA100 content.
3. more readable (instead of all on one line)  and helps with future diffs.