### PR TITLE
Add location option

### DIFF
--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -78,13 +78,13 @@ pickCourse options name =
 
 pickCourseByDepartment :: GraphOptions -> Text -> Bool
 pickCourseByDepartment options name =
-    Prelude.null (departments options)
-    || prefixedByOneOf name (departments options)
+    Prelude.null (departments options) ||
+    prefixedByOneOf name (departments options)
 
 pickCourseByLocation :: GraphOptions -> Text -> Bool
 pickCourseByLocation options name =
-    Prelude.null (location options)
-    || courseLocation `elem` map locationNum (location options)
+    Prelude.null (location options) ||
+    courseLocation `elem` map locationNum (location options)
     where
         courseLocation = last name
         locationNum l= case l of

--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -22,7 +22,7 @@ import qualified Data.Map.Strict as Map
 import Database.Requirement (Req(..))
 import Data.Sequence as Seq
 import Data.Hash.MD5 (Str(Str), md5s)
-import Data.Text.Lazy (Text, pack, isPrefixOf, isInfixOf)
+import Data.Text.Lazy (Text, pack, isPrefixOf, isInfixOf, last)
 import Data.Containers.ListUtils (nubOrd)
 import Control.Monad.State (State)
 import qualified Control.Monad.State as State
@@ -71,11 +71,33 @@ reqsToGraph options reqs = do
 
 data GeneratorState = GeneratorState Integer (Map.Map Text (DotNode Text))
 
+pickCourse :: GraphOptions -> Text -> Bool
+pickCourse options name =
+    pickCourseByDepartment options name &&
+    pickCourseByLocation options name
+
+pickCourseByDepartment :: GraphOptions -> Text -> Bool
+pickCourseByDepartment options name =
+    Prelude.null (departments options)
+    || prefixedByOneOf name (departments options)
+
+pickCourseByLocation :: GraphOptions -> Text -> Bool
+pickCourseByLocation options name =
+    Prelude.null (location options)
+    || courseLocation `elem` map locationNum (location options)
+    where
+        courseLocation = last name
+        locationNum l= case l of
+            "utsg" -> '1'
+            "utsc" -> '3'
+            "utm"  -> '5'
+            _ -> 'e' -- TODO we need to validate input
+
 -- | Convert the original requirement data into dot statements that can be used by buildGraph to create the
 -- corresponding DotGraph objects.
 reqToStmts :: GraphOptions -> (Text, Req) -> State GeneratorState [DotStatement Text]
 reqToStmts options (name, req) = do
-    if Prelude.null (departments options) || prefixedByOneOf name (departments options)
+    if pickCourse options name
         then do 
             node <- makeNode name
             stmts <- reqToStmts' options (nodeID node) req
@@ -86,10 +108,13 @@ reqToStmts' :: GraphOptions -> Text -> Req -> State GeneratorState [DotStatement
 -- No prerequisites.
 reqToStmts' _ _ NONE = return []
 -- A single course prerequisite.
-reqToStmts' _ parentID (J name2 _) = do       
-    prereq <- makeNode (pack name2)
-    edge <- makeEdge (nodeID prereq) parentID
-    return [DN prereq, DE edge]
+reqToStmts' options parentID (J name2 _) = do
+    if pickCourse options (pack name2) then do
+        prereq <- makeNode (pack name2)
+        edge <- makeEdge (nodeID prereq) parentID
+        return [DN prereq, DE edge]
+    else
+        return []
         
 -- Two or more required prerequisites.
 reqToStmts' options parentID (AND reqs) = do
@@ -140,7 +165,7 @@ reqToStmts' options parentID (FCES creds req) = do
     fceNode <- makeNode (pack $ "at least " ++ creds ++ " FCEs")
     edge <- makeEdge (nodeID fceNode) parentID
     prereqStmts <- reqToStmts' options (nodeID fceNode) req
-    return $  [DN fceNode, DE edge] ++ prereqStmts
+    return $ [DN fceNode, DE edge] ++ prereqStmts
 
 atLeastTwoCourseReqs :: [Req] -> Bool
 atLeastTwoCourseReqs reqs = Prelude.length (Prelude.filter isNotRawOrNone reqs) > 1

--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -29,6 +29,7 @@ import qualified Control.Monad.State as State
 import Control.Monad (mapM, liftM)
 import DynamicGraphs.GraphOptions (GraphOptions(..), defaultGraphOptions)
 import Prelude hiding (last)
+import Data.Maybe (mapMaybe)
 
 -- | Generates a DotGraph dependency graph including all the given courses and their recursive dependecies
 coursesToPrereqGraph :: [String] -- ^ courses to generate
@@ -84,14 +85,14 @@ pickCourseByDepartment options name =
 pickCourseByLocation :: GraphOptions -> Text -> Bool
 pickCourseByLocation options name =
     Prelude.null (location options) ||
-    courseLocation `elem` map locationNum (location options)
+    courseLocation `elem` mapMaybe locationNum (location options)
     where
         courseLocation = last name
-        locationNum l= case l of
-            "utsg" -> '1'
-            "utsc" -> '3'
-            "utm"  -> '5'
-            _ -> 'e' -- TODO we need to validate input
+        locationNum l = case l of
+            "utsg" -> Just '1'
+            "utsc" -> Just '3'
+            "utm" -> Just '5'
+            _ -> Nothing
 
 -- | Convert the original requirement data into dot statements that can be used by buildGraph to create the
 -- corresponding DotGraph objects.

--- a/app/DynamicGraphs/GraphOptions.hs
+++ b/app/DynamicGraphs/GraphOptions.hs
@@ -10,7 +10,7 @@ data GraphOptions =
                    maxDepth :: Int,          -- total recursive depth to recurse on (depth of the overall graph)
                    courseNumPrefix :: [Int], -- filter based on course number (most useful for filtering based on year)
                    distribution :: [T.Text], -- distribution to include: like "artsci", or "engineering"
-                   location :: [T.Text],     -- location of courses to include: like "st_george", or "scarborough"
+                   location :: [T.Text],     -- location of courses to include: like "utsg", or "utsc"
                    includeRaws :: Bool,      -- True to include nodes which are raw values
                    includeGrades :: Bool     -- True to include grade nodes
                 } deriving (Show)


### PR DESCRIPTION
Add functionality to filter generated graphs based by course locations. For example:
```
{"courses":["ACT348H1"], "location": ["utsg", "utm"]}
```
only includes courses from St. George and UTM. Allowed arguments are `"utsg", "utm", "utsc"`.