### PR TITLE
Changed viewbox height to svg's height so that it fills screen

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -651,8 +651,15 @@ export default class Graph extends React.Component {
       containerHeight = reactGraph.clientHeight;
     }
 
-    let newViewboxWidth = Math.max(this.state.width, containerWidth) * this.state.zoomFactor;
-    let newViewboxHeight = Math.max(this.state.height, containerHeight) * this.state.zoomFactor;
+    let newViewboxHeight= this.state.height;
+    let newViewboxWidth = this.state.width;
+    if (document.getElementById("generateRoot") !== null) {
+      newViewboxHeight = Math.max(this.state.height, containerHeight) * this.state.zoomFactor;
+      newViewboxWidth = Math.max(this.state.width, containerWidth) * this.state.zoomFactor;
+    } else {
+      newViewboxWidth = this.state.width * this.state.zoomFactor;
+      newViewboxHeight = this.state.height * this.state.zoomFactor;
+    }
 
     const viewBoxContainerRatio = containerHeight !== 0 ? newViewboxHeight / containerHeight : 1;
     const viewboxX = (this.state.width - newViewboxWidth) / 2 + this.state.horizontalPanFactor * viewBoxContainerRatio;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
Changed the way the viewbox dimensions are calculated so that the graph fills the height of the screen, regardless of the screen resolution.

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
This fixes a bug caused by PR #1230 , where the graph appears small and in the middle of the screen on some resolutions.

## Your Changes

<!--- Describe your changes here. -->
**Description**:
- Set the viewbox dimensions to the original SVG's dimensions, so that it scales up without any vertical whitespace
- Kept the old code for the generate page using an if-statement

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
Manual testing in browser, using dev tools to change the screen resolution. Kenneth also tested the Generate page for me since he is working on fixing it.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
I kept the old code for the generate page since otherwise the graph there looks way too big. I had to change the width as well because otherwise the ratio is messed up and the weird whitespace appears at the bottom.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->