### PR TITLE
fix: add fces prefix and and separator

### DIFF
--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -67,6 +67,7 @@ fcesInputs :: [(String, Req)]
 fcesInputs = [
       ("1.0 FCE from the following: (CSC148H1)", FCES "1.0" $ J "CSC148H1" "")
     , ("2.0 FCEs from CSC165H1/CSC148H1", FCES "2.0" $ OR [J "CSC165H1" "", J "CSC148H1" ""])
+    , ("2.0 FCEs in CSC165H1/CSC148H1", FCES "2.0" $ OR [J "CSC165H1" "", J "CSC148H1" ""])
     , ("2 FCEs from: MAT135H1, MAT136H1/ MAT137Y1", FCES "2" $ AND [J "MAT135H1" "",OR [J "MAT136H1" "",J "MAT137Y1" ""]])
     , ("Completion of 4.0 FCEs", FCES "4.0" $ RAW "")
     , ("Completion of 4 FCE.", FCES "4" $ RAW "")

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -3,8 +3,8 @@ module WebParsing.ReqParser where
 
 import Data.Char (isSpace, toLower, toUpper)
 import Database.Requirement
-import qualified Text.Parsec as Parsec
 import Text.Parsec ((<|>))
+import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
 
 -- define separators
@@ -15,7 +15,8 @@ fromSeparator = Parsec.spaces
             "from the following: ",
             "from:",
             "from",
-            "at"
+            "at",
+            "in"
     ])
 
 completionPrefix :: Parser ()
@@ -93,6 +94,8 @@ orSeparator = Parsec.choice $ map caseInsensitiveStr [
 andSeparator :: Parser String
 andSeparator = Parsec.choice $ map caseInsensitiveStr [
     ", and",
+    ", an additional",
+    ", additional",
     ",",
     "and",
     "; and",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
The current lists of `andSeparator` and `fcesPrefix` are not complete enough. Some parsable data are failing and being parsed as RAW.

## Your Changes
- Added `in` to `fcesPrefix`
- Added `, additional` and `, an additional` to `andSeparator`

**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Only tested the `in` in `fcesPrefix`. Wasn't able to test `, additional` and `, an additional` because the parser on master does not allow `fcesParser` to be parsed with other requirements yet. The tests for them will be added in #1267 where this issue is fixed

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->