### PR TITLE
moved unchanging style for InfoBox to css

### DIFF
--- a/js/components/graph/InfoBox.js
+++ b/js/components/graph/InfoBox.js
@@ -5,10 +5,7 @@ export default class InfoBox extends React.Component {
 
   render() {
     if (this.props.showInfoBox) {
-      //TODO: move to CSS
       var gStyles = {
-        cursor: "pointer",
-        transition: "opacity .4s",
         opacity: this.props.showInfoBox ? 1 : 0
       };
       var rectAttrs = {

--- a/js/components/graph/InfoBox.js
+++ b/js/components/graph/InfoBox.js
@@ -4,47 +4,42 @@ import PropTypes from "prop-types";
 export default class InfoBox extends React.Component {
 
   render() {
-    if (this.props.showInfoBox) {
-      var gStyles = {
-        opacity: this.props.showInfoBox ? 1 : 0
-      };
-      var rectAttrs = {
-        id: this.props.nodeId + "-tooltip" + "-rect",
-        x: this.props.xPos,
-        y: this.props.yPos,
-        rx: "4",
-        ry: "4",
-        fill: "white",
-        stroke: "black",
-        strokeWidth: "2",
-        width: "60",
-        height: "30"
-      };
+    var className = this.props.showInfoBox ? "tooltip-group-display" : "tooltip-group-hidden";
 
-      var textAttrs = {
-        id: this.props.nodeId + "-tooltip" + "-text",
-        x: this.props.xPos + 60 / 2 - 18,
-        y: this.props.yPos + 30 / 2 + 6
-      };
+    var rectAttrs = {
+      id: this.props.nodeId + "-tooltip" + "-rect",
+      x: this.props.xPos,
+      y: this.props.yPos,
+      rx: "4",
+      ry: "4",
+      fill: "white",
+      stroke: "black",
+      strokeWidth: "2",
+      width: "60",
+      height: "30"
+    };
 
-      return (
-        <g
-          id="infoBox"
-          className="tooltip-group"
-          style={gStyles}
-          onClick={this.props.onClick}
-          onMouseEnter={this.props.onMouseEnter}
-          onMouseLeave={this.props.onMouseLeave}
-        >
-          <rect {...rectAttrs} />
-          <text {...textAttrs}>Info</text>
-        </g>
-      );
-    } else {
-      return <g />;
-    }
+    var textAttrs = {
+      id: this.props.nodeId + "-tooltip" + "-text",
+      x: this.props.xPos + 60 / 2 - 18,
+      y: this.props.yPos + 30 / 2 + 6
+    };
+
+    return (
+      <g
+        id="infoBox"
+        className={className}
+        onClick={this.props.onClick}
+        onMouseEnter={this.props.onMouseEnter}
+        onMouseLeave={this.props.onMouseLeave}
+      >
+        <rect {...rectAttrs} />
+        <text {...textAttrs}>Info</text>
+      </g>
+    );
   }
 }
+
 
 InfoBox.propTypes = {
   showInfoBox: PropTypes.bool,

--- a/js/components/graph/__tests__/InfoBox.test.js
+++ b/js/components/graph/__tests__/InfoBox.test.js
@@ -9,7 +9,11 @@ describe("InfoBox", () => {
     const infoBoxProps = {
       onClick: jest.fn(),
       onMouseDown: jest.fn(),
-      onMouseLeave: jest.fn()
+      onMouseLeave: jest.fn(),
+      nodeId: "",
+      showInfoBox: false,
+      xPos: 0,
+      yPos: 0
     };
     const component = shallow(<InfoBox {...infoBoxProps} />);
     expect(component).toMatchSnapshot();
@@ -18,25 +22,25 @@ describe("InfoBox", () => {
   it("should appear when hovering over a course", async () => {
     const graph = await TestGraph.build();
     const aaa100 = graph.getByTestId("aaa100");
-    
-    expect(graph.textExists("Info")).toBe(false);
-    fireEvent.mouseOver(aaa100);
+
     const infoBox = graph.getNodeByText("Info");
-    expect(infoBox.classList.contains("tooltip-group")).toBe(true);
+    expect(infoBox.classList.contains("tooltip-group-hidden")).toBe(true);
+    fireEvent.mouseOver(aaa100);
+    expect(infoBox.classList.contains("tooltip-group-display")).toBe(true);
   });
-  
+
   it("should disappear a second after the the cursor isn't hovered over the course", async done => {
     const graph = await TestGraph.build();
     const aaa100 = graph.getByTestId("aaa100");
 
     fireEvent.mouseOver(aaa100);
     const infoBox = graph.getNodeByText("Info");
-    expect(infoBox.classList.contains("tooltip-group")).toBe(true);
+    expect(infoBox.classList.contains("tooltip-group-display")).toBe(true);
 
     fireEvent.mouseOut(aaa100);
 
     setTimeout(() => {
-      expect(graph.textExists("Info")).toBe(false);
+      expect(infoBox.classList.contains("tooltip-group-hidden")).toBe(true);
       done();
     }, 1000);
   });

--- a/js/components/graph/__tests__/__snapshots__/InfoBox.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/InfoBox.test.js.snap
@@ -1,3 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InfoBox should match shallow snapshot 1`] = `<g />`;
+exports[`InfoBox should match shallow snapshot 1`] = `
+<g
+  className="tooltip-group-hidden"
+  id="infoBox"
+  onClick={[MockFunction]}
+  onMouseLeave={[MockFunction]}
+>
+  <rect
+    fill="white"
+    height="30"
+    id="-tooltip-rect"
+    rx="4"
+    ry="4"
+    stroke="black"
+    strokeWidth="2"
+    width="60"
+    x={0}
+    y={0}
+  />
+  <text
+    id="-tooltip-text"
+    x={12}
+    y={21}
+  >
+    Info
+  </text>
+</g>
+`;

--- a/style/app.scss
+++ b/style/app.scss
@@ -2444,8 +2444,16 @@ main-filter input
   top  : -33px;
 }
 
-.tooltip-group
+.tooltip-group-display
 {
   cursor: pointer;
-  transition: opacity .4s;
+  transition: opacity 0.4s linear;
+  opacity:1;
+}
+
+.tooltip-group-hidden
+{
+  cursor: pointer;
+  transition: opacity 0.4s linear;
+  opacity:0;
 }

--- a/style/app.scss
+++ b/style/app.scss
@@ -2443,3 +2443,9 @@ main-filter input
   left : -388px;
   top  : -33px;
 }
+
+.tooltip-group
+{
+  cursor: pointer;
+  transition: opacity .4s;
+}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
There was a TODO in InfoBox.js for moving the style to CSS.
## Your Changes

<!--- Describe your changes here. -->
**Description**:
I moved style definitions that are not dynamic to App.scss. I kept the opacity in InfoBox.jss because I think it makes more sense to keep, as it needs to be changed depending on whether the infobox should be shown.
**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->


- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
I manually tested infobox visibility related functionality, meaning I tested that the infobox shows up if you hover over a course or the infobox and that the infobox disappears if you stop hovering over the course or infobox.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Is it better to keep the `opacity` in InfoBox.js, or would it be better to move it to CSS somehow? The only way I see how to do that in CSS is to create 1 class for visible elements and 1 for invisible elements and append the correct class name when InfoBox is rendered.
## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->

