### PR TITLE
Bugfixing Generate: connections + button position

### DIFF
--- a/js/components/generate/generate.js
+++ b/js/components/generate/generate.js
@@ -74,6 +74,10 @@ class GenerateForm extends React.Component {
         var hybridsList = [];
         var boolsList = [];
         var edgesList = [];
+        var parentsObj = {};
+        var inEdgesObj = {};
+        var childrenObj = {};
+        var outEdgesObj = {};
 
         var labelsList = data.texts.filter(function(entry) {
             // filter for mark percentages, allow preceding characters for potential geq
@@ -97,6 +101,32 @@ class GenerateForm extends React.Component {
             edgesList.push(entry);
           }
         });
+
+        nodesList.forEach(node => {
+          parentsObj[node.id_] = [];
+          inEdgesObj[node.id_] = [];
+          childrenObj[node.id_] = [];
+          outEdgesObj[node.id_] = [];
+        });
+
+        hybridsList.forEach(hybrid => {
+          childrenObj[hybrid.id_] = [];
+          outEdgesObj[hybrid.id_] = [];
+          populateHybridRelatives(hybrid, nodesList, parentsObj, childrenObj);
+        })
+
+        edgesList.forEach(edge => {
+          if (edge.target in parentsObj) {
+            parentsObj[edge.target].push(edge.source);
+            inEdgesObj[edge.target].push(edge.id_);
+          }
+
+          if (edge.source in childrenObj) {
+            childrenObj[edge.source].push(edge.target);
+            outEdgesObj[edge.source].push(edge.id_);
+          }
+        });
+
         this.graph.current.setState({
           labelsJSON: labelsList,
           regionsJSON: regionsList,
@@ -109,6 +139,12 @@ class GenerateForm extends React.Component {
           zoomFactor: 1,
           horizontalPanFactor: 0,
           verticalPanFactor: 0,
+          connections: {
+            'parents': parentsObj,
+            'inEdges': inEdgesObj,
+            'children': childrenObj,
+            'outEdges': outEdgesObj
+          }
         });
       })
       .catch((err) => {

--- a/style/app.scss
+++ b/style/app.scss
@@ -2349,11 +2349,10 @@ div[id*='_inq']  .code:after
 
 #generateRoot
 {
-  height   : 100%;
-  position : relative;
+  height : 100%;
 }
 
-#react-graph
+#generateRoot #react-graph
 {
   position : static;
 }

--- a/style/app.scss
+++ b/style/app.scss
@@ -2350,6 +2350,7 @@ div[id*='_inq']  .code:after
 #generateRoot
 {
   height : 100%;
+  position: relative;
 }
 
 #generateRoot #react-graph

--- a/style/app.scss
+++ b/style/app.scss
@@ -2349,10 +2349,11 @@ div[id*='_inq']  .code:after
 
 #generateRoot
 {
-  height : 100%;
+  height   : 100%;
+  position : relative;
 }
 
-#generateRoot #react-graph
+#react-graph
 {
   position : static;
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
I added code that populates `this.state.connections` inside `generate.js`'s `handleSubmit` method.

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Earlier, the Generate page would crash/not load a graph, since `connections` appeared as null. Previously, the code that populates `connections` was in `getGraph`, which is called when `start_blank=false`. When generating a graph, however, `start_blank=true`, so `connections` is never filled and the `parents` props of Nodes remained undefined.

Also, the navigation buttons used to overlap with the navigation bar.

## Your Changes

<!--- Describe your changes here. -->
**Description**:

- Copied in the code that populates `connections` from our previous code in `Graph.js`
- Changed the position of `#generateRoot` to `relative` so that the buttons are pushed to below the navigation bar

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
I manually checked that the value of `connections` was as expected.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
What I did here should be compatible with our panning code. From what I've checked, the generated graph should be able to pan (I merged in my PR in a separate branch to check). The only issue is the size and position of the graph differed when I merged in the panning code, and I suspect this has to do with the initialization of the `viewBoxPos` state. I'll be fixing that in a separate PR since it seems more complex than I expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
