### PR TITLE
css: Remove padding from graph buttons

### DIFF
--- a/style/app.scss
+++ b/style/app.scss
@@ -519,6 +519,7 @@ a:active
   display          : inline-block;
   width            : 25px;
   height           : 25px;
+  padding          : 0;
   position         : absolute;
 }
 


### PR DESCRIPTION
The previous padding was causing some of the graph button labels to appear off-centre:

![image](https://user-images.githubusercontent.com/3333115/117084237-38570b80-ad36-11eb-93f6-ef4f1d8352e4.png)

After removing the padding, the labels are now centred:

![image](https://user-images.githubusercontent.com/3333115/117084307-650b2300-ad36-11eb-9e89-4bbe485d831b.png)
