### PR TITLE
Linked Courseography icon to Courseography "home page"

### DIFF
--- a/app/MasterTemplate.hs
+++ b/app/MasterTemplate.hs
@@ -38,7 +38,7 @@ masterTemplate title headers body scripts =
 header :: T.Text -> H.Html
 header page =
     H.nav ! A.class_ "row header" $ do
-        H.a ! A.href "https://courseography.cdf.toronto.edu/graph" $ do
+        H.a ! A.href "/graph" $ do
             H.img ! A.id "courseography-header" ! A.src "/static/res/img/logo.png"
              ! H.customAttribute "context" (textValue page)
         H.ul ! A.id "nav-links" $ do

--- a/app/MasterTemplate.hs
+++ b/app/MasterTemplate.hs
@@ -38,7 +38,8 @@ masterTemplate title headers body scripts =
 header :: T.Text -> H.Html
 header page =
     H.nav ! A.class_ "row header" $ do
-        H.img ! A.id "courseography-header" ! A.src "/static/res/img/logo.png"
+        H.a ! A.href "https://courseography.cdf.toronto.edu/graph" $ do
+            H.img ! A.id "courseography-header" ! A.src "/static/res/img/logo.png"
              ! H.customAttribute "context" (textValue page)
         H.ul ! A.id "nav-links" $ do
             H.li ! A.id "nav-graph" $ toLink "/graph" "Graph▼"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Typically when someone is on a website, they expect to be redirected to whatever the "home page" of the site is when clicking on the icon that represents said site. This PR addresses this concern from #1218.

## Your Changes

<!--- Describe your changes here. -->
**Description**:
Wrapped the img in a `<a href="">` using Haskell.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] User Interface Change

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
Clicked the icon and was redirected correctly.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->
