### PR TITLE
General Updates - First PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,11 @@ jobs:
           command: |
             yarn run eslint
 
-      # TODO: Figure out why this fails.
-      # - run:
-      #     name: Generate documentation
-      #     command: |
-      #       stack exec courseography docs
+      - run:
+          name: Generate documentation
+          command: |
+            stack exec courseography docs
 
-      # - store_artifacts:
-      #     path: doc
-      #     destination: docs
+      - store_artifacts:
+          path: doc
+          destination: docs


### PR DESCRIPTION
- Update comments in `DynamicGraphs` for doc generation and language server ide support
- Fix issue with parallel edges being generated 
 This was caused by multiple references to the same grade when feeding `Req`s to reqsToGraph. For example if
```
reqs = [ 
("ACT240H1",OR [GRADE "63" (J "MAT137Y1" ""),GRADE "60" (J "MAT157Y1" "")]),
("ACT247H1",AND [J "ACT240H1" "",OR [GRADE "63" (J "MAT137Y1" ""),GRADE "60" (J "MAT157Y1" "")],J "STA257H1" ""
])]
```

Then the two references to `GRADE "63" (...)` would generate two DotEdge statements when running `reqToStmts reqs`. The fix is to filter out non-unique `DotStatements` after calling `reqToStmts` in `reqsToGraph`. Parsing `reqs` before calling `reqToStmts` would be too laborious and not result in any major performance gains.

- Fix issue with doc generation failing if `graph/gen` does not exist
- Uncomment the graph generation commands in `.circleci/config.yml`