### PR TITLE
Renaming reset button

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -664,7 +664,7 @@ export default class Graph extends React.Component {
         />
         <Button
           divId="reset-button"
-          text="Reset"
+          text="Reset View"
           mouseDown={this.resetZoomAndPan}
           mouseUp={this.onButtonRelease}
           onMouseEnter={this.buttonMouseEnter}

--- a/js/components/graph/Sidebar.js
+++ b/js/components/graph/Sidebar.js
@@ -14,10 +14,10 @@ export default class Sidebar extends React.Component {
     };
   }
 
-  componentWillUpdate(prevProps) { 
+  componentWillUpdate(prevProps) {
     if (prevProps.graphName !== this.state.graphName) {
       this.setState({ graphName: prevProps.graphName }, () => {
-        this.handleFocusEnabled(); 
+        this.handleFocusEnabled();
       });
     }
   }
@@ -119,7 +119,7 @@ export default class Sidebar extends React.Component {
     return (
       <div id="fce" className={contentHiddenClass}>
         <div id="fcecount" data-testid="test-fcecount">FCE Count: {fceString}</div>
-        <button id="reset" data-testid="test-reset" onClick={() => this.props.reset()}>Reset Graph</button>
+        <button id="reset" data-testid="test-reset" onClick={() => this.props.reset()}>Reset Selection</button>
       </div>
     )
   }
@@ -181,7 +181,7 @@ export default class Sidebar extends React.Component {
           {this.renderSidebarNav()}
           {this.renderSidebarButtons()}
         </div>
-        
+
         <div id="sidebar-button" onClick={() => this.toggleSidebar("button")} data-testid="test-sidebar-button">
           <img id="sidebar-icon"
            className={flippedClass}

--- a/js/components/graph/__tests__/__snapshots__/Sidebar.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/Sidebar.test.js.snap
@@ -4,32 +4,32 @@ exports[`Sidebar should match shallow snapshot 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    
+
 
     <nav>
-      
-    
+
+
       <li>
-        
-        
+
+
         <a
           id="nav-export"
         >
           Export
         </a>
-        
-    
+
+
       </li>
-      
+
 
     </nav>
-    
+
 
     <div
       class="react-graph"
       id="react-graph"
     />
-    
+
 
     <div
       id="fcecount"
@@ -49,13 +49,13 @@ Object {
               data-testid="test-fcecount"
               id="fcecount"
             >
-              FCE Count: 
+              FCE Count:
             </div>
             <button
               data-testid="test-reset"
               id="reset"
             >
-              Reset Graph
+              Reset Selection
             </button>
           </div>
           <nav
@@ -256,13 +256,13 @@ Object {
             data-testid="test-fcecount"
             id="fcecount"
           >
-            FCE Count: 
+            FCE Count:
           </div>
           <button
             data-testid="test-reset"
             id="reset"
           >
-            Reset Graph
+            Reset Selection
           </button>
         </div>
         <nav

--- a/js/components/graph/__tests__/__snapshots__/Sidebar.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/Sidebar.test.js.snap
@@ -4,32 +4,32 @@ exports[`Sidebar should match shallow snapshot 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-
+    
 
     <nav>
-
-
+      
+    
       <li>
-
-
+        
+        
         <a
           id="nav-export"
         >
           Export
         </a>
-
-
+        
+    
       </li>
-
+      
 
     </nav>
-
+    
 
     <div
       class="react-graph"
       id="react-graph"
     />
-
+    
 
     <div
       id="fcecount"
@@ -49,7 +49,7 @@ Object {
               data-testid="test-fcecount"
               id="fcecount"
             >
-              FCE Count:
+              FCE Count: 
             </div>
             <button
               data-testid="test-reset"
@@ -256,7 +256,7 @@ Object {
             data-testid="test-fcecount"
             id="fcecount"
           >
-            FCE Count:
+            FCE Count: 
           </div>
           <button
             data-testid="test-reset"

--- a/style/app.scss
+++ b/style/app.scss
@@ -583,6 +583,7 @@ a:active
   width : 52px;
   top   : 111px;
   right : 30px;
+  height: auto;
 }
 
 .opened


### PR DESCRIPTION
Resolved reset button confusion by:

- Renaming the button that controls position/zoom to 'Reset View'
- Renaming the button the controls the course selections on the graph to 'Reset Selection'
- Fixed the css to accommodate the name change for 'Reset View', specifically set the `height` to `auto` since 'View' did not fit

The empty space changes were done automatically by the setting you asked us to set ("remove trailing whitespace"), but I can reverse that change if you want. Also, I was not sure if it is best practice to use `auto`, but it fixed the height quite nicely. I can change it to a pixel number if that is preferred. Honestly I think the buttons look a bit odd now, so we can improve the UI in a future PR.

Additionally, I found some test files that refer to these buttons, should I update them to reflect the change?