### PR TITLE
Map nodeID to parents

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -162,7 +162,7 @@ export default class Graph extends React.Component {
           }
         });
 
-        // An object connecting a node to its parents/childs improves efficiency in NodeGrp/BoolGrp
+        // An object mapping a node to its parents/childs improves efficiency in NodeGroup/BoolGroup
         nodesList.forEach(node => {
           parentsObj[node.id_] = [];
         });

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -724,6 +724,7 @@ export default class Graph extends React.Component {
             edgesJSON={this.state.edgesJSON}
             highlightedNodes={this.state.highlightedNodes}
             onDraw={this.state.onDraw}
+            parentTree={this.state.parentTree}
           />
           <BoolGroup
             ref={this.bools}

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -36,7 +36,8 @@ export default class Graph extends React.Component {
       draggingNode: null,
       currFocus: null,
       graphName: null,
-      parents: null
+      parents: null,
+      parentTree: null
     };
 
     this.svg = React.createRef();
@@ -139,6 +140,7 @@ export default class Graph extends React.Component {
         var boolsList = [];
         var edgesList = [];
         var parentsObj = {};
+        var inEdgesObj = {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -165,11 +167,13 @@ export default class Graph extends React.Component {
         // An object mapping a node to its parents/childs improves efficiency in NodeGroup/BoolGroup
         nodesList.forEach(node => {
           parentsObj[node.id_] = [];
+          inEdgesObj[node.id_] = [];
         });
 
         edgesList.forEach(edge => {
           if (edge.target in parentsObj) {
             parentsObj[edge.target].push(edge.source);
+            inEdgesObj[edge.target].push(edge.id_);
           }
         });
 
@@ -186,7 +190,8 @@ export default class Graph extends React.Component {
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
           graphName: graphName,
-          parents: parentsObj
+          parents: parentsObj,
+          parentTree: {'parents': parentsObj, 'inEdges': inEdgesObj}
         });
       })
       .catch(err => {

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -36,7 +36,7 @@ export default class Graph extends React.Component {
       draggingNode: null,
       currFocus: null,
       graphName: null,
-      parentTree: null
+      connections: null
     };
 
     this.svg = React.createRef();
@@ -189,7 +189,7 @@ export default class Graph extends React.Component {
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
           graphName: graphName,
-          parentTree: {'parents': parentsObj, 'inEdges': inEdgesObj}
+          connections: {'parents': parentsObj, 'inEdges': inEdgesObj}
         });
       })
       .catch(err => {
@@ -722,7 +722,7 @@ export default class Graph extends React.Component {
             edgesJSON={this.state.edgesJSON}
             highlightedNodes={this.state.highlightedNodes}
             onDraw={this.state.onDraw}
-            parentTree={this.state.parentTree}
+            connections={this.state.connections}
           />
           <BoolGroup
             ref={this.bools}

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -35,7 +35,8 @@ export default class Graph extends React.Component {
       drawNodeID: 0,
       draggingNode: null,
       currFocus: null,
-      graphName: null
+      graphName: null,
+      parents: null
     };
 
     this.svg = React.createRef();
@@ -132,27 +133,12 @@ export default class Graph extends React.Component {
       })
       .then(data => {
         localStorage.setItem("active-graph", graphName);
-
-        // TODO: Create an object mapping nodeIDS to the IDs of preceeding nodes to replace:
-        /**
-         * this.props.edgesJSON.forEach(element => {
-            if (entry.id_ === element.target) {
-              parents.push(element.source);
-              inEdges.push(element.id_);
-            } else if (entry.id_ === element.source) {
-              childs.push(element.target);
-              outEdges.push(element.id_);
-            }
-          });
-
-          where entry is a Node
-         */
-
         var regionsList = [];
         var nodesList = [];
         var hybridsList = [];
         var boolsList = [];
         var edgesList = [];
+        var parentsObj = {};
 
         var labelsList = data.texts.filter(function(entry) {
           return entry.rId.startsWith("tspan");
@@ -175,6 +161,18 @@ export default class Graph extends React.Component {
             edgesList.push(entry);
           }
         });
+
+        // An object connecting a node to its parents/childs improves efficiency in NodeGrp/BoolGrp
+        nodesList.forEach(node => {
+          parentsObj[node.id_] = [];
+        });
+
+        edgesList.forEach(edge => {
+          if (edge.target in parentsObj) {
+            parentsObj[edge.target].push(edge.source);
+          }
+        });
+
         this.setState({
           labelsJSON: labelsList,
           regionsJSON: regionsList,
@@ -187,7 +185,8 @@ export default class Graph extends React.Component {
           zoomFactor: 1,
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
-          graphName: graphName
+          graphName: graphName,
+          parents: parentsObj
         });
       })
       .catch(err => {

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -163,7 +163,6 @@ export default class Graph extends React.Component {
           }
         });
 
-        // An object mapping a node to its parents/childs improves efficiency in NodeGroup/BoolGroup
         nodesList.forEach(node => {
           parentsObj[node.id_] = [];
           inEdgesObj[node.id_] = [];

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -179,6 +179,9 @@ export default class Graph extends React.Component {
           if (edge.target in parentsObj) {
             parentsObj[edge.target].push(edge.source);
             inEdgesObj[edge.target].push(edge.id_);
+          }
+
+          if (edge.source in childrenObj) {
             childrenObj[edge.source].push(edge.target);
             outEdgesObj[edge.source].push(edge.id_);
           }

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -132,6 +132,22 @@ export default class Graph extends React.Component {
       })
       .then(data => {
         localStorage.setItem("active-graph", graphName);
+
+        // TODO: Create an object mapping nodeIDS to the IDs of preceeding nodes to replace:
+        /**
+         * this.props.edgesJSON.forEach(element => {
+            if (entry.id_ === element.target) {
+              parents.push(element.source);
+              inEdges.push(element.id_);
+            } else if (entry.id_ === element.source) {
+              childs.push(element.target);
+              outEdges.push(element.id_);
+            }
+          });
+
+          where entry is a Node
+         */
+
         var regionsList = [];
         var nodesList = [];
         var hybridsList = [];

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -36,7 +36,6 @@ export default class Graph extends React.Component {
       draggingNode: null,
       currFocus: null,
       graphName: null,
-      parents: null,
       parentTree: null
     };
 
@@ -190,7 +189,6 @@ export default class Graph extends React.Component {
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
           graphName: graphName,
-          parents: parentsObj,
           parentTree: {'parents': parentsObj, 'inEdges': inEdgesObj}
         });
       })

--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -126,9 +126,9 @@ export default class NodeGroup extends React.Component {
               key={entry.id_}
               ref={this.setRefEntry(entry)}
               hybrid={false}
-              parents={this.props.parentTree['parents']}
+              parents={this.props.parentTree.parents[entry.id_]}
               childs={childs}
-              inEdges={this.props.parentTree['inEdges']}
+              inEdges={this.props.parentTree.inEdges[entry.id_]}
               outEdges={outEdges}
               svg={svg}
               highlighted={highlighted}

--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -106,15 +106,10 @@ export default class NodeGroup extends React.Component {
         })}
         {this.props.nodesJSON.map(entry => {
           var highlighted = highlightedNodes.indexOf(entry.id_) >= 0;
-          var parents = [];
           var childs = [];
           var outEdges = [];
-          var inEdges = [];
           this.props.edgesJSON.forEach(element => {
-            if (entry.id_ === element.target) {
-              parents.push(element.source);
-              inEdges.push(element.id_);
-            } else if (entry.id_ === element.source) {
+            if (entry.id_ === element.source) {
               childs.push(element.target);
               outEdges.push(element.id_);
             }
@@ -131,9 +126,9 @@ export default class NodeGroup extends React.Component {
               key={entry.id_}
               ref={this.setRefEntry(entry)}
               hybrid={false}
-              parents={parents}
+              parents={this.props.parentTree['parents']}
               childs={childs}
-              inEdges={inEdges}
+              inEdges={this.props.parentTree['inEdges']}
               outEdges={outEdges}
               svg={svg}
               highlighted={highlighted}
@@ -261,5 +256,6 @@ NodeGroup.propTypes = {
   nodeMouseEnter: PropTypes.func,
   nodeMouseLeave: PropTypes.func,
   nodesJSON: PropTypes.array,
+  parentTree: PropTypes.object,
   svg: PropTypes.object
 };

--- a/js/components/graph/NodeGroup.js
+++ b/js/components/graph/NodeGroup.js
@@ -126,9 +126,9 @@ export default class NodeGroup extends React.Component {
               key={entry.id_}
               ref={this.setRefEntry(entry)}
               hybrid={false}
-              parents={this.props.parentTree.parents[entry.id_]}
+              parents={this.props.connections.parents[entry.id_]}
               childs={childs}
-              inEdges={this.props.parentTree.inEdges[entry.id_]}
+              inEdges={this.props.connections.inEdges[entry.id_]}
               outEdges={outEdges}
               svg={svg}
               highlighted={highlighted}
@@ -256,6 +256,6 @@ NodeGroup.propTypes = {
   nodeMouseEnter: PropTypes.func,
   nodeMouseLeave: PropTypes.func,
   nodesJSON: PropTypes.array,
-  parentTree: PropTypes.object,
+  connections: PropTypes.object,
   svg: PropTypes.object
 };


### PR DESCRIPTION
Created an object mapping nodeIDs to nodeIDs/boolIDs of the nodes preceding the current one (parent nodes). This includes:

- Added a new `parents` state to `Graph`
- Initialized an object `parentsObj` with the `node.id_` as the keys and a blank list for values by iterating over `nodesList`
- Updated the object by iterating over the `edgesList`
- Added a comment explaining why this object was created
- Set `parents` to `parentsObj`