### PR TITLE
Add modifier data type for FCEs reqs

### DIFF
--- a/app/Database/Requirement.hs
+++ b/app/Database/Requirement.hs
@@ -7,14 +7,18 @@ Module containing data type that represents a "Requirement".
 We will use parsed data to create instances of this type.
 -}
 
-module Database.Requirement
-( Req(..) ) where
+module Database.Requirement (
+    Req (..),
+    Modifier (..)
+    ) where
 
 data Req = NONE
          | J String String
          | AND [Req]
          | OR [Req]
-         | FCES Float Req
+         | FCES Float Modifier
          | GRADE String Req
          | PROGRAM String
          | RAW String deriving (Eq, Show)
+
+newtype Modifier = REQUIREMENT Req deriving (Eq, Show)

--- a/app/DynamicGraphs/CourseFinder.hs
+++ b/app/DynamicGraphs/CourseFinder.hs
@@ -13,7 +13,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Lazy as T
 import Database.CourseQueries (prereqsForCourse)
-import Database.Requirement (Req (..))
+import Database.Requirement (Modifier (..), Req (..))
 import DynamicGraphs.GraphOptions (GraphOptions (..))
 import WebParsing.ReqParser (parseReqs)
 
@@ -48,7 +48,7 @@ lookupReqs options (OR parents) =
         hasTaken :: Req -> Bool
         hasTaken (J name _) = Set.member name (Set.fromList $ map T.unpack (taken options))
         hasTaken _ = False
-lookupReqs options (FCES _ parent) = lookupReqs options parent
+lookupReqs options (FCES _ (REQUIREMENT parent)) = lookupReqs options parent
 lookupReqs options (GRADE _ parent) = lookupReqs options parent
 -- This will catch both NONE and RAW values.
 lookupReqs _ _ = return ()

--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -24,7 +24,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Sequence as Seq
 import Data.Text.Lazy (Text, isInfixOf, isPrefixOf, last, pack, take)
-import Database.Requirement (Req (..))
+import Database.Requirement (Modifier (..), Req (..))
 import DynamicGraphs.CourseFinder (lookupCourses)
 import DynamicGraphs.GraphOptions (GraphOptions (..), defaultGraphOptions)
 import Prelude hiding (last)
@@ -176,9 +176,9 @@ reqToStmtsTree options parentID (RAW rawText) =
             prereq <- makeNode (pack rawText) Nothing
             edge <- makeEdge (nodeID prereq) parentID Nothing
             return $ Node [DN prereq, DE edge] []
