### PR TITLE
No filter recommended courses section

### DIFF
--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -112,7 +112,8 @@ reqHtmlToLines tags =
         isSectionSplit :: Tag T.Text -> Bool
         isSectionSplit tag =
             isTagText tag &&
-            any (flip T.isInfixOf $ fromTagText tag) ["First", "Second", "Third", "Higher", "Notes", "NOTES"]
+            any (flip T.isInfixOf $ fromTagText tag)
+                ["First", "Second", "Third", "Higher", "Recommended Courses:", "Notes", "NOTES"]
 
         isNoteSection :: [Tag T.Text] -> Bool
         isNoteSection (sectionTitleTag:_) =


### PR DESCRIPTION
## Motivation and Context
When parsing the required/related/recommended courses of a post, the current implementation deliberately filters out the "Notes" section of the requirement. For the requirement for Focus in Theory of Computation (ASFOC1689I), the "Recommended Courses" section comes after the "Notes" section, so it is being put in the same section as "Notes", which makes it filtered out by the parser.

We want to split the courses on "Recommended Courses:" in addition to "Notes" so that they are put into different sections.

## Your Changes
Added "Recommended Courses:" to the list of texts to split on

**Type of change** (select all that apply):
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Ran `stack run database` and ensured the data now has the "Recommended Courses:" part

(Left side is the fixed results; Right side is the old results)
![image](https://user-images.githubusercontent.com/38874004/183330789-3b8312b5-dbf3-4e52-9d78-9781500b577a.png)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->