### PR TITLE
Post parsing

### DIFF
--- a/app/Database/DataType.hs
+++ b/app/Database/DataType.hs
@@ -31,7 +31,7 @@ instance ToJSON ShapeType
 -- .
 instance FromJSON ShapeType
 
-data PostType = Specialist | Major | Minor | Certificate | Other
+data PostType = Specialist | Major | Minor | Focus | Certificate | Other
  deriving (Show, Read, Eq, Generic)
 derivePersistField "PostType"
 

--- a/app/Database/DataType.hs
+++ b/app/Database/DataType.hs
@@ -31,7 +31,7 @@ instance ToJSON ShapeType
 -- .
 instance FromJSON ShapeType
 
-data PostType = Specialist | Major | Minor | Other
+data PostType = Specialist | Major | Minor | Certificate | Other
  deriving (Show, Read, Eq, Generic)
 derivePersistField "PostType"
 

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -132,6 +132,7 @@ Post
     --UniquePostCode code
     --Primary code
     description T.Text
+    requirements T.Text
     deriving Show Eq
 
 PostCategory

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -132,7 +132,7 @@ Post
     --UniquePostCode code
     --Primary code
     description T.Text
-    deriving Show
+    deriving Show Eq
 
 PostCategory
     post PostId

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 {-|
 Description: Test Course Requirement Parsers using HUnit Testing Framework.
 
@@ -17,126 +19,50 @@ import Text.Parsec.Text (Parser)
 import WebParsing.PostParser (postInfoParser)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => Parser a -> String -> [(T.Text, a)] -> Test
+createTest :: Parser Post -> String -> [(T.Text, (T.Text, T.Text, PostType))] -> Test
 createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
                                 TestCase $ assertEqual ("for (" ++ T.unpack x ++ "),")
-                                (Right y) (Parsec.parse parser "" x)) input
+                                (Right $ makePost y) (Parsec.parse parser "" x)) input
 