---A prerequisite concerning a given number of earned credits
-reqToStmtsTree options parentID (FCES creds req) = do
-    fceNode <- makeNode (pack $ "at least " ++ show creds ++ " FCEs") Nothing
+--A prerequisite concerning a given number of earned credits in some course(s)
+reqToStmtsTree options parentID (FCES creds (REQUIREMENT req)) = do
+    fceNode <- makeNode (pack $ show creds ++ " FCEs") Nothing
     edge <- makeEdge (nodeID fceNode) parentID Nothing
     prereqStmts <- reqToStmtsTree options (nodeID fceNode) req
     return $ Node [DN fceNode, DE edge] [prereqStmts]

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -68,25 +68,25 @@ parInputs = [
 
 fcesInputs :: [(String, Req)]
 fcesInputs = [
-      ("1.0 FCE from the following: (CSC148H1)", FCES 1.0 $ J "CSC148H1" "")
-    , ("2.0 FCEs from CSC165H1/CSC148H1", FCES 2.0 $ OR [J "CSC165H1" "", J "CSC148H1" ""])
-    , ("2.0 FCEs in CSC165H1/CSC148H1", FCES 2.0 $ OR [J "CSC165H1" "", J "CSC148H1" ""])
-    , ("2 FCEs from: MAT135H1, MAT136H1/ MAT137Y1", FCES 2.0 $ AND [J "MAT135H1" "",OR [J "MAT136H1" "",J "MAT137Y1" ""]])
-    , ("Completion of 4.0 FCEs", FCES 4.0 $ RAW "")
-    , ("Completion of 4 FCE.", FCES 4.0 $ RAW "")
-    , ("Completion of 9 FCEs", FCES 9.0 $ RAW "")
-    , ("Completion of 9.0 credits or permission of the instructor", OR [FCES 9.0 (RAW ""), RAW "permission of the instructor"])
-    , ("Completion of 9.0 credits. Permission of the instructor", AND [FCES 9.0 (RAW ""), RAW "Permission of the instructor"])
-    , ("Completion of at least 9.0 FCE", FCES 9.0 $ RAW "")
-    , ("Completion of a minimum of 4.0 FCEs", FCES 4.0 $ RAW "")
-    , ("Completion of a minimum of 9 FCEs", FCES 9.0 $ RAW "")
-    , ("Completion of 4.0 credits", FCES 4.0 $ RAW "")
-    , ("at least 4.0 credits", FCES 4.0 $ RAW "")
-    , ("At least one 0.5 credit at the 400-level", FCES 0.5 $ RAW "the 400-level")
-    , ("At least 1.5 credits at the 400-level", FCES 1.5 $ RAW "the 400-level")
-    , ("1.0 credits or 1.0 credit in Canadian Studies", OR [FCES 1.0 (RAW ""),FCES 1.0 (RAW "Canadian Studies")])
-    , ("NEW240Y1, an additional 0.5 credits at the 300 level from the Critical Studies", AND [J "NEW240Y1" "", FCES 0.5 (RAW "the 300 level from the Critical Studies")])
-    , ("At least one 0.5 credit at the 400-level or permission of the instructor", OR [FCES 0.5 (RAW "the 400-level"), RAW "permission of the instructor"])
+      ("1.0 FCE from the following: (CSC148H1)", FCES 1.0 $ REQUIREMENT $ J "CSC148H1" "")
+    , ("2.0 FCEs from CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ OR [J "CSC165H1" "", J "CSC148H1" ""])
+    , ("2.0 FCEs in CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ OR [J "CSC165H1" "", J "CSC148H1" ""])
+    , ("2 FCEs from: MAT135H1, MAT136H1/ MAT137Y1", FCES 2.0 $ REQUIREMENT $ AND [J "MAT135H1" "",OR [J "MAT136H1" "",J "MAT137Y1" ""]])
+    , ("Completion of 4.0 FCEs", FCES 4.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of 4 FCE.", FCES 4.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of 9 FCEs", FCES 9.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of 9.0 credits or permission of the instructor", OR [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "permission of the instructor"])
+    , ("Completion of 9.0 credits. Permission of the instructor", AND [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "Permission of the instructor"])
+    , ("Completion of at least 9.0 FCE", FCES 9.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of a minimum of 4.0 FCEs", FCES 4.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of a minimum of 9 FCEs", FCES 9.0 $ REQUIREMENT $ RAW "")
+    , ("Completion of 4.0 credits", FCES 4.0 $ REQUIREMENT $ RAW "")
+    , ("at least 4.0 credits", FCES 4.0 $ REQUIREMENT $ RAW "")
+    , ("At least one 0.5 credit at the 400-level", FCES 0.5 $ REQUIREMENT $ RAW "the 400-level")
+    , ("At least 1.5 credits at the 400-level", FCES 1.5 $ REQUIREMENT $ RAW "the 400-level")
+    , ("1.0 credits or 1.0 credit in Canadian Studies", OR [FCES 1.0 (REQUIREMENT $ RAW ""),FCES 1.0 (REQUIREMENT $ RAW "Canadian Studies")])
+    , ("NEW240Y1, an additional 0.5 credits at the 300 level from the Critical Studies", AND [J "NEW240Y1" "", FCES 0.5 (REQUIREMENT $ RAW "the 300 level from the Critical Studies")])
+    , ("At least one 0.5 credit at the 400-level or permission of the instructor", OR [FCES 0.5 (REQUIREMENT $ RAW "the 400-level"), RAW "permission of the instructor"])
     ]
 
 gradeBefInputs :: [(String, Req)]
@@ -127,7 +127,7 @@ artSciInputs = [
     , ("EEB223H1 (ecology and evo), STA220H1 (recommended)/ STA257H1 (recommended)", AND [J "EEB223H1" "ecology and evo",OR [J "STA220H1" "recommended",J "STA257H1" "recommended"]])
     , ("EEB223H1 (ecology and evo)/ STA220H1 (recommended)/ STA257H1", OR [J "EEB223H1" "ecology and evo",J "STA220H1" "recommended",J "STA257H1" ""])
     , ("EEB223H1 (ecology and evo)/ STA220H1 (B-)/ STA257H1", OR [J "EEB223H1" "ecology and evo", GRADE "B-" $ J "STA220H1" "", J "STA257H1" ""])
-    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", FCES 0.5 $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""])
+    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", FCES 0.5 $ REQUIREMENT $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""])
     , ("MATB23H3/STA220H1 (recommended)/STA257H1 (recommended)", OR [J "MATB23H3" "",J "STA220H1" "recommended",J "STA257H1" "recommended"])
     ]
 

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -415,18 +415,19 @@ fcesParser = do
 
 -- | Parser for FCES modifiers
 fcesModifiersParser :: Parser Modifier
-fcesModifiersParser = do
-    req <- Parsec.try (andParser courseParser)
-        -- TODO: more modifier parsers will be added here
-        <|> rawModifierParser
+fcesModifiersParser = courseAsModParser
+    -- TODO: more modifier parsers will be added here
+    <|> rawModifierParser
 
-    case req of
-        -- TODO: more Req matching will be added here
-        r -> return $ REQUIREMENT r
+-- | An andParser for courses but wraps the returned Req in a Modifier
+courseAsModParser :: Parser Modifier
+courseAsModParser = do
+    req <- andParser courseParser
+    return $ REQUIREMENT req
 
 -- | Parser for the raw text in fcesParser
 -- | Like rawTextParser but terminates at ands and ors
-rawModifierParser :: Parser Req
+rawModifierParser :: Parser Modifier
 rawModifierParser = do
     Parsec.spaces
     text <- Parsec.manyTill Parsec.anyChar $ Parsec.try $ Parsec.spaces >> Parsec.choice [
@@ -434,7 +435,7 @@ rawModifierParser = do
         Parsec.lookAhead orSeparator,
         Parsec.eof >> return ""
         ]
-    return $ RAW text
+    return $ REQUIREMENT $ RAW text
 
 -- | Parser for requirements separated by a semicolon.
 categoryParser :: Parser Req

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -414,10 +414,15 @@ fcesParser = do
     FCES fces <$> fcesModifiersParser
 
 -- | Parser for FCES modifiers
-fcesModifiersParser :: Parser Req
-fcesModifiersParser = Parsec.try (andParser courseParser)
-    -- TODO: more modifier parsers will be added here
-    <|> rawModifierParser
+fcesModifiersParser :: Parser Modifier
+fcesModifiersParser = do
+    req <- Parsec.try (andParser courseParser)
+        -- TODO: more modifier parsers will be added here
+        <|> rawModifierParser
+
+    case req of
+        -- TODO: more Req matching will be added here
+        r -> return $ REQUIREMENT r
 
 -- | Parser for the raw text in fcesParser
 -- | Like rawTextParser but terminates at ands and ors

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -415,7 +415,7 @@ fcesParser = do
 
 -- | Parser for FCES modifiers
 fcesModifiersParser :: Parser Modifier
-fcesModifiersParser = courseAsModParser
+fcesModifiersParser = Parsec.try courseAsModParser
     -- TODO: more modifier parsers will be added here
     <|> rawModifierParser
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
The current Req data structure does not represent FCEs accurately. We want to introduce a modifier data type for the FCEs modifiers
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes
- Changed the second parameter type of the FCEs constructor from `Req` to `Modifier`
- Added the `Modifier` data type with a `REQUIREMENT` constructor that takes a `Req`
  - NOTE: The Modifier _data type_ is declared as a `newtype` instead of a `data` in this PR because HLint was failing here since we only had one constructor (`REQUIREMENT`). Once we add the other constructors in future PRs (eg. level, department), we will be able to change it to `data`
- Updated the test cases from `FCES Float Req` to `FCES Float (REQUIREMENT Req)`
<!--- Describe your changes here. -->

**Description**:

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
- Ran the tests in `app/ParserTests/ParserTests.hs` and ensured they all passed
- Generated a graph with FCEs requirements and ensured it looked fine
  - ![image](https://user-images.githubusercontent.com/38874004/172024387-5d8071e3-f8aa-4b30-90d8-df42deba96f4.png)
  - ![image](https://user-images.githubusercontent.com/38874004/172319364-0db12796-e156-4348-8753-87437fa03923.png) (wow 😮; see comment below)

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->

## Questions and Comments (if applicable)
Neither of AND and OR makes sense in cases like this. If we use AND, all 4 nodes need to be selected. If we use OR, we can get away with only 0.5 FCEs. We migjt need a new checking mechanism but I feel this is out of the scope of this PR?

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
