### PR TITLE
More user friendly data-testids

### DIFF
--- a/js/components/graph/Bool.js
+++ b/js/components/graph/Bool.js
@@ -91,7 +91,7 @@ export default class Bool extends React.Component {
       <g
         {...this.props.JSON}
         className={this.props.className + " " + this.state.status}
-        data-testid={this.props.JSON.id_}
+        data-testid={`and(${this.props.parents.join()})`}
       >
         <ellipse {...ellipseAttrs} />
         {this.props.JSON.text.map(

--- a/js/components/graph/Node.js
+++ b/js/components/graph/Node.js
@@ -167,6 +167,13 @@ export default class Node extends React.Component {
     });
   }
 
+  getDataTestId = () => {
+    if (this.props.hybrid) {
+      return `h(${this.props.parents.join(',')})`;
+    }
+    return this.props.JSON.id_;
+  }
+
   render() {
     let ellipse = null;
     var newClassName = this.props.className + " " + this.state.status;
@@ -212,7 +219,7 @@ export default class Node extends React.Component {
 
     // TODO: Look at this.props to see what we need to give the g
     return (
-      <g {...gAttrs} id={this.props.JSON.id_} className={newClassName} data-testid={this.props.JSON.id_}>
+      <g {...gAttrs} id={this.props.JSON.id_} className={newClassName} data-testid={this.getDataTestId()}>
         {ellipse}
         <rect {...rectAttrs} style={rectStyle} />
         {this.props.JSON.text.map(function(textTag, i) {

--- a/js/components/graph/__tests__/Node.test.js
+++ b/js/components/graph/__tests__/Node.test.js
@@ -46,7 +46,7 @@ describe("Hybrid Node", () => {
       inEdges: [],
       logicalType: "AND",
       outEdges: ["p32"],
-      parents: [],
+      parents: ["csc301", "csc318", "csc384", "csc418"],
       svg: {
         onKeyDown: jest.fn()
       }
@@ -57,12 +57,12 @@ describe("Hybrid Node", () => {
 
   it("should have the 'hybrid' CSS class", async () => {
     const graph = await TestGraph.build();
-    const hybrid101 = graph.getByTestId("h101");
+    const hybrid101 = graph.getByTestId("h(aaa101)");
     expect(hybrid101.classList.contains("hybrid")).toBe(true);
   });
   it("shouldn't do anything when you hover or click it", async () => {
     const graph = await TestGraph.build();
-    const hybrid101 = graph.getByTestId("h101");
+    const hybrid101 = graph.getByTestId("h(aaa101)");
 
     // convert DOMTokenList to object so we can deep copy
     const cssClassDeepCopy = JSON.parse(JSON.stringify(hybrid101.classList));
@@ -79,12 +79,12 @@ describe("Hybrid Node", () => {
   });
   it("should be 'inactive' when it's prereq parent is NOT met", async () => {
     const graph = await TestGraph.build();
-    const hybrid101 = graph.getByTestId("h101");
+    const hybrid101 = graph.getByTestId("h(aaa101)");
     expect(hybrid101.classList.contains("inactive")).toBe(true);
   });
   it("should be 'active' when its prereq parent is met", async () => {
     const graph = await TestGraph.build();
-    const hybrid101 = graph.getByTestId("h101");
+    const hybrid101 = graph.getByTestId("h(aaa101)");
     const aaa101 = graph.getByTestId("aaa101");
     fireEvent.click(aaa101);
     expect(hybrid101.classList.contains("active")).toBe(true);
@@ -92,7 +92,7 @@ describe("Hybrid Node", () => {
 
   it("should be 'missing' if not 'active' and it's an unmet prereq of the currently hovered course", async () => {
     const graph = await TestGraph.build();
-    const hybrid101 = graph.getByTestId("h101");
+    const hybrid101 = graph.getByTestId("h(aaa101)");
     const aaa303 = graph.getByTestId("aaa303");
 
     fireEvent.mouseOver(aaa303);
@@ -216,7 +216,7 @@ describe("Course Node", () => {
         const aaa202 = graph.getByTestId("aaa202");
         fireEvent.click(aaa201);
         fireEvent.mouseOver(aaa202);
-        // not missing!
+        // not missing because aaa201 is overridden
         expect(aaa101.classList.contains("takeable")).toBe(true);
       });
 

--- a/js/components/graph/__tests__/TestGraph.js
+++ b/js/components/graph/__tests__/TestGraph.js
@@ -31,17 +31,25 @@ export default class TestGraph {
 
   /**
    * @param {string} text
-   * @returns {DOM Element}
+   * @return {DOM Element} -  for example, SVGElement
    */
   getNodeByText(text) {
     return this.rtlGraph.getByText(text).parentNode;
   }
 
   /**
-   * @param {string} testId - value of the "data-testId" attribute
+   * @param {string} testId - value of the "data-testid" attribute
    * @returns {DOM Element}
    */
   getByTestId(testId) {
     return this.rtlGraph.getByTestId(testId);
+  }
+
+  /**
+   * @param {regex or string} text
+   * @returns {boolean} - whether the exact text exists on the webpage
+   */
+  textExists(text) {
+    return this.rtlGraph.queryByText(text) !== null;
   }
 }

--- a/js/components/graph/__tests__/__snapshots__/Bool.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/Bool.test.js.snap
@@ -3,6 +3,7 @@
 exports[`AND Bool should match shallow snapshot 1`] = `
 <g
   className="bool inactive"
+  data-testid="and(csc209,csc258)"
   fill=""
   graph={1}
   height={14.7368002}
@@ -51,6 +52,7 @@ exports[`AND Bool should match shallow snapshot 1`] = `
 exports[`OR Bool should match shallow snapshot 1`] = `
 <g
   className="bool inactive"
+  data-testid="and(csc209,csc258)"
   fill=""
   graph={1}
   height={14.7368002}

--- a/js/components/graph/__tests__/__snapshots__/Node.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/Node.test.js.snap
@@ -35,8 +35,8 @@ exports[`Course Node should match shallow snapshot 1`] = `
 
 exports[`Hybrid Node should match snapshot 1`] = `
 <g
-  className="hybrid takeable"
-  data-testid="h46"
+  className="hybrid inactive"
+  data-testid="h(csc301,csc318,csc384,csc418)"
   id="h46"
   onKeyDown={[MockFunction]}
   shapeRendering="geometricPrecision"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
+      "<rootDir>/cypress/",
       "<rootDir>/js/components/graph/__tests__/TestGraph.js",
       "<rootDir>/js/components/graph/__tests__/cleanup-after-each.js"
     ],


### PR DESCRIPTION
Why this PR
-------------------

Have data-testid values that are more debuggable and understandable.

**Boolean Node**
`bool1 -> and(csc209,csc258)`

**Hybrid Node**
`h46 -> h(csc301,csc318,csc384,csc418)`