### PR TITLE
svg-parser: Remove duplicate points in path

### DIFF
--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -231,7 +231,7 @@ parsePath key tags =
     concatMap (parsePathHelper key trans edgeInfo) (filter (TS.isTagOpenName "path") tags)
     where
         trans = getTransform $ head tags
-        edgeInfo = 
+        edgeInfo =
             if (length splitArr) == 2
                 then (T.pack (splitArr !! 0), T.pack (splitArr !! 1)) -- not super type-safe
                 else ("", "")
@@ -256,12 +256,21 @@ parsePathHelper key trans (src, dst) pathTag =
     else [updatePath fillAttr $
             Path key
                 ""
-                realD
+                (removeDups realD)
                 ""
                 ""
                 isRegion
                 src
                 dst]
+    where
+        -- Remove consecutive duplicated points
+        removeDups :: Eq a => [a] -> [a]
+        removeDups [] = []
+        removeDups [p] = [p]
+        removeDups (x:xs) =
+            if x == head xs
+                then removeDups xs
+                else x : removeDups xs
 
 
 -- | Create an ellipse from an open ellipse tag.


### PR DESCRIPTION
On some of the dynamically-generated graphs, some arrowheads were not facing the correct direction:

![image](https://user-images.githubusercontent.com/3333115/104827027-975d4700-5851-11eb-9e2b-b57a535cf230.png)

This was because the generated SVG from Graphviz had paths with a duplicate point at the end, e.g.:

```
<path fill="none" stroke="black" d="M554.5,-285C554.5,-267.32 554.5,-243 554.5,-243 554.5,-243 469.51,-243 469.51,-243"/>
```

This pull request modifies the SVG parsing to remove such duplicated points.