### PR TITLE
Hiding sidebar and buttons

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -86,7 +86,9 @@ export default class Graph extends React.Component {
         .addEventListener("mouseleave", this.hideGraphDropdown);
     }
 
-    document.querySelector(".sidebar").addEventListener("wheel", (event) => event.stopPropagation())
+    if (document.querySelector(".sidebar")) {
+      document.querySelector(".sidebar").addEventListener("wheel", (event) => event.stopPropagation())
+    }
   }
 
   componentWillUpdate(prevProps) {
@@ -732,11 +734,11 @@ export default class Graph extends React.Component {
         className={reactGraphClass}
         {...reactGraphPointerEvents}
       >
-        <Sidebar
+        {this.state.connections !== null && <Sidebar
           fceCount={this.props.fceCount}
           reset={this.reset}
           activeCourses={this.state.selectedNodes}
-        />
+        />}
         <CourseModal showCourseModal={this.state.showCourseModal} courseId={this.state.courseId} onClose={this.onClose} />
         <ExportModal context="graph" session="" ref={this.exportModal} />
         <GraphDropdown
@@ -746,7 +748,7 @@ export default class Graph extends React.Component {
           graphs={this.props.graphs}
           updateGraph={this.props.updateGraph}
         />
-        <div className="graph-button-group">
+        {this.state.connections !== null && <div className="graph-button-group">
           <div className="button-group">
             <Button
               text="+"
@@ -776,7 +778,7 @@ export default class Graph extends React.Component {
                 />
               </Button>
           </div>
-        </div>
+        </div>}
 
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -734,7 +734,7 @@ export default class Graph extends React.Component {
         className={reactGraphClass}
         {...reactGraphPointerEvents}
       >
-        {this.state.connections !== null && <Sidebar
+        {this.state.nodesJSON.length > 1 && <Sidebar
           fceCount={this.props.fceCount}
           reset={this.reset}
           activeCourses={this.state.selectedNodes}
@@ -748,7 +748,7 @@ export default class Graph extends React.Component {
           graphs={this.props.graphs}
           updateGraph={this.props.updateGraph}
         />
-        {this.state.connections !== null && <div className="graph-button-group">
+        {this.state.nodesJSON.length > 1 && <div className="graph-button-group">
           <div className="button-group">
             <Button
               text="+"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
Hide the sidebar and buttons in Generate when no graph has been generated yet.

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Having the sidebar and graph panning/zooming controls available before the graph itself is there feels unintuitive.

## Your Changes

<!--- Describe your changes here. -->
**Description**:
- Conditionally render sidebar and buttons when nodesJSON has more than 1 entry (this is because on Generate, invalid entries still result in a JSON that has 1 entry)
- fixed a resulting bug where the queryselector calling .sidebar continues even if the sidebar isnt there

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
Manual testing in browser. Yarn tests pass locally.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
I am not entirely sure why there is still a nodeJSON entry when the graph is empty?

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have
  passed. <!-- (check after opening pull request) -->
