### PR TITLE
fix: stop post parser from consuming failed matches

### DIFF
--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -109,5 +109,5 @@ parseRequirement requirement = map parseSingleReq $ filter isReq requirement
         -- Strips the optional leading numbering (#.) from a line.
         getLineText :: Parser T.Text
         getLineText = do
-            P.optional (P.digit >> P.char '.' >> P.space)
+            P.optional $ P.try (P.digit >> P.char '.' >> P.space)
             parseUntil P.eof


### PR DESCRIPTION
## Motivation and Context
The post parser tries to trim the number from the ordered list. For example, the "1. " and "2. " in this screenshot:
![image](https://user-images.githubusercontent.com/38874004/180126216-88c5cd11-76ad-4161-b14f-325f032c3c64.png)

When the ordered list is not there (or already parsed out by the html library), this `digit, "."` pattern is consumed, and the remaining string cannot be processed by `reqParser`.

The list trimmer should not consume the string if the `digit, ".", space` pattern fails.
## Your Changes
Added a `Parsec.try` in front of the parser to prevent consumption.
**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Removed `db/database.sqlite3`, re-ran `stack run database`, and checked that the data was parsed correctly
Before | After
-|-
![image](https://user-images.githubusercontent.com/38874004/180126939-91517d45-37ef-411b-96fe-ed478ed05eb8.png) | ![image](https://user-images.githubusercontent.com/38874004/180126873-a7ee64cd-b458-4570-982b-0d6962e26070.png)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
