### PR TITLE
add `dynamic` information to db

### DIFF
--- a/app/Database/CourseInsertion.hs
+++ b/app/Database/CourseInsertion.hs
@@ -32,7 +32,7 @@ saveGraphJSON jsonStr nameStr = do
     where
         insertGraph :: T.Text -> [Text] -> [Shape] -> [Path] -> SqlPersistM ()
         insertGraph nameStr_ texts shapes paths = do
-            gId <- insert $ Graph nameStr_ 256 256
+            gId <- insert $ Graph nameStr_ 256 256 False
             insertMany_ $ map (\text -> text {textGraph = gId}) texts
             insertMany_ $ map (\shape -> shape {shapeGraph = gId}) shapes
             insertMany_ $ map (\path -> path {pathGraph = gId}) paths

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -93,6 +93,7 @@ Graph json
     title T.Text
     width Double
     height Double
+    dynamic Bool
     deriving Show
 
 Text json

--- a/app/Svg/Database.hs
+++ b/app/Svg/Database.hs
@@ -11,17 +11,18 @@ module Svg.Database
     (insertGraph, insertElements, deleteGraphs) where
 
 import Database.Persist.Sqlite
-import Database.Tables hiding (graphWidth, graphHeight, paths, shapes, texts)
+import Database.Tables hiding (graphWidth, graphHeight, graphDynamic, paths, shapes, texts)
 import qualified Data.Text as T
 
 -- | Insert a new graph into the database, returning the key of the new graph.
 insertGraph :: T.Text   -- ^ The title of the graph that is being inserted.
             -> Double   -- ^ The width dimension of the graph
             -> Double   -- ^ The height dimension of the graph
+            -> Bool     -- ^ True if graph is dynamically generated            
             -> SqlPersistM GraphId -- ^ The unique identifier of the inserted graph.
-insertGraph graphName graphWidth graphHeight = do
+insertGraph graphName graphWidth graphHeight graphDynamic = do
     runMigration migrateAll
-    insert (Graph graphName graphWidth graphHeight)
+    insert (Graph graphName graphWidth graphHeight graphDynamic)
 
 -- | Insert graph components into the database.
 insertElements :: ([Path], [Shape], [Text]) -> SqlPersistM ()

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -61,7 +61,7 @@ parsePrebuiltSvgs = runSqlite databasePath $ do
 
 parseDynamicSvg :: T.Text -> T.Text -> IO ()
 parseDynamicSvg graphName graphContents =
-    runSqlite databasePath $ performParseFromMemory graphName graphContents
+    runSqlite databasePath $ performParseFromMemory graphName graphContents True
 
 -- | The starting point for parsing a graph with a given title and file.
 performParse :: T.Text -- ^ The title of the graph.
@@ -70,11 +70,14 @@ performParse :: T.Text -- ^ The title of the graph.
 performParse graphName inputFilename = do
     liftIO . print $ "Parsing graph " ++ T.unpack graphName ++ " from file " ++ inputFilename
     graphFile <- liftIO $ T.readFile (graphPath ++ inputFilename)
-    performParseFromMemory graphName graphFile
+    performParseFromMemory graphName graphFile False
 
-performParseFromMemory :: T.Text -> T.Text -> SqlPersistM ()
-performParseFromMemory graphName graphSvg = do
-    key <- insertGraph graphName graphWidth graphHeight
+performParseFromMemory :: T.Text -- ^ The title of the graph
+                       -> T.Text -- ^ Filename of the SVG to parse
+                       -> Bool -- ^ True if SVG is dynamically generated
+                       -> SqlPersistM ()
+performParseFromMemory graphName graphSvg isDynamic = do
+    key <- insertGraph graphName graphWidth graphHeight isDynamic
     let parsedGraph = parseSvg key graphSvg
     insertElements parsedGraph
         where (graphWidth, graphHeight) = parseSizeFromSvg graphSvg


### PR DESCRIPTION
Add a new column to Graph Table to include information about whether the graph was dynamically generated or not.

DB migrations are pretty flaky so any old database files will have to be deleted and regenerated:

```
stack exec courseography graphs 
stack exec courseography database
```