### PR TITLE
Add and/or separators for req parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This project would not exist without the contributions of many students in the D
 Alex Baluta,
 Alexander Biggs,
 Kelly Bell,
+Ching Chang,
 Christina Chen,
 Eugene Cheung,
 Kael Deverell,

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -29,6 +29,8 @@ orInputs = [
       ("CSC120H1/CSC148H1", OR [J "CSC120H1" "", J "CSC148H1" ""])
     , ("CSC108H1/CSC120H1/CSC148H1", OR [J "CSC108H1" "", J "CSC120H1" "", J "CSC148H1" ""])
     , ("FOR300H1/FOR301H1/FOR302H1", OR [J "FOR300H1" "", J "FOR301H1" "", J "FOR302H1" ""])
+    , ("BIO130H1 or BIO206H5 or BIOB10H3", OR [J "BIO130H1" "", J "BIO206H5" "", J "BIOB10H3" ""])
+    , ("CHM220H1 with a minimum grade of B, or CHM222H1", OR [GRADE "B" (J "CHM220H1" ""),J "CHM222H1" ""])
     ]
 
 andInputs :: [(String, Req)]
@@ -36,6 +38,7 @@ andInputs = [
       ("CSC165H1, CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
     , ("CSC120H1, CSC121H1, CSC148H1", AND [J "CSC120H1" "", J "CSC121H1" "", J "CSC148H1" ""])
     , ("CSC165H1 & CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
+    , ("BCH377H1; BCH378H1; and permission of Department", AND [J "BCH377H1" "", J "BCH378H1" "", RAW "permission of Department"])
     ]
 
 andorInputs :: [(String, Req)]
@@ -47,6 +50,7 @@ andorInputs = [
     , ("CLA204H1 + 1 OF CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
     , ("BIO220H1 and at least one of EEB319H1/EEB321H1", AND [J "BIO220H1" "", OR [J "EEB319H1" "", J "EEB321H1" ""]])
     , ("CLA204H1 plus one of CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
+    , ("ARH205H1/ ARH305H1, and one of ANT100Y1/ ANT200Y1/ ANT356H1", AND [OR [J "ARH205H1" "",J "ARH305H1" ""],OR [J "ANT100Y1" "",J "ANT200Y1" "",J "ANT356H1" ""]])
     ]
 
 parInputs :: [(String, Req)]

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -52,13 +52,16 @@ rParen = Parsec.char ')'
 orSeparator :: Parser String
 orSeparator = Parsec.choice $ map caseInsensitiveStr [
     "/",
-    "or"
+    "or",
+    ", or"
     ]
 
 andSeparator :: Parser String
 andSeparator = Parsec.choice $ map caseInsensitiveStr [
+    ", and",
     ",",
     "and",
+    "; and",
     ";",
     "&",
     "+",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The current parser on master doesn't handle requirements separated by certain and/or separators, such as `; and` and `, or`, which results in parsing well-formatted courses/programs/FCEs/grades into rawText.

## Your Changes

<!--- Describe your changes here. -->

**Description**: I added `; and`, `, and`, and `, or` into the lists of and/or separators.

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->

- For `orSeparator`, I added a test case with courses divided by the newly added separator (`, or`) and a test case with courses divided by an existing separator that wasn't tested before (`or`)
- For `andSeparator`, I tested `; and` with courses and rawText divided by `; and`, but tested `, and` with ORs of courses because there are no courses separatedly by `, and` in UofT's timetable that aren't in groups of ORs

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
The test I added for `andInputs` expects the output to have a rawText. I'm afraid if we improve the parser to handle more rawText in the future, this test will have to be updated as well. I used it anyway because I wasn't able to find a simpler prerequisite string with `; and` in UofT's timetable.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
