### PR TITLE
Add link to Courseography in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Courseography
+[Courseography](https://courseography.cs.toronto.edu)
 =============
 
 About


### PR DESCRIPTION
Added the link to the Courseography website in the README header.

https://github.com/facebook/react also does this and I thought it was nice.