### PR TITLE
feat: store post html instead of text

### DIFF
--- a/app/RequirementTests/PreProcessingTests.hs
+++ b/app/RequirementTests/PreProcessingTests.hs
@@ -1,5 +1,5 @@
 {-|
-Description: Test some pre-processing functions for requirement parsing and database data.
+Description: Test some pre-processing functions that clean up the text before running the parsers
 
 -}
 
@@ -11,8 +11,7 @@ import Test.HUnit (Test (..), assertEqual)
 import Text.HTML.TagSoup (Tag (..))
 import WebParsing.PostParser (pruneHtml)
 
--- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Eq b, Show a, Show b) => (a -> b) -> String -> [(a, b)] -> Test
+createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(a, b)] -> Test
 createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
                                 TestCase $ assertEqual ("for (" ++ show y ++ ")")
                                 y (function x)) input

--- a/app/RequirementTests/PreProcessingTests.hs
+++ b/app/RequirementTests/PreProcessingTests.hs
@@ -1,0 +1,42 @@
+{-|
+Description: Test some pre-processing functions for requirement parsing and database data.
+
+-}
+
+module RequirementTests.PreProcessingTests
+( preProcTestSuite ) where
+
+import Data.Text as T hiding (map)
+import Test.HUnit (Test (..), assertEqual)
+import Text.HTML.TagSoup (Tag (..))
+import WebParsing.PostParser (pruneHtml)
+
+-- Function to facilitate test case creation given a string, Req tuple
+createTest :: (Eq a, Eq b, Show a, Show b) => (a -> b) -> String -> [(a, b)] -> Test
+createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
+                                TestCase $ assertEqual ("for (" ++ show y ++ ")")
+                                y (function x)) input
+
+
+pruneHtmlInputs :: [([Tag T.Text], [Tag T.Text])]
+pruneHtmlInputs = [
+    ( [TagOpen "h1" [("class", "c1 c2")], TagText "reqs", TagClose "h1"]
+    , [TagOpen "h1" [], TagText"reqs", TagClose "h1"]
+    ),
+    ( [TagOpen "h2" [("style", "some: styles")], TagText "reqs", TagClose "h2"]
+    , [TagOpen "h2" [("style", "some: styles")], TagText "reqs", TagClose "h2"]
+    ),
+    ( [TagOpen "h3" [("class", "c1 c2"), ("style", "some: styles")], TagText "reqs", TagClose "h3"]
+    , [TagOpen "h3" [("style", "some: styles")], TagText "reqs", TagClose "h3"]
+    ),
+    ( [TagOpen "h4" [], TagOpen "a" [("href", "/CSC401H1")], TagText "CSC401H1", TagClose "a", TagClose "h4"]
+    , [TagOpen "h4" [], TagText "CSC401H1", TagClose "h4"]
+    )
+    ]
+
+pruneHtmlTests :: Test
+pruneHtmlTests = createTest pruneHtml "filtering out html attributes" pruneHtmlInputs
+
+-- functions for running tests in REPL
+preProcTestSuite :: Test
+preProcTestSuite = TestLabel "Pre-processing tests" $ TestList [pruneHtmlTests]

--- a/app/RequirementTests/tests.hs
+++ b/app/RequirementTests/tests.hs
@@ -11,13 +11,14 @@ module Main
 import Control.Monad
 import RequirementTests.ModifierTests (modifierTestSuite)
 import RequirementTests.PostParserTests (postTestSuite)
+import RequirementTests.PreProcessingTests (preProcTestSuite)
 import RequirementTests.ReqParserTests (reqTestSuite)
 import qualified System.Exit as Exit
 import Test.HUnit (Test (..), failures, runTestTT)
 
 -- Single test encompassing all test suites
 tests :: Test
-tests = TestList [reqTestSuite, postTestSuite, modifierTestSuite]
+tests = TestList [reqTestSuite, postTestSuite, preProcTestSuite, modifierTestSuite]
 
 main :: IO ()
 main = do

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -36,8 +36,6 @@ addPostToDatabase programElements = do
 
     case P.parse postInfoParser "POSt information" fullPostName of
         Left _ -> return ()
