### PR TITLE
Merge PR #1145 first: Update grade to prevent letters and numbers in course codes from being recognized as a grade

### DIFF
--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -63,6 +63,13 @@ gradeBefInputs = [
     , ("minimum grade of 75% CSC236H1", GRADE "75" $ J "CSC236H1" "")
     , ("minimum of 75% CSC236H1", GRADE "75" $ J "CSC236H1" "")
     , ("minimum (75%) CSC236H1", GRADE "75" $ J "CSC236H1" "")
+    , ("A grade of 75% in CSC236H1", GRADE "75" $ J "CSC236H1" "")
+    , ("At least C+ in CSC236H1", GRADE "C+" $ J "CSC236H1" "")
+    , ("A C+ in CSC236H1", GRADE "C+" $ J "CSC236H1" "")
+    , ("Minimum of 75% CSC236H1", GRADE "75" $ J "CSC236H1" "")
+    , ("Grade of C+ in CSC236H1", GRADE "C+" $ J "CSC236H1" "")
+    , ("A final grade of C+ in CSC236H1", GRADE "C+" $ J "CSC236H1" "")
+    , ("75% in CSC236H1", GRADE "75" $ J "CSC236H1" "")
     ]
 
 gradeAftInputs :: [(String, Req)]
@@ -83,7 +90,9 @@ artSciInputs = [
     , ("EEB223H1 (ecology and evo), STA220H1 (recommended)/ STA257H1 (recommended)", (AND [J "EEB223H1" "ecology and evo",OR [J "STA220H1" "recommended",J "STA257H1" "recommended"]]))
     , ("EEB223H1 (ecology and evo)/ STA220H1 (recommended)/ STA257H1", (OR [J "EEB223H1" "ecology and evo",J "STA220H1" "recommended",J "STA257H1" ""]))
     , ("EEB223H1 (ecology and evo)/ STA220H1 (B-)/ STA257H1", OR [J "EEB223H1" "ecology and evo", GRADE "B-" $ J "STA220H1" "", J "STA257H1" ""])
-    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", (FCES "0.5" $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""]))]
+    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", (FCES "0.5" $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""]))
+    , ("MATB23H3/STA220H1 (recommended)/STA257H1 (recommended)", (OR [J "MATB23H3" "",J "STA220H1" "recommended",J "STA257H1" "recommended"]))
+    ]
 
 noPrereqInputs :: [(String, Req)]
 noPrereqInputs = [

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -81,6 +81,10 @@ gradeAftInputs = [
     , ("CSC263H1 B-", GRADE "B-" $ J "CSC263H1" "") 
     , ("CSC263H1 with a minimum grade of 60%", GRADE "60" $ J "CSC263H1" "") 
     , ("CSC263H1 with a minimum mark of B-", GRADE "B-" $ J "CSC263H1" "")
+    , ("CSC236H1 (at least 75% or more)", GRADE "75" $ J "CSC236H1" "")
+    , ("CSC236H1 ( 75% or higher )", GRADE "75" $ J "CSC236H1" "")
+    , ("CSC263H1 with a minimum grade of 60% or more", GRADE "60" $ J "CSC263H1" "")
+    , ("CSC263H1 with a minimum grade of 60% or higher / CSC236H1 (75%)", OR [GRADE "60" $ J "CSC263H1" "", GRADE "75" $ J "CSC236H1" ""])
     ]
 
 artSciInputs :: [(String, Req)]

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -34,11 +34,18 @@ andInputs :: [(String, Req)]
 andInputs = [
       ("CSC165H1, CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
     , ("CSC120H1, CSC121H1, CSC148H1", AND [J "CSC120H1" "", J "CSC121H1" "", J "CSC148H1" ""])
+    , ("CSC165H1 & CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
     ]
 
 andorInputs :: [(String, Req)]
 andorInputs = [
       ("CSC148H1/CSC207H1, CSC165H1/CSC236H1", AND [OR [J "CSC148H1" "", J "CSC207H1" ""], OR [J "CSC165H1" "", J "CSC236H1" ""]])
+    , ("COG250Y1 and one of: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("COG250Y1 and one of either LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("COG250Y1 + one of the following: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("CLA204H1 + 1 OF CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
+    , ("BIO220H1 and at least one of EEB319H1/EEB321H1", AND [J "BIO220H1" "", OR [J "EEB319H1" "", J "EEB321H1" ""]])
+    , ("CLA204H1 plus one of CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
     ]
 
 parInputs :: [(String, Req)]

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -20,6 +20,10 @@ createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
                                 TestCase $ assertEqual ("for (" ++ x ++ "),")
                                 (Right y) (Parsec.parse parser "" x)) input
 
+createReqParserTest :: String -> [(String, Req)] -> Test
+createReqParserTest label input = TestLabel label $ TestList $ map (\(x, y) ->
+                                  TestCase $ assertEqual ("for (" ++ x ++ "),") y (parseReqs x)) input
+
 orInputs :: [(String, Req)]
 orInputs = [
       ("CSC120H1/CSC148H1", OR [J "CSC120H1" "", J "CSC148H1" ""])
@@ -81,6 +85,14 @@ artSciInputs = [
     , ("EEB223H1 (ecology and evo)/ STA220H1 (B-)/ STA257H1", OR [J "EEB223H1" "ecology and evo", GRADE "B-" $ J "STA220H1" "", J "STA257H1" ""])
     , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", (FCES "0.5" $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""]))]
 
+noPrereqInputs :: [(String, Req)]
+noPrereqInputs = [
+      ("", NONE)
+    , ("None", NONE)
+    , ("none", NONE)
+    , ("No", NONE)
+    , ("no", NONE)
+    ]
 
 orTests :: Test
 orTests = createTest categoryParser "Basic or Requirement" orInputs
@@ -106,6 +118,9 @@ gradeAftTests = createTest categoryParser "Basic grade requirements, where grade
 artSciTests :: Test
 artSciTests = createTest categoryParser "Arts and Science requirements from Christine's output" artSciInputs
 
+noPrereqTests :: Test
+noPrereqTests = createReqParserTest "No prerequisites required" noPrereqInputs
+
 -- functions for running tests in REPL
 reqTestSuite :: Test
-reqTestSuite = TestLabel "ReqParser tests" $ TestList [orTests, andTests, andorTests, parTests, fromParTests, gradeBefTests, gradeAftTests, artSciTests]
+reqTestSuite = TestLabel "ReqParser tests" $ TestList [orTests, andTests, andorTests, parTests, fromParTests, gradeBefTests, gradeAftTests, artSciTests, noPrereqTests]

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -28,6 +28,7 @@ orInputs :: [(String, Req)]
 orInputs = [
       ("CSC120H1/CSC148H1", OR [J "CSC120H1" "", J "CSC148H1" ""])
     , ("CSC108H1/CSC120H1/CSC148H1", OR [J "CSC108H1" "", J "CSC120H1" "", J "CSC148H1" ""])
+    , ("FOR300H1/FOR301H1/FOR302H1", OR [J "FOR300H1" "", J "FOR301H1" "", J "FOR302H1" ""])
     ]
 
 andInputs :: [(String, Req)]
@@ -40,12 +41,6 @@ andInputs = [
 andorInputs :: [(String, Req)]
 andorInputs = [
       ("CSC148H1/CSC207H1, CSC165H1/CSC236H1", AND [OR [J "CSC148H1" "", J "CSC207H1" ""], OR [J "CSC165H1" "", J "CSC236H1" ""]])
-    , ("COG250Y1 and one of: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("COG250Y1 and one of either LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("COG250Y1 + one of the following: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("CLA204H1 + 1 OF CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
-    , ("BIO220H1 and at least one of EEB319H1/EEB321H1", AND [J "BIO220H1" "", OR [J "EEB319H1" "", J "EEB321H1" ""]])
-    , ("CLA204H1 plus one of CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
     ]
 
 parInputs :: [(String, Req)]
@@ -92,6 +87,7 @@ gradeAftInputs = [
     , ("CSC236H1 ( 75% or higher )", GRADE "75" $ J "CSC236H1" "")
     , ("CSC263H1 with a minimum grade of 60% or more", GRADE "60" $ J "CSC263H1" "")
     , ("CSC263H1 with a minimum grade of 60% or higher / CSC236H1 (75%)", OR [GRADE "60" $ J "CSC263H1" "", GRADE "75" $ J "CSC236H1" ""])
+    , ("A in CSC236H1", GRADE "A" $ J "CSC236H1" "")
     ]
 
 artSciInputs :: [(String, Req)]

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -208,8 +208,10 @@ categoryParser :: Parser Req
 categoryParser = Parsec.try fcesParser <|> Parsec.try andParser
 
 parseReqs :: String -> Req
-parseReqs reqString =
-    let req = Parsec.parse categoryParser "" reqString
-    in case req of
-        Right x -> x
-        Left e -> J (show e) ""
+parseReqs reqString
+    | all (== ' ') reqString || reqString == "None" = NONE
+    | otherwise =
+        let req = Parsec.parse categoryParser "" reqString
+             in case req of
+                 Right x -> x
+                 Left e -> J (show e) ""

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -30,20 +30,19 @@ rParen :: Parser Char
 rParen = Parsec.char ')'
 
 orSeparator :: Parser String
-orSeparator = Parsec.choice $ map Parsec.string [
+orSeparator = Parsec.choice $ map caseInsensitiveStr [
     "/",
-    "OR",
-    "Or",
     "or"
     ]
 
 andSeparator :: Parser String
-andSeparator = Parsec.choice $ map Parsec.string [
+andSeparator = Parsec.choice $ map caseInsensitiveStr [
     ",",
-    "AND",
-    "And",
     "and",
-    ";"
+    ";",
+    "&",
+    "+",
+    "plus"
     ]
 
 semicolon :: Parser Char
@@ -67,7 +66,8 @@ creditsParser = do
 -- | Helpers for parsing grades
 percentParser :: Parser String
 percentParser = do
-    fces <- Parsec.many1 Parsec.digit
+    Parsec.try $ Parsec.notFollowedBy $ Parsec.digit >> (Parsec.count 2 Parsec.digit)
+    fces <- Parsec.count 2 Parsec.digit
     Parsec.optional (Parsec.char '%')
     return fces
 
@@ -180,6 +180,9 @@ utscCourseCodeParser = do
 -- We expect 3 letters followed by 3 digits or 4 letters followed by 2 digits, and a letter and a number.
 courseIDParser :: Parser String
 courseIDParser = do
+    _ <- Parsec.optional $ (Parsec.choice $ map caseInsensitiveStr ["one of either", "one of the following", "at least one of", "one of", "1 of"])
+    _ <- Parsec.optional $ Parsec.string ":"
+    Parsec.spaces
     courseCode <- Parsec.try utsgCourseCodeParser <|> utscCourseCodeParser
     sess <- Parsec.string "H" <|> Parsec.string "Y"
     sessNum <- Parsec.digit

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -5,6 +5,7 @@ import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
 import Text.Parsec ((<|>))
 import Database.Requirement
+import Data.Char (toLower)
 
 -- define separators
 fromSeparator :: Parser ()
@@ -208,10 +209,12 @@ categoryParser :: Parser Req
 categoryParser = Parsec.try fcesParser <|> Parsec.try andParser
 
 parseReqs :: String -> Req
-parseReqs reqString
-    | all (== ' ') reqString || reqString == "None" = NONE
-    | otherwise =
-        let req = Parsec.parse categoryParser "" reqString
-             in case req of
-                 Right x -> x
-                 Left e -> J (show e) ""
+parseReqs reqString = do
+    let reqStringLower = [toLower c | c <- reqString]
+    if all (== ' ') reqString || reqStringLower == "none" || reqStringLower == "no"
+        then NONE
+        else do
+            let req = Parsec.parse categoryParser "" reqString
+                in case req of
+                    Right x -> x
+                    Left e -> J (show e) ""

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -5,7 +5,7 @@ import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
 import Text.Parsec ((<|>))
 import Database.Requirement
-import Data.Char (toLower)
+import Data.Char (toLower, isSpace)
 
 -- define separators
 fromSeparator :: Parser ()
@@ -211,7 +211,7 @@ categoryParser = Parsec.try fcesParser <|> Parsec.try andParser
 parseReqs :: String -> Req
 parseReqs reqString = do
     let reqStringLower = [toLower c | c <- reqString]
-    if all (== ' ') reqString || reqStringLower == "none" || reqStringLower == "no"
+    if all isSpace reqString || reqStringLower == "none" || reqStringLower == "no"
         then NONE
         else do
             let req = Parsec.parse categoryParser "" reqString

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -87,7 +87,7 @@ infoParser= do
 -- a number with or without a percent symbol, or a letter A-F followed by a +/-.
 gradeParser :: Parser String
 gradeParser = do
-    grade <- (Parsec.between lParen rParen percentParser <|> letterParser) <|> (percentParser <|> letterParser)
+    grade <- (Parsec.between lParen rParen percentParser <|> letterParser) <|> percentParser <|> letterParser
     _ <- Parsec.try $ Parsec.lookAhead $ Parsec.choice $ map Parsec.try [
         andSeparator,
         orSeparator,
@@ -101,6 +101,7 @@ gradeParser = do
 coBefParser :: Parser Req
 coBefParser = do
     _ <- Parsec.optional $ caseInsensitiveStr "an " <|> caseInsensitiveStr "a "
+    Parsec.spaces
     grade <- cutoffHelper <|> gradeParser
     Parsec.spaces
     _ <- Parsec.manyTill Parsec.anyChar (Parsec.try $ Parsec.lookAhead singleParser)
@@ -109,7 +110,7 @@ coBefParser = do
 
     where
     cutoffHelper = do
-        _ <- Parsec.choice $ map (Parsec.try . (>> Parsec.space) . caseInsensitiveStr)
+        _ <- Parsec.choice $ map (Parsec.try . caseInsensitiveStr)
                 ["minimum grade", "minimum mark", "minimum", "grade", "final grade", "at least"]
         Parsec.spaces
         _ <- Parsec.optional $ caseInsensitiveStr "of"
@@ -248,7 +249,7 @@ categoryParser = Parsec.try fcesParser <|> Parsec.try andParser
 
 parseReqs :: String -> Req
 parseReqs reqString = do
-    let reqStringLower = [toLower c | c <- reqString]
+    let reqStringLower = map toLower reqString
     if all isSpace reqString || reqStringLower == "none" || reqStringLower == "no"
         then NONE
         else do

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -3,7 +3,7 @@ module WebParsing.ReqParser where
 
 import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
-import Text.Parsec ((<|>), (<?>))
+import Text.Parsec ((<|>))
 import Database.Requirement
 import Data.Char (toLower, toUpper, isSpace)
 
@@ -54,7 +54,7 @@ caseInsensitiveChar c = Parsec.char (toLower c) <|> Parsec.char (toUpper c)
 
 -- Match the string 's' regardless of the case of each character
 caseInsensitiveStr :: Parsec.Stream s m Char => String -> Parsec.ParsecT s u m String
-caseInsensitiveStr s = Parsec.try (mapM caseInsensitiveChar s) <?> "\"" ++ s ++ "\""
+caseInsensitiveStr s = Parsec.try (mapM caseInsensitiveChar s)
 
 creditsParser :: Parser String
 creditsParser = do
@@ -96,7 +96,6 @@ gradeParser = do
         Parsec.oneOf "(),/;" >> return ""
         ]
     return grade
-
 
 -- parse for cutoff percentage before a course
 coBefParser :: Parser Req

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -152,15 +152,30 @@ rawTextParser = do
     text <- Parsec.many $ Parsec.noneOf ";\r\n"
     return $ RAW text
 
--- | Parser for a single course.
--- We expect 3 letters, 3 digits, and a letter and a number.
-courseIDParser :: Parser String
-courseIDParser = do
+-- | Parser for a single UTSG course.
+-- We expect 3 letters, 3 digits
+utsgCourseCodeParser :: Parser String
+utsgCourseCodeParser = do
     code <- Parsec.count 3 Parsec.letter
     num <- Parsec.count 3 Parsec.digit
-    -- TODO: Make the last two letters more restricted.
-    sess <- Parsec.count 2 Parsec.alphaNum
-    return (code ++ num ++ sess)
+    return (code ++ num)
+
+-- | Parser for a single UTSC course.
+-- We expect 4 letters, 2 digits
+utscCourseCodeParser :: Parser String
+utscCourseCodeParser = do
+    code <- Parsec.count 4 Parsec.letter
+    num <- Parsec.count 2 Parsec.digit
+    return (code ++ num)
+
+-- | Parser for a single course.
+-- We expect 3 letters followed by 3 digits or 4 letters followed by 2 digits, and a letter and a number.
+courseIDParser :: Parser String
+courseIDParser = do
+    courseCode <- Parsec.try utsgCourseCodeParser <|> utscCourseCodeParser
+    sess <- Parsec.string "H" <|> Parsec.string "Y"
+    sessNum <- Parsec.digit
+    return (courseCode ++ sess ++ [sessNum])
 
 singleParser :: Parser Req
 singleParser = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,14 +6,8 @@ packages:
 - .
 allow-newer: true
 extra-deps:
-- binary-0.8.7.0
-- HaTeX-3.20.0.0
-- containers-0.5.11.0
-- graphviz-2999.20.0.3
-- happstack-server-7.5.1.3
-- sendfile-0.7.9
-- wl-pprint-extras-3.5.0.5
+- happstack-server-7.6.1
 compiler-check: newer-minor
-resolver: lts-13.19
+resolver: lts-14.27
 dump-logs: all
 require-stack-version: ! '>= 1.6'


### PR DESCRIPTION
For example, forestry courses have course code FOR100Y1
The parser may have picked up "F" as a grade requirement and "OR" as "or".

Also add more "and" representations such as "+", "&" and "plus".

This PR also fixes the issue when course prereqs are presented in the format of "A in MAT137H1". Previously, I skipped over the optional "A" at the beginning of the prereq sentence, so the "A" as a grade may be skipped over.

This fixes #1146 