### PR TITLE
Added children to graph state as object

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -36,7 +36,7 @@ export default class Graph extends React.Component {
       draggingNode: null,
       currFocus: null,
       graphName: null,
-      children: null
+      connections: null
     };
 
     this.svg = React.createRef();
@@ -138,7 +138,8 @@ export default class Graph extends React.Component {
         var hybridsList = [];
         var boolsList = [];
         var edgesList = [];
-        var children = {};
+        var childrenObj = {};
+        var outEdgesObj= {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -163,12 +164,14 @@ export default class Graph extends React.Component {
         });
 
         nodesList.forEach(function(node) {
-          children[node.id_] = [];
+          childrenObj[node.id_] = [];
+          outEdgesObj[node.id_] = [];
         });
 
         edgesList.forEach(function(edge) {
-          if (edge.source in children) {
-            children[edge.source].push(edge.target);
+          if (edge.source in childrenObj) {
+            childrenObj[edge.source].push(edge.target);
+            outEdgesObj[edge.source].push(edge.id_);
           }
         });
 
@@ -185,7 +188,7 @@ export default class Graph extends React.Component {
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
           graphName: graphName,
-          children: children
+          connections: {'children': childrenObj, 'outEdges': outEdgesObj}
         });
       })
       .catch(err => {
@@ -718,6 +721,7 @@ export default class Graph extends React.Component {
             edgesJSON={this.state.edgesJSON}
             highlightedNodes={this.state.highlightedNodes}
             onDraw={this.state.onDraw}
+            connections={this.state.connections}
           />
           <BoolGroup
             ref={this.bools}

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -142,7 +142,7 @@ export default class Graph extends React.Component {
         var boolsList = [];
         var edgesList = [];
         var childrenObj = {};
-        var outEdgesObj= {};
+        var outEdgesObj = {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -166,12 +166,12 @@ export default class Graph extends React.Component {
           }
         });
 
-        nodesList.forEach(function(node) {
+        nodesList.forEach(node => {
           childrenObj[node.id_] = [];
           outEdgesObj[node.id_] = [];
         });
 
-        edgesList.forEach(function(edge) {
+        edgesList.forEach(edge => {
           if (edge.source in childrenObj) {
             childrenObj[edge.source].push(edge.target);
             outEdgesObj[edge.source].push(edge.id_);

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -35,7 +35,8 @@ export default class Graph extends React.Component {
       drawNodeID: 0,
       draggingNode: null,
       currFocus: null,
-      graphName: null
+      graphName: null,
+      children: null
     };
 
     this.svg = React.createRef();
@@ -137,6 +138,7 @@ export default class Graph extends React.Component {
         var hybridsList = [];
         var boolsList = [];
         var edgesList = [];
+        var childs = {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -159,6 +161,17 @@ export default class Graph extends React.Component {
             edgesList.push(entry);
           }
         });
+
+        nodesList.forEach(function(node) {
+          let output = [];
+          edgesList.forEach(function(edge) {
+            if (node.id_ === edge.source) {
+              output.push(edge.target);
+            }
+          });
+          childs[node.id_] = output;
+        });
+
         this.setState({
           labelsJSON: labelsList,
           regionsJSON: regionsList,
@@ -171,7 +184,8 @@ export default class Graph extends React.Component {
           zoomFactor: 1,
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
-          graphName: graphName
+          graphName: graphName,
+          children: childs
         });
       })
       .catch(err => {

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -138,7 +138,7 @@ export default class Graph extends React.Component {
         var hybridsList = [];
         var boolsList = [];
         var edgesList = [];
-        var childs = {};
+        var children = {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -163,13 +163,13 @@ export default class Graph extends React.Component {
         });
 
         nodesList.forEach(function(node) {
-          let output = [];
-          edgesList.forEach(function(edge) {
-            if (node.id_ === edge.source) {
-              output.push(edge.target);
-            }
-          });
-          childs[node.id_] = output;
+          children[node.id_] = [];
+        });
+
+        edgesList.forEach(function(edge) {
+          if (edge.source in children) {
+            children[edge.source].push(edge.target);
+          }
         });
 
         this.setState({
@@ -185,7 +185,7 @@ export default class Graph extends React.Component {
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
           graphName: graphName,
-          children: childs
+          children: children
         });
       })
       .catch(err => {

--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -125,6 +125,11 @@ export default class NodeGroup extends React.Component {
               inEdges.push(element.id_);
             }
           });
+          hybridRelationships.forEach(element => {
+            if (element[0] === entry.id_) {
+              this.props.connections.children[entry.id_].push(element[1]);
+            }
+          });
           return (
             <Node
               JSON={entry}

--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -118,21 +118,11 @@ export default class NodeGroup extends React.Component {
         {this.props.nodesJSON.map(entry => {
           var highlighted = highlightedNodes.indexOf(entry.id_) >= 0;
           var parents = [];
-          var childs = [];
-          var outEdges = [];
           var inEdges = [];
           this.props.edgesJSON.forEach(element => {
             if (entry.id_ === element.target) {
               parents.push(element.source);
               inEdges.push(element.id_);
-            } else if (entry.id_ === element.source) {
-              childs.push(element.target);
-              outEdges.push(element.id_);
-            }
-          });
-          hybridRelationships.forEach(element => {
-            if (element[0] === entry.id_) {
-              childs.push(element[1]);
             }
           });
           return (
@@ -143,9 +133,9 @@ export default class NodeGroup extends React.Component {
               ref={this.setRefEntry(entry)}
               hybrid={false}
               parents={parents}
-              childs={childs}
+              childs={this.props.connections.children[entry.id_]}
               inEdges={inEdges}
-              outEdges={outEdges}
+              outEdges={this.props.connections.outEdges[entry.id_]}
               svg={svg}
               highlighted={highlighted}
               onClick={this.props.nodeClick}
@@ -272,5 +262,6 @@ NodeGroup.propTypes = {
   nodeMouseEnter: PropTypes.func,
   nodeMouseLeave: PropTypes.func,
   nodesJSON: PropTypes.array,
+  connections: PropTypes.object,
   svg: PropTypes.object
 };


### PR DESCRIPTION
As said, calculated children in the getGraph in fetch(url).then(data => ...) and verified correct children by checking the corresponding state in the Graph React component using Inspect element. The children are stored as an object literal, where the key is node id and value is a list of the Bool and Node id's.

**I have not removed the edgesJSON map from the BoolGroup render method.** 