### PR TITLE
Link to JS instead of CSS file

### DIFF
--- a/app/Scripts.hs
+++ b/app/Scripts.hs
@@ -32,7 +32,7 @@ timetableScripts :: H.Html
 timetableScripts = do
     mapM_ toScript $
         [if enableCdn
-         then "//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"
+         then "https://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"
          else "/static/js/vendor/bootstrap.min.3.1.1.js"
          ]
     H.script ! A.src "/static/js/grid/app.js" $ ""


### PR DESCRIPTION
Why this PR
-------------------
`Uncaught SyntaxError: Unexpected token {`

I get that error when I go to the grid page
https://courseography.cs.toronto.edu/grid

It's trying to read JS from a CSS file.

CDN link from here: https://blog.getbootstrap.com/2014/02/13/bootstrap-3-1-1-released/