### PR TITLE
Remove async from describe blocks

### DIFF
--- a/js/components/graph/__tests__/Node.test.js
+++ b/js/components/graph/__tests__/Node.test.js
@@ -145,7 +145,7 @@ describe("Course Node", () => {
     expect(aaa100.classList.contains("node")).toBe(true);
   });
 
-  describe("Unselected Course Node", async () => {
+  describe("Unselected Course Node", () => {
     it("should be 'takeable' if it has no prereqs", async () => {
       const graph = await TestGraph.build();
       const aaa101 = graph.getNodeByText("AAA101");
@@ -185,14 +185,14 @@ describe("Course Node", () => {
     });
   });
 
-  describe("Selected Course Node", async () => {
+  describe("Selected Course Node", () => {
     it("with met prereqs should 'active'", async () => {
       const graph = await TestGraph.build();
       const aaa100 = graph.getNodeByText("AAA100");
       fireEvent.click(aaa100);
       expect(aaa100.classList.contains("active")).toBe(true);
     });
-    describe("selected course with un-met prereqs", async () => {
+    describe("selected course with un-met prereqs", () => {
       it("should be 'overridden' (if you don't hover over it)", async () => {
         const graph = await TestGraph.build();
         const aaa201 = graph.getNodeByText("AAA201");


### PR DESCRIPTION
Why this PR
-----------------------
`describe` blocks don't need to be `async`.
It's just for grouping tests.

Only `it` blocks need to be `async`.

On Jest version 24.8.0. Jest raises the following error:
> Returning a value from "describe" will fail the test in a future version of Jest.