### PR TITLE
refactor: rename AND/OR to REQAND/REQOR

### DIFF
--- a/app/Database/Requirement.hs
+++ b/app/Database/Requirement.hs
@@ -14,8 +14,8 @@ module Database.Requirement (
 
 data Req = NONE
          | J String String
-         | AND [Req]
-         | OR [Req]
+         | REQAND [Req]
+         | REQOR [Req]
          | FCES Float Modifier
          | GRADE String Req
          | PROGRAM String

--- a/app/DynamicGraphs/CourseFinder.hs
+++ b/app/DynamicGraphs/CourseFinder.hs
@@ -38,10 +38,10 @@ lookupReqs options (J name _) = do
         -- This course has been taken or is not a department we want to include; we don't need its prerequisites
         then return ()
         else lookupCourse options $ T.pack name
-lookupReqs options (AND parents) = mapM_ (lookupReqs options) parents
-lookupReqs options (OR parents) =
+lookupReqs options (REQAND parents) = mapM_ (lookupReqs options) parents
+lookupReqs options (REQOR parents) =
     if any hasTaken parents
-        -- We've taken at least one of parents, so this entire OR is satisfied
+        -- We've taken at least one of parents, so this entire REQOR is satisfied
         then return ()
         else mapM_ (lookupReqs options) parents
     where

--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -51,8 +51,8 @@ sampleGraph = fst $ State.runState (reqsToGraph
     defaultGraphOptions
     [("MAT237H1", J "MAT137H1" ""),
     ("MAT133H1", NONE),
-    ("CSC148H1", AND [J "CSC108H1" "", J "CSC104H1" ""]),
-    ("CSC265H1", AND [J "CSC148H1" "", J "CSC236H1" ""])
+    ("CSC148H1", REQAND [J "CSC108H1" "", J "CSC104H1" ""]),
+    ("CSC265H1", REQAND [J "CSC148H1" "", J "CSC236H1" ""])
     ])
     (GeneratorState 0 Map.empty)
 
@@ -127,7 +127,7 @@ reqToStmtsTree options parentID (J name2 _) = do
     else
         return (Node [] [])
 -- Two or more required prerequisites.
-reqToStmtsTree options parentID (AND reqs) = do
+reqToStmtsTree options parentID (REQAND reqs) = do
     andNode <- makeBool "and"
     edge <- makeEdge (nodeID andNode) parentID Nothing
     prereqStmts <- mapM (reqToStmtsTree options (nodeID andNode)) reqs
@@ -140,7 +140,7 @@ reqToStmtsTree options parentID (AND reqs) = do
             return $ Node [DN node, DE newEdge] xs
         _ -> return $ Node [DN andNode, DE edge] filteredStmts
 -- A choice from two or more prerequisites.
-reqToStmtsTree options parentID (OR reqs) = do
+reqToStmtsTree options parentID (REQOR reqs) = do
     orNode <- makeBool "or"
     edge <- makeEdge (nodeID orNode) parentID Nothing
     prereqStmts <- mapM (reqToStmtsTree options (nodeID orNode)) reqs

--- a/app/ParserTests/ParserTests.hs
+++ b/app/ParserTests/ParserTests.hs
@@ -26,57 +26,57 @@ createReqParserTest label input = TestLabel label $ TestList $ map (\(x, y) ->
 
 orInputs :: [(String, Req)]
 orInputs = [
-      ("CSC120H1/CSC148H1", OR [J "CSC120H1" "", J "CSC148H1" ""])
-    , ("CSC108H1/CSC120H1/CSC148H1", OR [J "CSC108H1" "", J "CSC120H1" "", J "CSC148H1" ""])
-    , ("FOR300H1/FOR301H1/FOR302H1", OR [J "FOR300H1" "", J "FOR301H1" "", J "FOR302H1" ""])
-    , ("BIO130H1 or BIO206H5 or BIOB10H3", OR [J "BIO130H1" "", J "BIO206H5" "", J "BIOB10H3" ""])
-    , ("CHM220H1 with a minimum grade of B, or CHM222H1", OR [GRADE "B" (J "CHM220H1" ""),J "CHM222H1" ""])
+      ("CSC120H1/CSC148H1", REQOR [J "CSC120H1" "", J "CSC148H1" ""])
+    , ("CSC108H1/CSC120H1/CSC148H1", REQOR [J "CSC108H1" "", J "CSC120H1" "", J "CSC148H1" ""])
+    , ("FOR300H1/FOR301H1/FOR302H1", REQOR [J "FOR300H1" "", J "FOR301H1" "", J "FOR302H1" ""])
+    , ("BIO130H1 or BIO206H5 or BIOB10H3", REQOR [J "BIO130H1" "", J "BIO206H5" "", J "BIOB10H3" ""])
+    , ("CHM220H1 with a minimum grade of B, or CHM222H1", REQOR [GRADE "B" (J "CHM220H1" ""),J "CHM222H1" ""])
     ]
 
 andInputs :: [(String, Req)]
 andInputs = [
-      ("CSC165H1, CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
-    , ("CSC120H1, CSC121H1, CSC148H1", AND [J "CSC120H1" "", J "CSC121H1" "", J "CSC148H1" ""])
-    , ("CSC165H1 & CSC236H1", AND [J "CSC165H1" "", J "CSC236H1" ""])
-    , ("BCH377H1; BCH378H1; and permission of Department", AND [J "BCH377H1" "", J "BCH378H1" "", RAW "permission of Department"])
-    , ("CSC111H1. Permission of department", AND [J "CSC111H1" "", RAW "Permission of department"])
-    , ("CSC110H1, an additional permission of department", AND [J "CSC110H1" "", RAW "permission of department"])
-    , ("CSC110H1, additional CSC111H1", AND [J "CSC110H1" "", J "CSC111H1" ""]) -- TODO: can change the second part to FCEs to make more sense
+      ("CSC165H1, CSC236H1", REQAND [J "CSC165H1" "", J "CSC236H1" ""])
+    , ("CSC120H1, CSC121H1, CSC148H1", REQAND [J "CSC120H1" "", J "CSC121H1" "", J "CSC148H1" ""])
+    , ("CSC165H1 & CSC236H1", REQAND [J "CSC165H1" "", J "CSC236H1" ""])
+    , ("BCH377H1; BCH378H1; and permission of Department", REQAND [J "BCH377H1" "", J "BCH378H1" "", RAW "permission of Department"])
+    , ("CSC111H1. Permission of department", REQAND [J "CSC111H1" "", RAW "Permission of department"])
+    , ("CSC110H1, an additional permission of department", REQAND [J "CSC110H1" "", RAW "permission of department"])
+    , ("CSC110H1, additional CSC111H1", REQAND [J "CSC110H1" "", J "CSC111H1" ""]) -- TODO: can change the second part to FCEs to make more sense
     ]
 
 andorInputs :: [(String, Req)]
 andorInputs = [
-      ("CSC148H1/CSC207H1, CSC165H1/CSC236H1", AND [OR [J "CSC148H1" "", J "CSC207H1" ""], OR [J "CSC165H1" "", J "CSC236H1" ""]])
-    , ("COG250Y1 and one of: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("COG250Y1 and one of either LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("COG250Y1 + one of the following: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", AND [J "COG250Y1" "", OR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
-    , ("CLA204H1 + 1 OF CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
-    , ("BIO220H1 and at least one of EEB319H1/EEB321H1", AND [J "BIO220H1" "", OR [J "EEB319H1" "", J "EEB321H1" ""]])
-    , ("CLA204H1 plus one of CLA160H1/CLA260H1", AND [J "CLA204H1" "", OR [J "CLA160H1" "", J "CLA260H1" ""]])
-    , ("ARH205H1/ ARH305H1, and one of ANT100Y1/ ANT200Y1/ ANT356H1", AND [OR [J "ARH205H1" "",J "ARH305H1" ""],OR [J "ANT100Y1" "",J "ANT200Y1" "",J "ANT356H1" ""]])
+      ("CSC148H1/CSC207H1, CSC165H1/CSC236H1", REQAND [REQOR [J "CSC148H1" "", J "CSC207H1" ""], REQOR [J "CSC165H1" "", J "CSC236H1" ""]])
+    , ("COG250Y1 and one of: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", REQAND [J "COG250Y1" "", REQOR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("COG250Y1 and one of either LIN232H1/LIN241H1 or JLP315H1/JLP374H1", REQAND [J "COG250Y1" "", REQOR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("COG250Y1 + one of the following: LIN232H1/LIN241H1 or JLP315H1/JLP374H1", REQAND [J "COG250Y1" "", REQOR [J "LIN232H1" "", J "LIN241H1" "", J "JLP315H1" "", J "JLP374H1" ""]])
+    , ("CLA204H1 + 1 OF CLA160H1/CLA260H1", REQAND [J "CLA204H1" "", REQOR [J "CLA160H1" "", J "CLA260H1" ""]])
+    , ("BIO220H1 and at least one of EEB319H1/EEB321H1", REQAND [J "BIO220H1" "", REQOR [J "EEB319H1" "", J "EEB321H1" ""]])
+    , ("CLA204H1 plus one of CLA160H1/CLA260H1", REQAND [J "CLA204H1" "", REQOR [J "CLA160H1" "", J "CLA260H1" ""]])
+    , ("ARH205H1/ ARH305H1, and one of ANT100Y1/ ANT200Y1/ ANT356H1", REQAND [REQOR [J "ARH205H1" "",J "ARH305H1" ""],REQOR [J "ANT100Y1" "",J "ANT200Y1" "",J "ANT356H1" ""]])
     ]
 
 parInputs :: [(String, Req)]
 parInputs = [
       ("(CSC148H1)", J "CSC148H1" "")
-    , ("CSC108H1, (CSC165H1/CSC148H1)", AND [J "CSC108H1" "", OR [J "CSC165H1" "", J "CSC148H1" ""]])
-    , ("(MAT135H1, MAT136H1)/ MAT137Y1", OR [AND [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" ""])
-    , ("CSC148H1/(CSC108H1/CSC120H1, MAT137Y1/MAT157Y1)", OR [J "CSC148H1" "", AND [OR [J "CSC108H1" "", J "CSC120H1" ""], OR [J "MAT137Y1" "", J "MAT157Y1" ""]]])
-    , ("STA247H1/STA255H1/STA257H1/PSY201H1/ECO227Y1, (MAT135H1, MAT136H1)/MAT137Y1/MAT157Y1", AND [OR [J "STA247H1" "", J "STA255H1" "", J "STA257H1" "", J "PSY201H1" "", J "ECO227Y1" ""], OR [AND [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" "", J "MAT157Y1" ""]])
+    , ("CSC108H1, (CSC165H1/CSC148H1)", REQAND [J "CSC108H1" "", REQOR [J "CSC165H1" "", J "CSC148H1" ""]])
+    , ("(MAT135H1, MAT136H1)/ MAT137Y1", REQOR [REQAND [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" ""])
+    , ("CSC148H1/(CSC108H1/CSC120H1, MAT137Y1/MAT157Y1)", REQOR [J "CSC148H1" "", REQAND [REQOR [J "CSC108H1" "", J "CSC120H1" ""], REQOR [J "MAT137Y1" "", J "MAT157Y1" ""]]])
+    , ("STA247H1/STA255H1/STA257H1/PSY201H1/ECO227Y1, (MAT135H1, MAT136H1)/MAT137Y1/MAT157Y1", REQAND [REQOR [J "STA247H1" "", J "STA255H1" "", J "STA257H1" "", J "PSY201H1" "", J "ECO227Y1" ""], REQOR [REQAND [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" "", J "MAT157Y1" ""]])
     ]
 
 
 fcesInputs :: [(String, Req)]
 fcesInputs = [
       ("1.0 FCE from the following: (CSC148H1)", FCES 1.0 $ REQUIREMENT $ J "CSC148H1" "")
-    , ("2.0 FCEs from CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ OR [J "CSC165H1" "", J "CSC148H1" ""])
-    , ("2.0 FCEs in CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ OR [J "CSC165H1" "", J "CSC148H1" ""])
-    , ("2 FCEs from: MAT135H1, MAT136H1/ MAT137Y1", FCES 2.0 $ REQUIREMENT $ AND [J "MAT135H1" "",OR [J "MAT136H1" "",J "MAT137Y1" ""]])
+    , ("2.0 FCEs from CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ REQOR [J "CSC165H1" "", J "CSC148H1" ""])
+    , ("2.0 FCEs in CSC165H1/CSC148H1", FCES 2.0 $ REQUIREMENT $ REQOR [J "CSC165H1" "", J "CSC148H1" ""])
+    , ("2 FCEs from: MAT135H1, MAT136H1/ MAT137Y1", FCES 2.0 $ REQUIREMENT $ REQAND [J "MAT135H1" "",REQOR [J "MAT136H1" "",J "MAT137Y1" ""]])
     , ("Completion of 4.0 FCEs", FCES 4.0 $ REQUIREMENT $ RAW "")
     , ("Completion of 4 FCE.", FCES 4.0 $ REQUIREMENT $ RAW "")
     , ("Completion of 9 FCEs", FCES 9.0 $ REQUIREMENT $ RAW "")
-    , ("Completion of 9.0 credits or permission of the instructor", OR [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "permission of the instructor"])
-    , ("Completion of 9.0 credits. Permission of the instructor", AND [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "Permission of the instructor"])
+    , ("Completion of 9.0 credits or permission of the instructor", REQOR [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "permission of the instructor"])
+    , ("Completion of 9.0 credits. Permission of the instructor", REQAND [FCES 9.0 (REQUIREMENT $ RAW ""), RAW "Permission of the instructor"])
     , ("Completion of at least 9.0 FCE", FCES 9.0 $ REQUIREMENT $ RAW "")
     , ("Completion of a minimum of 4.0 FCEs", FCES 4.0 $ REQUIREMENT $ RAW "")
     , ("Completion of a minimum of 9 FCEs", FCES 9.0 $ REQUIREMENT $ RAW "")
@@ -84,11 +84,11 @@ fcesInputs = [
     , ("at least 4.0 credits", FCES 4.0 $ REQUIREMENT $ RAW "")
     , ("At least one 0.5 credit at the 400-level", FCES 0.5 $ DEPARTMENT "400-level")
     , ("At least 1.5 credits at the 400-level", FCES 1.5 $ DEPARTMENT "400-level")
-    , ("1.0 credits or 1.0 credit in Canadian Studies", OR [FCES 1.0 (REQUIREMENT $ RAW ""),FCES 1.0 (DEPARTMENT "Canadian Studies")])
-    , ("NEW240Y1, an additional 0.5 credits at the 300 level from the Critical Studies", AND [J "NEW240Y1" "", FCES 0.5 (DEPARTMENT "300 level")])
-    , ("At least one 0.5 credit at the 400-level or permission of the instructor", OR [FCES 0.5 (DEPARTMENT "400-level"), RAW "permission of the instructor"])
+    , ("1.0 credits or 1.0 credit in Canadian Studies", REQOR [FCES 1.0 (REQUIREMENT $ RAW ""),FCES 1.0 (DEPARTMENT "Canadian Studies")])
+    , ("NEW240Y1, an additional 0.5 credits at the 300 level from the Critical Studies", REQAND [J "NEW240Y1" "", FCES 0.5 (DEPARTMENT "300 level")])
+    , ("At least one 0.5 credit at the 400-level or permission of the instructor", REQOR [FCES 0.5 (DEPARTMENT "400-level"), RAW "permission of the instructor"])
     , ("0.5 credit in HPS", FCES 0.5 (DEPARTMENT "HPS"))
-    , ("1.0 credit in MST courses and 0.5 credit in HIS", AND [FCES 1.0 (DEPARTMENT "MST"), FCES 0.5 (DEPARTMENT "HIS")])
+    , ("1.0 credit in MST courses and 0.5 credit in HIS", REQAND [FCES 1.0 (DEPARTMENT "MST"), FCES 0.5 (DEPARTMENT "HIS")])
     , ("2.0 ENG credits", FCES 2.0 (DEPARTMENT "ENG"))
     , ("Any 9.0 credits", FCES 9.0 (REQUIREMENT $ RAW ""))
     , ("9.0 credits in any field", FCES 9.0 (REQUIREMENT $ RAW ""))
@@ -126,37 +126,37 @@ gradeAftInputs = [
     , ("CSC236H1 (at least 75% or more)", GRADE "75" $ J "CSC236H1" "")
     , ("CSC236H1 ( 75% or higher )", GRADE "75" $ J "CSC236H1" "")
     , ("CSC263H1 with a minimum grade of 60% or more", GRADE "60" $ J "CSC263H1" "")
-    , ("CSC263H1 with a minimum grade of 60% or higher / CSC236H1 (75%)", OR [GRADE "60" $ J "CSC263H1" "", GRADE "75" $ J "CSC236H1" ""])
+    , ("CSC263H1 with a minimum grade of 60% or higher / CSC236H1 (75%)", REQOR [GRADE "60" $ J "CSC263H1" "", GRADE "75" $ J "CSC236H1" ""])
     , ("A in CSC236H1", GRADE "A" $ J "CSC236H1" "")
     ]
 
 artSciInputs :: [(String, Req)]
 artSciInputs = [
       ("BIO220H1 (ecology and evolutionary biology)", J "BIO220H1" "ecology and evolutionary biology")
-    , ("EEB223H1/ STA220H1 (recommended)/ STA257H1 (recommended)", OR [J "EEB223H1" "",J "STA220H1" "recommended",J "STA257H1" "recommended"])
-    , ("EEB223H1 (ecology and evo), STA220H1 (recommended)/ STA257H1 (recommended)", AND [J "EEB223H1" "ecology and evo",OR [J "STA220H1" "recommended",J "STA257H1" "recommended"]])
-    , ("EEB223H1 (ecology and evo)/ STA220H1 (recommended)/ STA257H1", OR [J "EEB223H1" "ecology and evo",J "STA220H1" "recommended",J "STA257H1" ""])
-    , ("EEB223H1 (ecology and evo)/ STA220H1 (B-)/ STA257H1", OR [J "EEB223H1" "ecology and evo", GRADE "B-" $ J "STA220H1" "", J "STA257H1" ""])
-    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", FCES 0.5 $ REQUIREMENT $ OR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""])
-    , ("MATB23H3/STA220H1 (recommended)/STA257H1 (recommended)", OR [J "MATB23H3" "",J "STA220H1" "recommended",J "STA257H1" "recommended"])
+    , ("EEB223H1/ STA220H1 (recommended)/ STA257H1 (recommended)", REQOR [J "EEB223H1" "",J "STA220H1" "recommended",J "STA257H1" "recommended"])
+    , ("EEB223H1 (ecology and evo), STA220H1 (recommended)/ STA257H1 (recommended)", REQAND [J "EEB223H1" "ecology and evo",REQOR [J "STA220H1" "recommended",J "STA257H1" "recommended"]])
+    , ("EEB223H1 (ecology and evo)/ STA220H1 (recommended)/ STA257H1", REQOR [J "EEB223H1" "ecology and evo",J "STA220H1" "recommended",J "STA257H1" ""])
+    , ("EEB223H1 (ecology and evo)/ STA220H1 (B-)/ STA257H1", REQOR [J "EEB223H1" "ecology and evo", GRADE "B-" $ J "STA220H1" "", J "STA257H1" ""])
+    , ("0.5 FCE from: EEB225H1 (recommended)/ STA220H1 (B-)/ STA257H1/  STA288H1/ GGR270H1/ PSY201H1", FCES 0.5 $ REQUIREMENT $ REQOR [J "EEB225H1" "recommended", GRADE "B-" $ J "STA220H1" "", J "STA257H1" "", J "STA288H1" "", J "GGR270H1" "", J "PSY201H1" ""])
+    , ("MATB23H3/STA220H1 (recommended)/STA257H1 (recommended)", REQOR [J "MATB23H3" "",J "STA220H1" "recommended",J "STA257H1" "recommended"])
     ]
 
 programOrInputs :: [(String, Req)]
 programOrInputs = [
       ("Admission to Vic One", PROGRAM "Vic One")
-    , ("Enrolment in the International Relations program or in a History major or specialist program, or permission of instructor", OR [PROGRAM "International Relations",PROGRAM "History major",PROGRAM "History specialist", RAW "permission of instructor"])
-    , ("Enrolment in the International Relations program or in a History or Political Science major or specialist program", OR [PROGRAM "International Relations",PROGRAM "History major",PROGRAM "History specialist",PROGRAM "Political Science major",PROGRAM "Political Science specialist"])
-    --, ("Enrolment in ASMAJ1618. A student must be in third or fourth year.", AND [PROGRAM "ASMAJ1618",RAW "A student must be in third or fourth year."])
-    , ("Enrolment in the PSY Research Specialist program, and PSY309H1, and one of PSY319H1/ PSY329H1/ PSY339H1", AND [PROGRAM "PSY Research Specialist",J "PSY309H1" "",OR [J "PSY319H1" "",J "PSY329H1" "",J "PSY339H1" ""]])
-    , ("70% in SOC212H1 and enrolment in Sociology program", AND [GRADE "70" (J "SOC212H1" ""),PROGRAM "Sociology"])
-    , ("(70% in SOC212H1 and enrolment in Sociology program)", AND [GRADE "70" (J "SOC212H1" ""),PROGRAM "Sociology"])
-    , ("Admission to International Relations Major or Specialist program", OR [PROGRAM "International Relations Major",PROGRAM "International Relations Specialist"])
+    , ("Enrolment in the International Relations program or in a History major or specialist program, or permission of instructor", REQOR [PROGRAM "International Relations",PROGRAM "History major",PROGRAM "History specialist", RAW "permission of instructor"])
+    , ("Enrolment in the International Relations program or in a History or Political Science major or specialist program", REQOR [PROGRAM "International Relations",PROGRAM "History major",PROGRAM "History specialist",PROGRAM "Political Science major",PROGRAM "Political Science specialist"])
+    --, ("Enrolment in ASMAJ1618. A student must be in third or fourth year.", REQAND [PROGRAM "ASMAJ1618",RAW "A student must be in third or fourth year."])
+    , ("Enrolment in the PSY Research Specialist program, and PSY309H1, and one of PSY319H1/ PSY329H1/ PSY339H1", REQAND [PROGRAM "PSY Research Specialist",J "PSY309H1" "",REQOR [J "PSY319H1" "",J "PSY329H1" "",J "PSY339H1" ""]])
+    , ("70% in SOC212H1 and enrolment in Sociology program", REQAND [GRADE "70" (J "SOC212H1" ""),PROGRAM "Sociology"])
+    , ("(70% in SOC212H1 and enrolment in Sociology program)", REQAND [GRADE "70" (J "SOC212H1" ""),PROGRAM "Sociology"])
+    , ("Admission to International Relations Major or Specialist program", REQOR [PROGRAM "International Relations Major",PROGRAM "International Relations Specialist"])
     , ("Instructor’s permission required for admission to course", RAW "Instructor\8217s permission required for admission to course")
-    , ("MGT100H1, or enrolment in the Actuarial Science Specialist or Major", OR [J "MGT100H1" "",PROGRAM "Actuarial Science Specialist",PROGRAM "Actuarial Science Major"])
+    , ("MGT100H1, or enrolment in the Actuarial Science Specialist or Major", REQOR [J "MGT100H1" "",PROGRAM "Actuarial Science Specialist",PROGRAM "Actuarial Science Major"])
     , ("Enrolment in Psychology Minor", PROGRAM "Psychology Minor")
-    , ("Enrolment in History major or permission of instructor", OR [PROGRAM "History major",RAW "permission of instructor"])
-    , ("enrolment in a science, mathematics, or engineering program", OR [PROGRAM "science",PROGRAM "mathematics",PROGRAM "or engineering"])
-    , ("enrolment in a science, mathematics, or engineering program, or permission from instructor", OR [PROGRAM "science",PROGRAM "mathematics",PROGRAM "or engineering", RAW "permission from instructor"])
+    , ("Enrolment in History major or permission of instructor", REQOR [PROGRAM "History major",RAW "permission of instructor"])
+    , ("enrolment in a science, mathematics, or engineering program", REQOR [PROGRAM "science",PROGRAM "mathematics",PROGRAM "or engineering"])
+    , ("enrolment in a science, mathematics, or engineering program, or permission from instructor", REQOR [PROGRAM "science",PROGRAM "mathematics",PROGRAM "or engineering", RAW "permission from instructor"])
     ]
 
 noPrereqInputs :: [(String, Req)]

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -309,7 +309,7 @@ justParser = do
     markInfoParser = do
         Parsec.try (fmap Left percentParser <|> fmap Left letterParser <|> fmap Right infoParser)
 
--- parse for single course with or without cutoff OR a req within parentheses
+-- parse for single course with or without cutoff REQOR a req within parentheses
 courseParser :: Parser Req
 courseParser = Parsec.choice $ map Parsec.try [
     parParser,
@@ -353,25 +353,25 @@ oneOfParser p = do
     case reqs of
         [] -> fail "Empty Req."
         [x] -> return x
-        (x:xs) -> return $ OR $ flattenOr (x:xs)
+        (x:xs) -> return $ REQOR $ flattenOr (x:xs)
 
--- | Returns a parser that parses ORs of the given parser
+-- | Returns a parser that parses REQORs of the given parser
 orParser :: Parser Req -> Parser Req
 orParser p = do
     reqs <- Parsec.sepBy p orSeparator
     case reqs of
         [] -> fail "Empty Req."
         [x] -> return x
-        (x:xs) -> return $ OR $ flattenOr (x:xs)
+        (x:xs) -> return $ REQOR $ flattenOr (x:xs)
 
--- | Returns a parser that parses ANDs of ORs of the given parser
+-- | Returns a parser that parses REQANDs of REQORs of the given parser
 andParser :: Parser Req -> Parser Req
 andParser p = do
     reqs <- Parsec.sepBy (Parsec.try (oneOfParser p) <|> Parsec.try (orParser p)) andSeparator
     case reqs of
         [] -> fail "Empty Req."
         [x] -> return x
-        (x:xs) -> return $ AND (x:xs)
+        (x:xs) -> return $ REQAND (x:xs)
 
 -- | Parser for programs grouped together
 -- | Parses program names and degree types, then concatenate every combination
@@ -392,10 +392,10 @@ programGroupParser = do
         [PROGRAM x] -> case degrees of
             [] -> return $ PROGRAM x
             [d] -> return $ PROGRAM (x ++ " " ++ d)
-            ds -> return $ OR [PROGRAM (x ++ " " ++ d) | d <- ds]
+            ds -> return $ REQOR [PROGRAM (x ++ " " ++ d) | d <- ds]
         xs -> case degrees of
-            [] -> return $ OR [PROGRAM x | PROGRAM x <- xs]
-            ds -> return $ OR [PROGRAM (x ++ " " ++ d) | PROGRAM x <- xs, d <- ds]
+            [] -> return $ REQOR [PROGRAM x | PROGRAM x <- xs]
+            ds -> return $ REQOR [PROGRAM (x ++ " " ++ d) | PROGRAM x <- xs, d <- ds]
 
 programOrParser :: Parser Req
 programOrParser = do
@@ -405,7 +405,7 @@ programOrParser = do
     case progs of
         [] -> fail "Empty Req."
         [x] -> return x
-        (x:xs) -> return $ OR $ flattenOr (x:xs)
+        (x:xs) -> return $ REQOR $ flattenOr (x:xs)
 
 -- | Parser for FCE requirements:
 -- "... 9.0 FCEs ..."
@@ -499,14 +499,14 @@ sepByNoConsume p sep = (do
     return (x:xs))
     <|> return []
 
--- Flattens nested ORs into a single OR
--- eg. OR [OR ["CS major, "Math major"], RAW "permission from instructor"]
--- Nested ORs occur because the way programs are related through ORs is
+-- Flattens nested REQORs into a single REQOR
+-- eg. REQOR [REQOR ["CS major, "Math major"], RAW "permission from instructor"]
+-- Nested REQORs occur because the way programs are related through REQORs is
 -- different than that of courses. So they each have their orParser, which
--- may be related throuhg another OR
+-- may be related throuhg another REQOR
 flattenOr :: [Req] -> [Req]
 flattenOr [] = []
-flattenOr (OR x:xs) = x ++ flattenOr xs
+flattenOr (REQOR x:xs) = x ++ flattenOr xs
 flattenOr (x:xs) = x:flattenOr xs
 
 -- | Trims leading and trailing spaces from a string


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

#1275 requires an `AND` constructor for the modifier data type. To avoid name collision, we need to rename the `AND` constructor for the `Req` data type to `REQAND`. Likewise for `OR` to `REQOR` for a future `OR` (`MODOR`) to be added for `Modifier`.

## Your Changes

<!--- Describe your changes here. -->
Renamed all `AND`s and `OR`s to `REQAND`s and `REQOR`s in
- `app/Database/Requirement.hs`
- `app/ParserTests/ParserTests.hs`
- `app/WebParsing/ReqParser.hs`
- `app/DynamicGraphs/CourseFinder.hs`
- `app/DynamicGraphs/GraphGenerator.hs`

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
- Reran `app/ParserTests/tests.hs` and ensured everything still passed
- Generated a graph with ANDs and ORs and ensured it still generated correctly
![image](https://user-images.githubusercontent.com/38874004/174186317-69a9608e-f3dc-4d0f-bd6c-0f01555170b2.png)

<!--- Please describe in detail how you tested this pull request. -->
<!--- This can include tests you added and manual testing in the web browser. -->

## Questions and Comments (if applicable)
I kept the "and"s and "or"s in the displayed generated graph the same because that's more intuitive for the users

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