-        Right post -> do
-            postExists <- insertUnique post { postDescription = descriptionText, postRequirements = renderTags requirementLines }
         Right (department, code) -> do
             postExists <- insertUnique Post {
                 postName = getPostType code department,

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -28,7 +28,7 @@ addPostToDatabase :: [Tag T.Text] -> SqlPersistM ()
 addPostToDatabase programElements = do
     let fullPostName = maybe "" (strip . fromTagText) $ find isTagText programElements
         postDescHtml = partitions isDescriptionSection programElements
-        descriptionText = if null postReqHtml then T.empty else innerText $ head postDescHtml
+        descriptionText = if null postReqHtml then T.empty else renderTags $ head postDescHtml
         postReqHtml = sections isRequirementSection programElements
         requirementLines = if null postReqHtml then [] else pruneHtml $ last postReqHtml
         requirements = concatMap parseRequirement $ reqHtmlToLines requirementLines

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -1,6 +1,7 @@
 module WebParsing.PostParser
     ( addPostToDatabase
     , postInfoParser
+    , pruneHtml
     ) where
 
 import Control.Monad.Trans (liftIO)

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -99,13 +99,13 @@ postCodeParser = do
     variant <- P.many P.letter
     return $ T.pack $ code ++ num ++ variant
 
--- | Prunes all the attributes (eg. "class", "href") in the html except for the style.
+-- | Prunes all the attributes (eg. class, href) in the html except for the style.
 -- | Removes all <a></a> tags
 pruneHtml :: [Tag T.Text] -> [Tag T.Text]
 pruneHtml [] = []
 pruneHtml ((TagOpen "a" _):xs) = pruneHtml xs
 pruneHtml ((TagClose "a"):xs) = pruneHtml xs
-pruneHtml ((TagOpen t attrs):xs) = (TagOpen t [style | style@("style", _) <- attrs]) : pruneHtml xs
+pruneHtml ((TagOpen tag attrs):xs) = (TagOpen tag [style | style@("style", _) <- attrs]) : pruneHtml xs
 pruneHtml (x:xs) = x : pruneHtml xs
 
 -- | Split requirements HTML into individual lines.

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -8,7 +8,7 @@ import Data.Either (fromRight)
 import Data.Functor (void)
 import Data.List (find)
 import Data.List.Split (keepDelimsL, split, splitWhen, whenElt)
-import Data.Text (intercalate, strip)
+import Data.Text (strip)
 import qualified Data.Text as T
 import Database.DataType (PostType (..))
 import Database.Persist (insertUnique)
@@ -28,14 +28,14 @@ addPostToDatabase programElements = do
         postDescHtml = partitions isDescriptionSection programElements
         descriptionText = if null postReqHtml then T.empty else innerText $ head postDescHtml
         postReqHtml = sections isRequirementSection programElements
-        requirementLines = if null postReqHtml then [] else reqHtmlToLines $ last postReqHtml
-        requirements = concatMap parseRequirement requirementLines
+        requirementLines = if null postReqHtml then [] else pruneHtml $ last postReqHtml
+        requirements = concatMap parseRequirement $ reqHtmlToLines requirementLines
     liftIO $ print fullPostName
 
     case P.parse postInfoParser "POSt information" fullPostName of
         Left _ -> return ()
         Right post -> do
-            postExists <- insertUnique post { postDescription = descriptionText, postRequirements = intercalate "\n" $ concat requirementLines }
+            postExists <- insertUnique post { postDescription = descriptionText, postRequirements = renderTags requirementLines }
             case postExists of
                 Just key ->
                     mapM_ (insert_ . PostCategory key) requirements
@@ -97,6 +97,15 @@ postCodeParser = do
     num <- P.count 4 P.digit
     variant <- P.many P.letter
     return $ T.pack $ code ++ num ++ variant
+
+-- | Prunes all the attributes (eg. "class", "href") in the html except for the style.
+-- | Removes all <a></a> tags
+pruneHtml :: [Tag T.Text] -> [Tag T.Text]
+pruneHtml [] = []
+pruneHtml ((TagOpen "a" _):xs) = pruneHtml xs
+pruneHtml ((TagClose "a"):xs) = pruneHtml xs
+pruneHtml ((TagOpen t attrs):xs) = (TagOpen t [style | style@("style", _) <- attrs]) : pruneHtml xs
+pruneHtml (x:xs) = x : pruneHtml xs
 
 -- | Split requirements HTML into individual lines.
 reqHtmlToLines :: [Tag T.Text] -> [[T.Text]]

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -28,6 +28,7 @@ test-suite RequirementTests
     Database.Tables,
     RequirementTests.PostParserTests,
     RequirementTests.ReqParserTests,
+    RequirementTests.PreProcessingTests,
     RequirementTests.ModifierTests,
     WebParsing.ParsecCombinators,
     WebParsing.PostParser,


### PR DESCRIPTION
## Motivation and Context
> the parsing stuff like newlines -> lists [...] may be overfitting to the existing POSt data. A more robust approach in this case would be to modify the post parsing to store the raw HTML of the program info instead of just plaintext, and then embed that raw HTML directly in the modal

## Your Changes
- Added a `pruneHtml` function that removes all the attributes from the html except the "style" attribute. It also trims the `<a>` tags
- Ran `pruneHtml` and `renderTags` (converts tags to html) before putting the data into the database

**Type of change** (select all that apply):
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
- Tested `pruneHtml` when there is
  - an `<a>` tag
  - a style attribute
  - a class attribute
  - a tag with both a class attribute and a style attribute
- Manually inspected some rows in the `post` table of the database after parsing and ensure things were correct
- Applied the changes to #1291 and ensured the modals looked pretty

## Questions and Comments (if applicable)
> Note that the raw text still needs to be extracted for the purpose of parsing requirements, but I think you've created database columns that can store the raw HTML as well.

I did not create a column to store the raw HTML and I could not find one from the current schema. The current schema has a column that stores the post requirements as plain text. I am replacing the data in that column with the pruned HTML. The raw text is still extracted and parsed, but they are no longer in the database (but the parsed data is).

I decided to trim the `<a>` tags because they are all links to the course page on the art&sci calendar, which show the exact same information we have on the graph when the user clicks on the nodes.

The test file looks a little empty to have an entire for it now but I'm thinking it can be used for #1287 too

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
