### PR TITLE
Use focus data

### DIFF
--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -9,6 +9,7 @@ and serve the information back to the client.
 
 module Database.CourseQueries
     (retrieveCourse,
+     retrievePost,
      returnCourse,
      allCourses,
      prereqsForCourse,
@@ -68,6 +69,26 @@ queryCourse :: T.Text -> IO Response
 queryCourse str = do
     courseJSON <- returnCourse str
     return $ createJSONResponse courseJSON
+
+-- | Takes a post code (eg. "ASFOC1689A") and sends a JSON representation
+-- | of the post as a response.
+retrievePost :: T.Text -> ServerPart Response
+retrievePost = liftIO . queryPost
+
+-- | Queries the database for information about the post
+-- | then returns a JSON representation of the post
+queryPost :: T.Text -> IO Response
+queryPost postText = do
+    postJSON <- returnPost postText
+    return $ createJSONResponse postJSON
+
+-- | Queries the database for information about the post then returns a Post value
+returnPost :: T.Text -> IO (Maybe Post)
+returnPost str = runSqlite databasePath $ do
+    sqlPost :: (Maybe (Entity Post)) <- selectFirst [PostCode <-. [str]] []
+    case sqlPost of
+      Nothing -> return Nothing
+      Just post -> return $ Just $ entityVal post
 
 -- | Queries the database for all information regarding a specific meeting for
 --  a @course@, returns a Meeting.

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -132,7 +132,7 @@ Post
     --UniquePostCode code
     --Primary code
     description T.Text
-    deriving Show
+    deriving Show Eq Generic
 
 PostCategory
     post PostId
@@ -206,6 +206,7 @@ data Course =
            } deriving (Show, Generic)
 
 instance ToJSON Course
+instance ToJSON Post
 instance ToJSON Time
 instance ToJSON MeetTime'
 instance ToJSON Building

--- a/app/Routes.hs
+++ b/app/Routes.hs
@@ -6,7 +6,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.Text.Lazy (Text)
 import Database.CourseInsertion (saveGraphJSON)
 import Database.CourseQueries (allCourses, courseInfo, deptList, getGraphJSON, queryGraphs,
-                               retrieveCourse)
+                               retrieveCourse, retrievePost)
 import DynamicGraphs.WriteRunDot (findAndSavePrereqsResponse)
 import Happstack.Server hiding (host)
 import Response
@@ -27,7 +27,8 @@ strictRoutes aboutContents privacyContents = [
     ("image", look "JsonLocalStorageObj" >>= graphImageResponse),
     ("timetable-image", lookText' "session" >>= \session -> look "courses" >>= exportTimetableImageResponse session),
     ("timetable-pdf", look "courses" >>= \courses -> look "JsonLocalStorageObj" >>= exportTimetablePDFResponse courses),
-    ("post", postResponse),
+    ("post", lookText' "code" >>= retrievePost),
+    ("post-progress", postResponse),
     ("draw", drawResponse),
     ("about", aboutResponse aboutContents),
     ("privacy", privacyResponse privacyContents),


### PR DESCRIPTION
## Motivation and Context
> currently, the CS focus data is all hard-coded in the front-end JS files. But, we're also parsing the focus data from the academic calendar and storing it as a "program" in the database. So, it would be good to change the front-end to look up the focus information from the server when the FocusModal is opened

## Your Changes


**Type of change** (select all that apply):
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing

## Questions and Comments (if applicable)


## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->