-postInfoInputs :: [(T.Text, Post)]
+-- | Input and output pair of each post
+-- | Output is in the order of (postDepartment, postCode, postName)
+postInfoInputs :: [(T.Text, (T.Text, T.Text, PostType))]
 postInfoInputs = [
       ("Music Major (Arts Program) - ASMAJ2276",
-        Post {
-        postName = Major,
-        postDepartment = "Music Major (Arts Program)",
-        postCode = "ASMAJ2276",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Music Major (Arts Program)", "ASMAJ2276", Major))
     , ("Focus in Artificial Intelligence (Major) - ASFOC1689K",
-        Post {
-        postName = Focus,
-        postDepartment = "Focus in Artificial Intelligence (Major)",
-        postCode = "ASFOC1689K",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Focus in Artificial Intelligence (Major)", "ASFOC1689K", Focus))
     , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
-        Post {
-        postName = Specialist,
-        postDepartment = "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell",
-        postCode = "ASSPE1003A",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell", "ASSPE1003A", Specialist))
     , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
-        Post {
-        postName = Focus,
-        postDepartment = "Focus in Medical Anthropology (Specialist: Society, Culture and Language)",
-        postCode = "ASFOC2112B",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Focus in Medical Anthropology (Specialist: Society, Culture and Language)", "ASFOC2112B", Focus))
     , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
-        Post {
-        postName = Specialist,
-        postDepartment = "Anthropology Specialist (Society, Culture, and Language) (Arts Program)",
-        postCode = "ASSPE2112",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Anthropology Specialist (Society, Culture, and Language) (Arts Program)", "ASSPE2112", Specialist))
     , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
-        Post {
-        postName = Major,
-        postDepartment = "Christianity and Culture: Major Program in Religious Education (Arts Program)",
-        postCode = "ASMAJ1021",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Christianity and Culture: Major Program in Religious Education (Arts Program)", "ASMAJ1021", Major))
     , ("Minor in French Language (Arts Program) - ASMIN0120",
-        Post {
-        postName = Minor,
-        postDepartment = "Minor in French Language (Arts Program)",
-        postCode = "ASMIN0120",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Minor in French Language (Arts Program)", "ASMIN0120", Minor))
     , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
-        Post {
-        postName = Minor,
-        postDepartment = "Minor Program in Christianity and Education (Arts Program)",
-        postCode = "ASMIN1014",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Minor Program in Christianity and Education (Arts Program)", "ASMIN1014", Minor))
     , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
-        Post {
-        postName = Specialist,
-        postDepartment = "Psychology Research Specialist - Thesis (Science Program)",
-        postCode = "ASSPE1958",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Psychology Research Specialist - Thesis (Science Program)", "ASSPE1958", Specialist))
     , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
-        Post {
-        postName = Major,
-        postDepartment = "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)",
-        postCode = "ASMAJ1445B",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)", "ASMAJ1445B", Major))
     , ("Certificate in Business Fundamentals - ASCER2400",
-        Post {
-        postName = Certificate,
-        postDepartment = "Certificate in Business Fundamentals",
-        postCode = "ASCER2400",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Certificate in Business Fundamentals", "ASCER2400", Certificate))
     , ("Focus in Green Chemistry",
-        Post {
-        postName = Other,
-        postDepartment = "Focus in Green Chemistry",
-        postCode = "",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Focus in Green Chemistry", "", Other))
     , ("Focus in Finance - ASFOC2431B",
-        Post {
-        postName = Focus,
-        postDepartment = "Focus in Finance",
-        postCode = "ASFOC2431B",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Focus in Finance", "ASFOC2431B", Focus))
     , ("Biological Physics Specialist",
-        Post {
-        postName = Other,
-        postDepartment = "Biological Physics Specialist",
-        postCode = "",
-        postDescription = "",
-        postRequirements = ""
-        })
+        ("Biological Physics Specialist", "", Other))
     ]
+
+-- | Takes a tuple of (postDepartment, postCode, postName) and makes a Post data
+-- | by filling postDescription and postRequirements with empty text
+makePost :: (T.Text, T.Text, PostType) -> Post
+makePost (postDepartment, postCode, postName) = Post { postName, postDepartment, postCode, postDescription = T.empty, postRequirements = T.empty }
+
 postInfoTests :: Test
 postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs
 

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -24,20 +24,20 @@ createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
 
 postInfoInputs :: [(T.Text, Post)]
 postInfoInputs = [
-      ("Music Major (Arts Program) - ASMAJ2276", Post {postName = Major, postDepartment = "Music (Arts Program)", postCode = "ASMAJ2276", postDescription = ""})
-    , ("Focus in Artificial Intelligence (Major) - ASFOC1689K", Post {postName = Major, postDepartment = "Focus in Artificial Intelligence", postCode = "ASFOC1689K", postDescription = ""})
-    , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A", Post {postName = Specialist, postDepartment = "Cell & Molecular Biology Focus in Molecular Networks of the Cell", postCode = "ASSPE1003A", postDescription = ""})
-    , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B", Post {postName = Specialist, postDepartment = "Focus in Medical Anthropology (Society, Culture and Language)", postCode = "ASFOC2112B", postDescription = ""})
-    , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112", Post {postName = Specialist, postDepartment = "Anthropology (Society, Culture, and Language) (Arts Program)", postCode = "ASSPE2112", postDescription = ""})
-    , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021", Post {postName = Major, postDepartment = "Christianity and Culture: Religious Education (Arts Program)", postCode = "ASMAJ1021", postDescription = ""})
-    , ("Minor in French Language (Arts Program) - ASMIN0120", Post {postName = Minor, postDepartment = "French Language (Arts Program)", postCode = "ASMIN0120", postDescription = ""})
-    , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014", Post {postName = Minor, postDepartment = "Christianity and Education (Arts Program)", postCode = "ASMIN1014", postDescription = ""})
-    , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)", Post {postName = Specialist, postDepartment = "Psychology Research - Thesis (Science Program)", postCode = "ASSPE1958", postDescription = ""})
-    , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B", Post {postName = Major, postDepartment = "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)", postCode = "ASMAJ1445B", postDescription = ""})
-    , ("Certificate in Business Fundamentals - ASCER2400", Post {postName = Certificate, postDepartment = "Business Fundamentals", postCode = "ASCER2400", postDescription = ""})
-    , ("Focus in Green Chemistry", Post {postName = Other, postDepartment = "Focus in Green Chemistry", postCode = "", postDescription = ""})
-    , ("Focus in Finance - ASFOC2431B", Post {postName = Other, postDepartment = "Focus in Finance", postCode = "ASFOC2431B", postDescription = ""})
-    , ("Biological Physics Specialist", Post {postName = Specialist, postDepartment = "Biological Physics", postCode = "", postDescription = ""})
+      (T.pack "Music Major (Arts Program) - ASMAJ2276", Post {postName = Major, postDepartment = T.pack "Music (Arts Program)", postCode = T.pack "ASMAJ2276", postDescription = T.pack ""})
+    , (T.pack "Focus in Artificial Intelligence (Major) - ASFOC1689K", Post {postName = Major, postDepartment = T.pack "Focus in Artificial Intelligence", postCode = T.pack "ASFOC1689K", postDescription = T.pack ""})
+    , (T.pack "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A", Post {postName = Specialist, postDepartment = T.pack "Cell & Molecular Biology Focus in Molecular Networks of the Cell", postCode = T.pack "ASSPE1003A", postDescription = T.pack ""})
+    , (T.pack "Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B", Post {postName = Specialist, postDepartment = T.pack "Focus in Medical Anthropology (Society, Culture and Language)", postCode = T.pack "ASFOC2112B", postDescription = T.pack ""})
+    , (T.pack "Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112", Post {postName = Specialist, postDepartment = T.pack "Anthropology (Society, Culture, and Language) (Arts Program)", postCode = T.pack "ASSPE2112", postDescription = T.pack ""})
+    , (T.pack "Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021", Post {postName = Major, postDepartment = T.pack "Christianity and Culture: Religious Education (Arts Program)", postCode = T.pack "ASMAJ1021", postDescription = T.pack ""})
+    , (T.pack "Minor in French Language (Arts Program) - ASMIN0120", Post {postName = Minor, postDepartment = T.pack "French Language (Arts Program)", postCode = T.pack "ASMIN0120", postDescription = T.pack ""})
+    , (T.pack "Minor Program in Christianity and Education (Arts Program) - ASMIN1014", Post {postName = Minor, postDepartment = T.pack "Christianity and Education (Arts Program)", postCode = T.pack "ASMIN1014", postDescription = T.pack ""})
+    , (T.pack "Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)", Post {postName = Specialist, postDepartment = T.pack "Psychology Research - Thesis (Science Program)", postCode = T.pack "ASSPE1958", postDescription = T.pack ""})
+    , (T.pack "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B", Post {postName = Major, postDepartment = T.pack "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)", postCode = T.pack "ASMAJ1445B", postDescription = T.pack ""})
+    , (T.pack "Certificate in Business Fundamentals - ASCER2400", Post {postName = Certificate, postDepartment = T.pack "Business Fundamentals", postCode = T.pack "ASCER2400", postDescription = T.pack ""})
+    , (T.pack "Focus in Green Chemistry", Post {postName = Other, postDepartment = T.pack "Focus in Green Chemistry", postCode = T.pack "", postDescription = T.pack ""})
+    , (T.pack "Focus in Finance - ASFOC2431B", Post {postName = Other, postDepartment = T.pack "Focus in Finance", postCode = T.pack "ASFOC2431B", postDescription = T.pack ""})
+    , (T.pack "Biological Physics Specialist", Post {postName = Specialist, postDepartment = T.pack "Biological Physics", postCode = T.pack "", postDescription = T.pack ""})
     ]
 postInfoTests :: Test
 postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -24,103 +24,103 @@ createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
 
 postInfoInputs :: [(T.Text, Post)]
 postInfoInputs = [
-      (T.pack "Music Major (Arts Program) - ASMAJ2276",
+      ("Music Major (Arts Program) - ASMAJ2276",
         Post {
         postName = Major,
-        postDepartment = T.pack "Music (Arts Program)",
-        postCode = T.pack "ASMAJ2276",
-        postDescription = T.pack ""
+        postDepartment = "Music (Arts Program)",
+        postCode = "ASMAJ2276",
+        postDescription = ""
         })
-    , (T.pack "Focus in Artificial Intelligence (Major) - ASFOC1689K",
+    , ("Focus in Artificial Intelligence (Major) - ASFOC1689K",
         Post {
         postName = Major,
-        postDepartment = T.pack "Focus in Artificial Intelligence",
-        postCode = T.pack "ASFOC1689K",
-        postDescription = T.pack ""
+        postDepartment = "Focus in Artificial Intelligence",
+        postCode = "ASFOC1689K",
+        postDescription = ""
         })
-    , (T.pack "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
+    , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
         Post {
         postName = Specialist,
-        postDepartment = T.pack "Cell & Molecular Biology Focus in Molecular Networks of the Cell",
-        postCode = T.pack "ASSPE1003A",
-        postDescription = T.pack ""
+        postDepartment = "Cell & Molecular Biology Focus in Molecular Networks of the Cell",
+        postCode = "ASSPE1003A",
+        postDescription = ""
         })
-    , (T.pack "Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
+    , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
         Post {
         postName = Specialist,
-        postDepartment = T.pack "Focus in Medical Anthropology (Society, Culture and Language)",
-        postCode = T.pack "ASFOC2112B",
-        postDescription = T.pack ""
+        postDepartment = "Focus in Medical Anthropology (Society, Culture and Language)",
+        postCode = "ASFOC2112B",
+        postDescription = ""
         })
-    , (T.pack "Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
+    , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
         Post {
         postName = Specialist,
-        postDepartment = T.pack "Anthropology (Society, Culture, and Language) (Arts Program)",
-        postCode = T.pack "ASSPE2112",
-        postDescription = T.pack ""
+        postDepartment = "Anthropology (Society, Culture, and Language) (Arts Program)",
+        postCode = "ASSPE2112",
+        postDescription = ""
         })
-    , (T.pack "Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
+    , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
         Post {
         postName = Major,
-        postDepartment = T.pack "Christianity and Culture: Religious Education (Arts Program)",
-        postCode = T.pack "ASMAJ1021",
-        postDescription = T.pack ""
+        postDepartment = "Christianity and Culture: Religious Education (Arts Program)",
+        postCode = "ASMAJ1021",
+        postDescription = ""
         })
-    , (T.pack "Minor in French Language (Arts Program) - ASMIN0120",
+    , ("Minor in French Language (Arts Program) - ASMIN0120",
         Post {
         postName = Minor,
-        postDepartment = T.pack "French Language (Arts Program)",
-        postCode = T.pack "ASMIN0120",
-        postDescription = T.pack ""
+        postDepartment = "French Language (Arts Program)",
+        postCode = "ASMIN0120",
+        postDescription = ""
         })
-    , (T.pack "Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
+    , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
         Post {
         postName = Minor,
-        postDepartment = T.pack "Christianity and Education (Arts Program)",
-        postCode = T.pack "ASMIN1014",
-        postDescription = T.pack ""
+        postDepartment = "Christianity and Education (Arts Program)",
+        postCode = "ASMIN1014",
+        postDescription = ""
         })
-    , (T.pack "Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
+    , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
         Post {
         postName = Specialist,
-        postDepartment = T.pack "Psychology Research - Thesis (Science Program)",
-        postCode = T.pack "ASSPE1958",
-        postDescription = T.pack ""
+        postDepartment = "Psychology Research - Thesis (Science Program)",
+        postCode = "ASSPE1958",
+        postDescription = ""
         })
-    , (T.pack "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
+    , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
         Post {
         postName = Major,
-        postDepartment = T.pack "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)",
-        postCode = T.pack "ASMAJ1445B",
-        postDescription = T.pack ""
+        postDepartment = "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)",
+        postCode = "ASMAJ1445B",
+        postDescription = ""
         })
-    , (T.pack "Certificate in Business Fundamentals - ASCER2400",
+    , ("Certificate in Business Fundamentals - ASCER2400",
         Post {
         postName = Certificate,
-        postDepartment = T.pack "Business Fundamentals",
-        postCode = T.pack "ASCER2400",
-        postDescription = T.pack ""
+        postDepartment = "Business Fundamentals",
+        postCode = "ASCER2400",
+        postDescription = ""
         })
-    , (T.pack "Focus in Green Chemistry",
+    , ("Focus in Green Chemistry",
         Post {
         postName = Other,
-        postDepartment = T.pack "Focus in Green Chemistry",
-        postCode = T.pack "",
-        postDescription = T.pack ""
+        postDepartment = "Focus in Green Chemistry",
+        postCode = "",
+        postDescription = ""
         })
-    , (T.pack "Focus in Finance - ASFOC2431B",
+    , ("Focus in Finance - ASFOC2431B",
         Post {
         postName = Other,
-        postDepartment = T.pack "Focus in Finance",
-        postCode = T.pack "ASFOC2431B",
-        postDescription = T.pack ""
+        postDepartment = "Focus in Finance",
+        postCode = "ASFOC2431B",
+        postDescription = ""
         })
-    , (T.pack "Biological Physics Specialist",
+    , ("Biological Physics Specialist",
         Post {
         postName = Specialist,
-        postDepartment = T.pack "Biological Physics",
-        postCode = T.pack "",
-        postDescription = T.pack ""
+        postDepartment = "Biological Physics",
+        postCode = "",
+        postDescription = ""
         })
     ]
 postInfoTests :: Test

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 {-|
-Description: Test Course Requirement Parsers using HUnit Testing Framework.
+Description: Test Post Parsers using HUnit Testing Framework.
 
-Module containing test cases for Requirement Parsers.
+Module containing test cases for Post Parsers.
 
 -}
 

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -130,8 +130,8 @@ postInfoInputs = [
         })
     , ("Biological Physics Specialist",
         Post {
-        postName = Specialist,
-        postDepartment = "Biological Physics",
+        postName = Other,
+        postDepartment = "Biological Physics Specialist",
         postCode = "",
         postDescription = "",
         postRequirements = ""

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -1,0 +1,47 @@
+{-|
+Description: Test Course Requirement Parsers using HUnit Testing Framework.
+
+Module containing test cases for Requirement Parsers.
+
+-}
+
+module RequirementTests.PostParserTests
+( postTestSuite ) where
+
+import qualified Data.Text as T
+import Database.DataType (PostType (..))
+import Database.Tables
+import Test.HUnit (Test (..), assertEqual)
+import qualified Text.Parsec as Parsec
+import Text.Parsec.Text (Parser)
+import WebParsing.PostParser (postInfoParser)
+
+-- Function to facilitate test case creation given a string, Req tuple
+createTest :: (Eq a, Show a) => Parser a -> String -> [(T.Text, a)] -> Test
+createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
+                                TestCase $ assertEqual ("for (" ++ T.unpack x ++ "),")
+                                (Right y) (Parsec.parse parser "" x)) input
+
+postInfoInputs :: [(T.Text, Post)]
+postInfoInputs = [
+      ("Music Major (Arts Program) - ASMAJ2276", Post {postName = Major, postDepartment = "Music (Arts Program)", postCode = "ASMAJ2276", postDescription = ""})
+    , ("Focus in Artificial Intelligence (Major) - ASFOC1689K", Post {postName = Major, postDepartment = "Focus in Artificial Intelligence", postCode = "ASFOC1689K", postDescription = ""})
+    , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A", Post {postName = Specialist, postDepartment = "Cell & Molecular Biology Focus in Molecular Networks of the Cell", postCode = "ASSPE1003A", postDescription = ""})
+    , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B", Post {postName = Specialist, postDepartment = "Focus in Medical Anthropology (Society, Culture and Language)", postCode = "ASFOC2112B", postDescription = ""})
+    , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112", Post {postName = Specialist, postDepartment = "Anthropology (Society, Culture, and Language) (Arts Program)", postCode = "ASSPE2112", postDescription = ""})
+    , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021", Post {postName = Major, postDepartment = "Christianity and Culture: Religious Education (Arts Program)", postCode = "ASMAJ1021", postDescription = ""})
+    , ("Minor in French Language (Arts Program) - ASMIN0120", Post {postName = Minor, postDepartment = "French Language (Arts Program)", postCode = "ASMIN0120", postDescription = ""})
+    , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014", Post {postName = Minor, postDepartment = "Christianity and Education (Arts Program)", postCode = "ASMIN1014", postDescription = ""})
+    , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)", Post {postName = Specialist, postDepartment = "Psychology Research - Thesis (Science Program)", postCode = "ASSPE1958", postDescription = ""})
+    , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B", Post {postName = Major, postDepartment = "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)", postCode = "ASMAJ1445B", postDescription = ""})
+    , ("Certificate in Business Fundamentals - ASCER2400", Post {postName = Certificate, postDepartment = "Business Fundamentals", postCode = "ASCER2400", postDescription = ""})
+    , ("Focus in Green Chemistry", Post {postName = Other, postDepartment = "Focus in Green Chemistry", postCode = "", postDescription = ""})
+    , ("Focus in Finance - ASFOC2431B", Post {postName = Other, postDepartment = "Focus in Finance", postCode = "ASFOC2431B", postDescription = ""})
+    , ("Biological Physics Specialist", Post {postName = Specialist, postDepartment = "Biological Physics", postCode = "", postDescription = ""})
+    ]
+postInfoTests :: Test
+postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs
+
+-- functions for running tests in REPL
+postTestSuite :: Test
+postTestSuite = TestLabel "PostParser tests" $ TestList [postInfoTests]

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -24,20 +24,104 @@ createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
 
 postInfoInputs :: [(T.Text, Post)]
 postInfoInputs = [
-      (T.pack "Music Major (Arts Program) - ASMAJ2276", Post {postName = Major, postDepartment = T.pack "Music (Arts Program)", postCode = T.pack "ASMAJ2276", postDescription = T.pack ""})
-    , (T.pack "Focus in Artificial Intelligence (Major) - ASFOC1689K", Post {postName = Major, postDepartment = T.pack "Focus in Artificial Intelligence", postCode = T.pack "ASFOC1689K", postDescription = T.pack ""})
-    , (T.pack "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A", Post {postName = Specialist, postDepartment = T.pack "Cell & Molecular Biology Focus in Molecular Networks of the Cell", postCode = T.pack "ASSPE1003A", postDescription = T.pack ""})
-    , (T.pack "Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B", Post {postName = Specialist, postDepartment = T.pack "Focus in Medical Anthropology (Society, Culture and Language)", postCode = T.pack "ASFOC2112B", postDescription = T.pack ""})
-    , (T.pack "Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112", Post {postName = Specialist, postDepartment = T.pack "Anthropology (Society, Culture, and Language) (Arts Program)", postCode = T.pack "ASSPE2112", postDescription = T.pack ""})
-    , (T.pack "Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021", Post {postName = Major, postDepartment = T.pack "Christianity and Culture: Religious Education (Arts Program)", postCode = T.pack "ASMAJ1021", postDescription = T.pack ""})
-    , (T.pack "Minor in French Language (Arts Program) - ASMIN0120", Post {postName = Minor, postDepartment = T.pack "French Language (Arts Program)", postCode = T.pack "ASMIN0120", postDescription = T.pack ""})
-    , (T.pack "Minor Program in Christianity and Education (Arts Program) - ASMIN1014", Post {postName = Minor, postDepartment = T.pack "Christianity and Education (Arts Program)", postCode = T.pack "ASMIN1014", postDescription = T.pack ""})
-    , (T.pack "Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)", Post {postName = Specialist, postDepartment = T.pack "Psychology Research - Thesis (Science Program)", postCode = T.pack "ASSPE1958", postDescription = T.pack ""})
-    , (T.pack "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B", Post {postName = Major, postDepartment = T.pack "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)", postCode = T.pack "ASMAJ1445B", postDescription = T.pack ""})
-    , (T.pack "Certificate in Business Fundamentals - ASCER2400", Post {postName = Certificate, postDepartment = T.pack "Business Fundamentals", postCode = T.pack "ASCER2400", postDescription = T.pack ""})
-    , (T.pack "Focus in Green Chemistry", Post {postName = Other, postDepartment = T.pack "Focus in Green Chemistry", postCode = T.pack "", postDescription = T.pack ""})
-    , (T.pack "Focus in Finance - ASFOC2431B", Post {postName = Other, postDepartment = T.pack "Focus in Finance", postCode = T.pack "ASFOC2431B", postDescription = T.pack ""})
-    , (T.pack "Biological Physics Specialist", Post {postName = Specialist, postDepartment = T.pack "Biological Physics", postCode = T.pack "", postDescription = T.pack ""})
+      (T.pack "Music Major (Arts Program) - ASMAJ2276",
+        Post {
+        postName = Major,
+        postDepartment = T.pack "Music (Arts Program)",
+        postCode = T.pack "ASMAJ2276",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Focus in Artificial Intelligence (Major) - ASFOC1689K",
+        Post {
+        postName = Major,
+        postDepartment = T.pack "Focus in Artificial Intelligence",
+        postCode = T.pack "ASFOC1689K",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
+        Post {
+        postName = Specialist,
+        postDepartment = T.pack "Cell & Molecular Biology Focus in Molecular Networks of the Cell",
+        postCode = T.pack "ASSPE1003A",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
+        Post {
+        postName = Specialist,
+        postDepartment = T.pack "Focus in Medical Anthropology (Society, Culture and Language)",
+        postCode = T.pack "ASFOC2112B",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
+        Post {
+        postName = Specialist,
+        postDepartment = T.pack "Anthropology (Society, Culture, and Language) (Arts Program)",
+        postCode = T.pack "ASSPE2112",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
+        Post {
+        postName = Major,
+        postDepartment = T.pack "Christianity and Culture: Religious Education (Arts Program)",
+        postCode = T.pack "ASMAJ1021",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Minor in French Language (Arts Program) - ASMIN0120",
+        Post {
+        postName = Minor,
+        postDepartment = T.pack "French Language (Arts Program)",
+        postCode = T.pack "ASMIN0120",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
+        Post {
+        postName = Minor,
+        postDepartment = T.pack "Christianity and Education (Arts Program)",
+        postCode = T.pack "ASMIN1014",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
+        Post {
+        postName = Specialist,
+        postDepartment = T.pack "Psychology Research - Thesis (Science Program)",
+        postCode = T.pack "ASSPE1958",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
+        Post {
+        postName = Major,
+        postDepartment = T.pack "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)",
+        postCode = T.pack "ASMAJ1445B",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Certificate in Business Fundamentals - ASCER2400",
+        Post {
+        postName = Certificate,
+        postDepartment = T.pack "Business Fundamentals",
+        postCode = T.pack "ASCER2400",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Focus in Green Chemistry",
+        Post {
+        postName = Other,
+        postDepartment = T.pack "Focus in Green Chemistry",
+        postCode = T.pack "",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Focus in Finance - ASFOC2431B",
+        Post {
+        postName = Other,
+        postDepartment = T.pack "Focus in Finance",
+        postCode = T.pack "ASFOC2431B",
+        postDescription = T.pack ""
+        })
+    , (T.pack "Biological Physics Specialist",
+        Post {
+        postName = Specialist,
+        postDepartment = T.pack "Biological Physics",
+        postCode = T.pack "",
+        postDescription = T.pack ""
+        })
     ]
 postInfoTests :: Test
 postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -27,100 +27,114 @@ postInfoInputs = [
       ("Music Major (Arts Program) - ASMAJ2276",
         Post {
         postName = Major,
-        postDepartment = "Music (Arts Program)",
+        postDepartment = "Music Major (Arts Program)",
         postCode = "ASMAJ2276",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Focus in Artificial Intelligence (Major) - ASFOC1689K",
         Post {
-        postName = Major,
-        postDepartment = "Focus in Artificial Intelligence",
+        postName = Focus,
+        postDepartment = "Focus in Artificial Intelligence (Major)",
         postCode = "ASFOC1689K",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
         Post {
         postName = Specialist,
-        postDepartment = "Cell & Molecular Biology Focus in Molecular Networks of the Cell",
+        postDepartment = "Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell",
         postCode = "ASSPE1003A",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
         Post {
-        postName = Specialist,
-        postDepartment = "Focus in Medical Anthropology (Society, Culture and Language)",
+        postName = Focus,
+        postDepartment = "Focus in Medical Anthropology (Specialist: Society, Culture and Language)",
         postCode = "ASFOC2112B",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
         Post {
         postName = Specialist,
-        postDepartment = "Anthropology (Society, Culture, and Language) (Arts Program)",
+        postDepartment = "Anthropology Specialist (Society, Culture, and Language) (Arts Program)",
         postCode = "ASSPE2112",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
         Post {
         postName = Major,
-        postDepartment = "Christianity and Culture: Religious Education (Arts Program)",
+        postDepartment = "Christianity and Culture: Major Program in Religious Education (Arts Program)",
         postCode = "ASMAJ1021",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Minor in French Language (Arts Program) - ASMIN0120",
         Post {
         postName = Minor,
-        postDepartment = "French Language (Arts Program)",
+        postDepartment = "Minor in French Language (Arts Program)",
         postCode = "ASMIN0120",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
         Post {
         postName = Minor,
-        postDepartment = "Christianity and Education (Arts Program)",
+        postDepartment = "Minor Program in Christianity and Education (Arts Program)",
         postCode = "ASMIN1014",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
         Post {
         postName = Specialist,
-        postDepartment = "Psychology Research - Thesis (Science Program)",
+        postDepartment = "Psychology Research Specialist - Thesis (Science Program)",
         postCode = "ASSPE1958",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
         Post {
         postName = Major,
-        postDepartment = "Cognitive Science - Arts (Language and Cognition Stream) (Arts Program)",
+        postDepartment = "Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)",
         postCode = "ASMAJ1445B",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Certificate in Business Fundamentals - ASCER2400",
         Post {
         postName = Certificate,
-        postDepartment = "Business Fundamentals",
+        postDepartment = "Certificate in Business Fundamentals",
         postCode = "ASCER2400",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Focus in Green Chemistry",
         Post {
         postName = Other,
         postDepartment = "Focus in Green Chemistry",
         postCode = "",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Focus in Finance - ASFOC2431B",
         Post {
-        postName = Other,
+        postName = Focus,
         postDepartment = "Focus in Finance",
         postCode = "ASFOC2431B",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     , ("Biological Physics Specialist",
         Post {
         postName = Specialist,
         postDepartment = "Biological Physics",
         postCode = "",
-        postDescription = ""
+        postDescription = "",
+        postRequirements = ""
         })
     ]
 postInfoTests :: Test

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -50,12 +50,12 @@ postInfoInputs = [
         ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)", "ASMAJ1445B", Major))
     , ("Certificate in Business Fundamentals - ASCER2400",
         ("Certificate in Business Fundamentals", "ASCER2400", Certificate))
-    , ("Focus in Green Chemistry",
-        ("Focus in Green Chemistry", "", Other))
     , ("Focus in Finance - ASFOC2431B",
         ("Focus in Finance", "ASFOC2431B", Focus))
+    , ("Focus in Green Chemistry",
+        ("Focus in Green Chemistry", "", Focus))
     , ("Biological Physics Specialist",
-        ("Biological Physics Specialist", "", Other))
+        ("Biological Physics Specialist", "", Specialist))
     ]
 
 -- | Takes a tuple of (postDepartment, postCode, postName) and makes a Post data

--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -61,7 +61,8 @@ postInfoInputs = [
 -- | Takes a tuple of (postDepartment, postCode, postName) and makes a Post data
 -- | by filling postDescription and postRequirements with empty text
 makePost :: (T.Text, T.Text, PostType) -> Post
-makePost (postDepartment, postCode, postName) = Post { postName, postDepartment, postCode, postDescription = T.empty, postRequirements = T.empty }
+makePost (postDepartment, postCode, postName) =
+    Post { postName, postDepartment, postCode, postDescription = T.empty, postRequirements = T.empty }
 
 postInfoTests :: Test
 postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs

--- a/app/RequirementTests/ReqParserTests.hs
+++ b/app/RequirementTests/ReqParserTests.hs
@@ -5,7 +5,7 @@ Module containing test cases for Requirement Parsers.
 
 -}
 
-module RequirementTests.ParserTests
+module RequirementTests.ReqParserTests
 ( reqTestSuite ) where
 
 import Database.Requirement

--- a/app/RequirementTests/tests.hs
+++ b/app/RequirementTests/tests.hs
@@ -10,13 +10,14 @@ module Main
 
 import Control.Monad
 import RequirementTests.ModifierTests (modifierTestSuite)
-import RequirementTests.ParserTests (reqTestSuite)
+import RequirementTests.PostParserTests (postTestSuite)
+import RequirementTests.ReqParserTests (reqTestSuite)
 import qualified System.Exit as Exit
 import Test.HUnit (Test (..), failures, runTestTT)
 
 -- Single test encompassing all test suites
 tests :: Test
-tests = TestList [reqTestSuite, modifierTestSuite]
+tests = TestList [reqTestSuite, postTestSuite, modifierTestSuite]
 
 main :: IO ()
 main = do

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -55,12 +55,12 @@ postInfoParser = do
         void postCodeParser,
         P.eof
         ]
-    code <- postCodeParser P.<|> return ""
+    code <- postCodeParser P.<|> return (T.pack "")
 
     case deptNameBef of
-        "" -> return $ Post postType (T.pack $ trim deptNameAft) code ""
-        xs | last xs == '(' -> return $ Post postType (T.pack $ trim $ trim deptNameBef ++ trim deptNameAft) code ""
-           | otherwise -> return $ Post postType (T.pack $ trim $ trim deptNameBef ++ " " ++ trim deptNameAft) code ""
+        "" -> return $ Post postType (T.pack $ trim deptNameAft) code $ T.pack ""
+        xs | last xs == '(' -> return $ Post postType (T.pack $ trim $ trim deptNameBef ++ trim deptNameAft) code (T.pack "")
+           | otherwise -> return $ Post postType (T.pack $ trim $ trim deptNameBef ++ " " ++ trim deptNameAft) code (T.pack "")
 
 postTypeParser :: Parser PostType
 postTypeParser = P.try postNameParser P.<|> P.between (P.char '(') (P.char ')') postNameParser

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -28,14 +28,14 @@ addPostToDatabase programElements = do
         postDescHtml = partitions isDescriptionSection programElements
         postReqHtml = sections isRequirementSection programElements
         requirementLines = if null postReqHtml then [] else reqHtmlToLines $ last postReqHtml
-        description = if null postReqHtml then [] else innerText $ head postDescHtml
+        descriptionText = if null postReqHtml then T.empty else innerText $ head postDescHtml
         requirements = concatMap parseRequirement requirementLines
     liftIO $ print fullPostName
 
     case P.parse postInfoParser "POSt information" fullPostName of
         Left _ -> return ()
         Right post -> do
-            postExists <- insertUnique post { postDescription = descriptionLines, postRequirements = intercalate "\n" $ concat requirementLines }
+            postExists <- insertUnique post { postDescription = descriptionText, postRequirements = intercalate "\n" $ concat requirementLines }
             case postExists of
                 Just key ->
                     mapM_ (insert_ . PostCategory key) requirements
@@ -43,6 +43,7 @@ addPostToDatabase programElements = do
     where
         isDescriptionSection tag = tagOpenAttrNameLit "div" "class" (T.isInfixOf "views-field-body") tag || isRequirementSection tag
         isRequirementSection tag = tagOpenAttrNameLit "div" "class" (T.isInfixOf "views-field-field-enrolment-requirements") tag || tagOpenAttrNameLit "div" "class" (T.isInfixOf "views-field-field-completion-requirements") tag
+
 
 -- | Parse a Post value from its title.
 -- Titles are usually of the form "Actuarial Science Major (Science Program)".

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -55,11 +55,30 @@ postInfoParser = do
         ]
     code <- postCodeParser P.<|> return T.empty
 
-    return $ Post (getPostType code) (T.pack deptName) code T.empty T.empty
+    let deptNameText = T.pack deptName
+        postType = getPostType code deptNameText
+
+    return $ Post postType deptNameText code T.empty T.empty
+
+-- | Extracts the post type (eg. major) from a post code if it is non-empty,
+-- | or from a dept name otherwise
+getPostType :: T.Text -> T.Text -> PostType
+getPostType "" deptName = getPostTypeFromName deptName
+getPostType code _ = getPostTypeFromCode code
+
+-- | Extracts the post type (eg. major) from a post name (eg. "Biology Specialist")
+getPostTypeFromName :: T.Text -> PostType
+getPostTypeFromName deptName
+    | T.isInfixOf "Specialist" deptName = Specialist
+    | T.isInfixOf "Major" deptName = Major
+    | T.isInfixOf "Minor" deptName = Minor
+    | T.isInfixOf "Focus" deptName = Focus
+    | T.isInfixOf "Certificate" deptName = Certificate
+    | otherwise = Other
 
 -- | Extracts the post type (eg. major) from a post code (eg. ASMAJ1689)
-getPostType :: T.Text -> PostType
-getPostType = abbrevToPost . T.take 3 . T.drop 2
+getPostTypeFromCode :: T.Text -> PostType
+getPostTypeFromCode = abbrevToPost . T.take 3 . T.drop 2
 
 -- | Maps the post type abbreviations to their corresponding PostType
 abbrevToPost :: T.Text -> PostType

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -68,7 +68,7 @@ postTypeParser = P.try postNameParser P.<|> P.between (P.char '(') (P.char ')') 
 postNameParser :: Parser PostType
 postNameParser = do
     _ <- P.spaces
-    postTypeName <- P.choice $ map (P.try . text) [
+    postTypeName <- P.choice $ map (P.try . text . T.pack) [
         "Specialist",
         "Major",
         "Minor",

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -67,8 +67,7 @@ degreeType :: Parser String
 degreeType = Parsec.between Parsec.spaces Parsec.spaces $ Parsec.choice $ map caseInsensitiveStr [
     "major",
     "minor",
-    "specialist",
-    "certificate"
+    "specialist"
     ]
 
 programSuffix :: Parser String

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -67,7 +67,8 @@ degreeType :: Parser String
 degreeType = Parsec.between Parsec.spaces Parsec.spaces $ Parsec.choice $ map caseInsensitiveStr [
     "major",
     "minor",
-    "specialist"
+    "specialist",
+    "certificate"
     ]
 
 programSuffix :: Parser String

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -51,6 +51,9 @@ test-suite RequirementTests
     test-framework-quickcheck2,
     text,
     unordered-containers
+  default-extensions:
+    OverloadedStrings,
+    ScopedTypeVariables
   default-language: Haskell2010
   ghc-options: -Wall -fwarn-tabs
   hs-source-dirs: app

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -23,22 +23,34 @@ custom-setup
 test-suite RequirementTests
   main-is: RequirementTests/tests.hs
   other-modules:
+    Database.DataType,
     Database.Requirement,
-    RequirementTests.ParserTests,
+    Database.Tables,
+    RequirementTests.PostParserTests,
+    RequirementTests.ReqParserTests,
     RequirementTests.ModifierTests,
+    WebParsing.ParsecCombinators,
+    WebParsing.PostParser,
     WebParsing.ReqParser,
     DynamicGraphs.GraphNodeUtils
   Type: exitcode-stdio-1.0
   build-depends:
+    aeson,
     base >=4.14,
     Cabal >= 1.16.0,
     HUnit,
     mtl,
     parsec,
+    persistent,
+    persistent-sqlite,
     QuickCheck,
+    split,
+    tagsoup,
     test-framework,
     test-framework-hunit,
-    test-framework-quickcheck2
+    test-framework-quickcheck2,
+    text,
+    unordered-containers
   default-language: Haskell2010
   ghc-options: -Wall -fwarn-tabs
   hs-source-dirs: app


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
The code and description of post aren't being stored in the database. We want to update their parser and write them in the database.

## Your Changes
- Updated `postInfoParser` to parse the post code, name, and department
- Stored the code and raw requirement description into the database

**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Created `app/RequirementTests/PostParserTests.hs` and added it to `app/RequirementTests/tests.hs`
- Renamed `app/RequirementTests/ParserTests.hs` to `app/RequirementTests/ReqParserTests.hs`
- Manually inspected every input-output pair after running `stack run database`
- Ensured `stack run database` puts as many rows into the database as the number of posts on art&sci's list of posts

## Questions and Comments (if applicable)
- `app/WebParsing/PostParser.hs` imports the `trim` helper function from `app/WebParsing/ReqParser.hs`. Would it be better if I moved the `trim` function (and perhaps other helper functions) to a `app/WebParsing/ParserUtils.hs` and imported it in both files?
- Should I revert d56dbaa for readability now that we have the `OverloadedString` extension, or keep it for more accurate types?
- For the following cases:

Index | Input | Ideal output
:-:|:-|:-
1 | "CS Major: A" | "CS: A"
2 | "CS (Major: A)" | "CS (A)"
3 | "CS (Major) A" | "CS A"

(1) suggests `postTypeParser` shouldn't parse the `:`. (2) suggests the parser needs to parse `:` when it is inside of `()`. To know whether it is inside of `()`, the parsing for `()` needs to be in `postTypeParser`. But putting it in `postTypeParser` means `()` is not parsed by `postNameParser`, so the output won't contain the `()`. If we try to parse it from `postNameParser` and pass a boolean of whether the last character is `(` into `postTypeParser`, then we will need to drop the `(` from `postNameParser` when concatenating the outputs together depending on whether it is case (2) or (3), and there is no way of knowing that from `postNameParser`. My final approach was to always parse the `:` following the post type, so the output of (1) would be "CS A".

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->