### PR TITLE
Remove the path built-in as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "leaflet": "^1.5.1",
-    "path": "^0.12.7",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-leaflet": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,13 +4781,6 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-path@^0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
-  dependencies:
-    process "^0.11.1"
-    util "^0.10.3"
-
 pbkdf2@^3.0.3:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.9.tgz#f2c4b25a600058b3c3773c086c37dbbee1ffe693"
@@ -4909,7 +4902,7 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process@^0.11.0, process@^0.11.1:
+process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 


### PR DESCRIPTION
Why this PR
---------------
`path` is built into Node.js and doesn't need to be explicitly stated in `package.json` as a dependency.

https://www.npmjs.com/package/path
> This is an exact copy of the NodeJS ’path’ module published to the NPM registry.

resolves #1057