### PR TITLE
Use magick executable for image conversion.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Install Package Dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y imagemagick texlive-latex-base
+            sudo apt-get install -y imagemagick-6-common texlive-latex-base
             stack update
 
             curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -

--- a/Setup.hs
+++ b/Setup.hs
@@ -10,7 +10,7 @@ main = defaultMainWithHooks
         -- | Checks existence of Config.hs. If it doesn't exist, copy it from DevelopmentConfig.hs
         -- And check that Imagemagick and LaTeX are available
         preBuildChecks _ _ = do
-            mapM_ checkDependency ["convert", "pdflatex"]
+            mapM_ checkDependency ["magick", "pdflatex"]
             configExistbool <- doesFileExist "app/Config.hs"
             case configExistbool of
                 False -> copyFile "app/DevelopmentConfig.hs" "app/Config.hs" >> return emptyHookedBuildInfo

--- a/app/Export/ImageConversion.hs
+++ b/app/Export/ImageConversion.hs
@@ -29,7 +29,7 @@ convertToImage :: String -> String -> IO
                       Maybe Handle,
                       ProcessHandle)
 convertToImage inName outName =
-    createProcess $ shell $ "convert " ++ inName ++ " " ++ outName
+    createProcess $ shell $ "magick convert " ++ inName ++ " " ++ outName
 
 -- | Removes a file.
 removeFile :: String -> IO ()


### PR DESCRIPTION
Useful to fix issue on Windows where the pre-build check passes because of a built-in `convert` executable, but Imagemagick isn't actually installed.