### PR TITLE
Update configuration for 2022-23

### DIFF
--- a/app/DevelopmentConfig.hs
+++ b/app/DevelopmentConfig.hs
@@ -81,7 +81,7 @@ timetableUrl = "https://timetable.iit.artsci.utoronto.ca/"
 
 -- | The Faculty of Arts and Science API for course timetables (by unit).
 timetableApiUrl :: Text
-timetableApiUrl = "https://timetable.iit.artsci.utoronto.ca/api/20219/courses?org="
+timetableApiUrl = "https://timetable.iit.artsci.utoronto.ca/api/20229/courses?org="
 
 -- | The Faculty of Arts and Science API for a list of all units.
 orgApiUrl :: String
@@ -98,30 +98,30 @@ programsUrl = "https://artsci.calendar.utoronto.ca/listing-program-subject-areas
 
 -- | First day of classes for the fall term.
 fallStartDate :: Day
-fallStartDate = fromGregorian 2021 09 09
+fallStartDate = fromGregorian 2022 09 08
 
 -- | Last day of classes for the fall term.
 fallEndDate :: Day
-fallEndDate = fromGregorian 2021 12 08
+fallEndDate = fromGregorian 2022 12 07
 
 -- | First day of classes for the winter term.
 winterStartDate :: Day
-winterStartDate = fromGregorian 2022 01 10
+winterStartDate = fromGregorian 2023 01 09
 
 -- | Last day of classes for the winter term.
 winterEndDate :: Day
-winterEndDate = fromGregorian 2020 04 08
+winterEndDate = fromGregorian 2023 04 06
 
 -- | Out of date day. Used to control forbidden inputs for days.
 outDay :: Day
-outDay = fromGregorian 2023 01 01
+outDay = fromGregorian 2024 01 01
 
 -- Holidays for the fall and winter term.
 holidays :: [String]
-holidays = ["20191011T", "20191108T", "20191109T",
-            "20191110T", "20191111T", "20191112T",
-            "20200221T", "20200222T", "20200223T",
-            "20200224T", "20200225T"]
+holidays = ["20221010T", "20221107T", "20221108T",
+            "20221109T", "20221110T", "20221111T",
+            "20230220T", "20230221T", "20230222T",
+            "20200223T", "20230224T"]
 
 -- SCRIPT DEPENDENCIES CONFIGURATION
 

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -1,5 +1,5 @@
 name:                courseography
-version:             0.3.1.0
+version:             0.4.0.0
 synopsis:            Program and course planning app for the University of Toronto.
 description:         A web application designed to aid students in planning their courses
                      at the University of Toronto.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "courseography",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": "git@github.com:Courseography/courseography.git",
   "author": "David Liu <david@cs.toronto.edu>",
   "license": "GPL-3.0",


### PR DESCRIPTION
## Your Changes

Update Courseography configuration for 2023-23 (in particular, enabling parsing of timetable data for 2022-23 school year.

**Description**:

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->

Re-ran `stack exec courseography database` to ensure timetable data for 2022-23 was loaded.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
