### PR TITLE
Turned methods into arrow functions and removed constructor

### DIFF
--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -3,14 +3,7 @@ import React from "react";
 import Node from "./Node";
 
 export default class NodeGroup extends React.Component {
-  constructor(props) {
-    super(props);
-    this.reset = this.reset.bind(this);
-    this.findRelationship = this.findRelationship.bind(this);
-    this.setRefEntry = this.setRefEntry.bind(this);
-  }
-
-  reset() {
+  reset = () => {
     this.props.nodesJSON.forEach(nodeJSON => {
       var node = this[nodeJSON.id_];
       var state = node.props.parents.length === 0 ? "takeable" : "inactive";
@@ -27,7 +20,7 @@ export default class NodeGroup extends React.Component {
   }
 
   // Helper for hybrid computation
-  findRelationship(course) {
+  findRelationship = course => {
     var nodes = this.props.nodesJSON;
     var node = nodes.find(
       n =>
@@ -37,7 +30,7 @@ export default class NodeGroup extends React.Component {
     return node;
   }
 
-  setRefEntry(entry) {
+  setRefEntry = entry => {
     return (elem) => elem && (this[entry.id_] = elem);
   }
 


### PR DESCRIPTION
Changed `reset`, `findRelationship`, and `setRefEntry` into arrow functions.
Removed the calls to `bind` in the constructor. Deleted the constructor as it only contained a call to `super(props)`.