### PR TITLE
Rename categoryParser and courseOrProgParser

### DIFF
--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -159,35 +159,35 @@ noPrereqInputs = [
     ]
 
 orTests :: Test
-orTests = createTest categoryParser "Basic or Requirement" orInputs
+orTests = createTest reqParser "Basic or Requirement" orInputs
 
 andTests :: Test
-andTests = createTest categoryParser "Basic and Requirement" andInputs
+andTests = createTest reqParser "Basic and Requirement" andInputs
 
 andorTests :: Test
-andorTests = createTest categoryParser "Basic and-or-mixed Requirement" andorInputs
+andorTests = createTest reqParser "Basic and-or-mixed Requirement" andorInputs
 
 parTests :: Test
-parTests = createTest categoryParser "Basic and-or-parenthesized Requirement" parInputs
+parTests = createTest reqParser "Basic and-or-parenthesized Requirement" parInputs
 
 fcesTests:: Test
-fcesTests = createTest categoryParser "Basic fces Requirement" fcesInputs
+fcesTests = createTest reqParser "Basic fces Requirement" fcesInputs
 
 -- Outdated
 -- fromParTests :: Test
--- fromParTests = createTest categoryParser "Paranthesized From Requirements with integer or float fces" fromParInputs
+-- fromParTests = createTest reqParser "Paranthesized From Requirements with integer or float fces" fromParInputs
 
 gradeBefTests :: Test
-gradeBefTests = createTest categoryParser "Basic grade requirements which come before." gradeBefInputs
+gradeBefTests = createTest reqParser "Basic grade requirements which come before." gradeBefInputs
 
 gradeAftTests :: Test
-gradeAftTests = createTest categoryParser "Basic grade requirements, where grades come after." gradeAftInputs
+gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." gradeAftInputs
 
 artSciTests :: Test
-artSciTests = createTest categoryParser "Arts and Science requirements from Christine's output" artSciInputs
+artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" artSciInputs
 
 programOrTests :: Test
-programOrTests = createTest categoryParser "program requirements" programOrInputs
+programOrTests = createTest reqParser "program requirements" programOrInputs
 
 noPrereqTests :: Test
 noPrereqTests = createReqParserTest "No prerequisites required" noPrereqInputs

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -249,7 +249,7 @@ cutoffParser = Parsec.try coAftParser <|> coBefParser
 
 -- | Parser for requirements written within parentheses
 parParser :: Parser Req
-parParser = Parsec.between lParen rParen categoryParser
+parParser = Parsec.between lParen rParen reqParser
 
 -- | Parser for raw text in a prerequisite, e.g., "proficiency in C/C++".
 -- Note that even if a course code appears in the middle of such text,
@@ -315,8 +315,8 @@ courseParser = Parsec.choice $ map Parsec.try [
 -- Parses for a single course or a group of programs
 -- Programs need to be parsed in groups because of the concatenation issue
 -- explained in the docstring of `programGroupParser`
-courseOrProgParser :: Parser Req
-courseOrProgParser = Parsec.between Parsec.spaces Parsec.spaces $ Parsec.choice $ map Parsec.try [
+categoryParser :: Parser Req
+categoryParser = Parsec.between Parsec.spaces Parsec.spaces $ Parsec.choice $ map Parsec.try [
     fcesParser,
     courseParser,
     programOrParser,
@@ -432,8 +432,8 @@ rawModifierParser = do
     return $ RAW text
 
 -- | Parser for requirements separated by a semicolon.
-categoryParser :: Parser Req
-categoryParser = Parsec.try $ andParser courseOrProgParser
+reqParser :: Parser Req
+reqParser = Parsec.try $ andParser categoryParser
 
 -- Similar to Parsec.sepBy but stops when sep passes but p fails,
 -- and doesn't consume failed characters
@@ -461,7 +461,7 @@ parseReqs reqString = do
     if all isSpace reqString || reqStringLower == "none" || reqStringLower == "no"
         then NONE
         else do
-            let req = Parsec.parse categoryParser "" reqString
+            let req = Parsec.parse reqParser "" reqString
                 in case req of
                     Right x -> x
                     Left e -> J (show e) ""


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
#1267 added `fcesParser` into `courseOrProgParser` to fix the hierarchy of the parsing order. As a result, `courseOrProgParser` became an inaccurate description of what the function does. This PR aims to rename the affected function names

<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes
- Renamed `courseOrProgParser` to `categoryParser` as it now contains `fcesParser`
- Renamed the original `categoryParer` to `reqParser` to avoid conflicts
<!--- Describe your changes here. -->

**Description**:

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->
Ran the tests in `app/ParserTests/ParserTests.hs` and ensured they all passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
