### PR TITLE
Update program parser for artsci website

### DIFF
--- a/app/WebParsing/ArtSciParser.hs
+++ b/app/WebParsing/ArtSciParser.hs
@@ -106,7 +106,7 @@ parseDepartment (relativeURL, _) = do
 parsePrograms :: [Tag T.Text] -> SqlPersistM ()
 parsePrograms programs = mapM_ addPostToDatabase $ TS.partitions isAccordionHeader programs
     where
-        isAccordionHeader = tagOpenAttrNameLit "p" "class" (T.isInfixOf "js-views-accordion-group-header")
+        isAccordionHeader = tagOpenAttrNameLit "h3" "class" (T.isInfixOf "js-views-accordion-group-header")
 
 -- | Parse the section of the course calendar listing the courses offered by a department.
 parseCourses :: [Tag T.Text] -> [(Courses, T.Text, T.Text)]


### PR DESCRIPTION
## Motivation and Context
Update FAS calendar parser to account for slightly changed HTML format in course headings

## Your Changes
Updated the parser looking for the `p` tags on the academic calendar to look for the `h3` tags
<!--- Describe your changes here. -->

**Description**:

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Comments
This is the last task I was assigned so if it gets merged, let me know what I should work on next :)

## Testing
Ran stack exec courseography database and ensured that programs were parsed | Ran `stack run` to start the localhost and ensured that the programs were shown
-|-
![image](https://user-images.githubusercontent.com/38874004/170788512-afefe1b2-594d-4372-8427-184e81d06158.png) | ![image](https://user-images.githubusercontent.com/38874004/170787345-37cccbcd-b048-4d32-85d3-10d25631724c.png)

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->