### PR TITLE
Fixed FCE Counter for Generate

### DIFF
--- a/js/components/generate/generate.js
+++ b/js/components/generate/generate.js
@@ -17,11 +17,20 @@ class GenerateForm extends React.Component {
       maxDepth: 0,
       location: ['utsg'],
       includeRaws: false,
-      includeGrades: false
+      includeGrades: false,
+      fceCount: 0
     };
 
     this.graph = React.createRef();
   }
+
+  setFCECount = credits => {
+    this.setState({ fceCount: credits });
+  };
+
+  incrementFCECount = credits => {
+    this.setState({ fceCount: this.state.fceCount + credits });
+  };
 
   handleInputChange = (event) => {
     const target = event.target;
@@ -224,6 +233,9 @@ class GenerateForm extends React.Component {
     <Graph
       ref={this.graph}
       start_blank={true}
+      fceCount = {this.state.fceCount}
+      incrementFCECount={this.incrementFCECount}
+      setFCECount={this.setFCECount}
     />
     </div>
     )


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
Made the FCE counter on the new sidebar functional on the Generate page.

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
The FCE counter currently does not display any numbers on the Generate tab, regardless of whether nodes are selected.

## Your Changes

<!--- Describe your changes here. -->
**Description**: Added the FCE count state to the Generate component and relevant methods, based on the implementation in Container.js. Passed this state down as a prop to the Graph component.

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
Manual testing in browser. Yarn tests pass locally.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
The tests passed locally, but failed on CircleCI, not sure why.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->
