### PR TITLE
Rename Hybrid Node (linked with AAA101) from h108 to h101

### DIFF
--- a/js/components/graph/__mocks__/testData.js
+++ b/js/components/graph/__mocks__/testData.js
@@ -68,7 +68,7 @@ export default {
       stroke: "",
       pos: [600.585648, 41.51310800000002],
       fill: "#888888",
-      id_: "h108"
+      id_: "h101"
     },
     {
       graph: 1,
@@ -268,7 +268,7 @@ export default {
       stroke: "",
       fill: "none",
       id_: "p6",
-      source: "h108",
+      source: "h101",
       target: "aaa201"
     },
     {


### PR DESCRIPTION
Why this PR
----------------
Avoid confusing any future maintainers as to why the Hybrid Node linked with AAA101 has an id 108.

Fixing this copy-paste error.