### PR TITLE
Resolve type errors between Text and String

### DIFF
--- a/app/WebParsing/ParsecCombinators.hs
+++ b/app/WebParsing/ParsecCombinators.hs
@@ -15,7 +15,7 @@ getCourseFromTag courseTag =
     in
         case course of
             Right courseName -> courseName
-            Left _ -> ""
+            Left _ -> T.pack ""
 
 findCourseFromTag :: Parser T.Text
 findCourseFromTag = do

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -42,7 +42,6 @@ addPostToDatabase programElements = do
         isRequirementSection tag = tagOpenAttrNameLit (T.pack "div") (T.pack "class") (T.isInfixOf $ T.pack "views-field-field-enrolment-requirements") tag || tagOpenAttrNameLit (T.pack "div") (T.pack "class") (T.isInfixOf $ T.pack "views-field-field-completion-requirements") tag
 
 
-
 -- | Parse a Post value from its title.
 -- Titles are usually of the form "Actuarial Science Major (Science Program)".
 postInfoParser :: Parser Post


### PR DESCRIPTION
## Motivation and Context
There are some places in the code where the function is expecting `Text` but receiving `String`, and places where type definitions are not allowed. These errors are somehow not thrown by ghc when compiling the main executable and so the current code on master compiles fine. However, #1289 adds test cases to the post parser, which requires `app/WebParsing/PostParser.hs` and all its dependencies with errors to be added to the test suite in `courseography.cabal`. These errors show up when running `stack test`.

## Your Changes
- (Un)packed `String`/`Text` to `Text`/`String` where needed
- Added `{-# LANGUAGE ScopedTypeVariables #-}` in `app/WebParsing/PostParser.hs` to allow type signatures in do blocks

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Ran `stack test` and ensured everything still worked.
- Applied the changes to #1289 locally and ran `stack test` to ensure every error was fixed, and every test passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->