### PR TITLE
refactor: change return value of postInfoParser

### DIFF
--- a/app/RequirementTests/PostParserTests.hs
+++ b/app/RequirementTests/PostParserTests.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 {-|
 Description: Test Post Parsers using HUnit Testing Framework.
 
@@ -10,63 +8,73 @@ Module containing test cases for Post Parsers.
 module RequirementTests.PostParserTests
 ( postTestSuite ) where
 
+import Data.Bifunctor (second)
 import qualified Data.Text as T
 import Database.DataType (PostType (..))
-import Database.Tables
 import Test.HUnit (Test (..), assertEqual)
 import qualified Text.Parsec as Parsec
-import Text.Parsec.Text (Parser)
-import WebParsing.PostParser (postInfoParser)
+import WebParsing.PostParser (getPostType, postInfoParser)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: Parser Post -> String -> [(T.Text, (T.Text, T.Text, PostType))] -> Test
-createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                TestCase $ assertEqual ("for (" ++ T.unpack x ++ "),")
-                                (Right $ makePost y) (Parsec.parse parser "" x)) input
+createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(a, b)] -> Test
+createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
+                                TestCase $ assertEqual ("for (" ++ show x ++ "),")
+                                y (function x)) input
 
 -- | Input and output pair of each post
 -- | Output is in the order of (postDepartment, postCode, postName)
-postInfoInputs :: [(T.Text, (T.Text, T.Text, PostType))]
+postInfoInputs :: [(T.Text, (T.Text, T.Text))]
 postInfoInputs = [
       ("Music Major (Arts Program) - ASMAJ2276",
-        ("Music Major (Arts Program)", "ASMAJ2276", Major))
+        ("Music Major (Arts Program)", "ASMAJ2276"))
     , ("Focus in Artificial Intelligence (Major) - ASFOC1689K",
-        ("Focus in Artificial Intelligence (Major)", "ASFOC1689K", Focus))
+        ("Focus in Artificial Intelligence (Major)", "ASFOC1689K"))
     , ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell - ASSPE1003A",
-        ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell", "ASSPE1003A", Specialist))
+        ("Cell & Molecular Biology Specialist: Focus in Molecular Networks of the Cell", "ASSPE1003A"))
     , ("Focus in Medical Anthropology (Specialist: Society, Culture and Language) - ASFOC2112B",
-        ("Focus in Medical Anthropology (Specialist: Society, Culture and Language)", "ASFOC2112B", Focus))
+        ("Focus in Medical Anthropology (Specialist: Society, Culture and Language)", "ASFOC2112B"))
     , ("Anthropology Specialist (Society, Culture, and Language) (Arts Program) - ASSPE2112",
-        ("Anthropology Specialist (Society, Culture, and Language) (Arts Program)", "ASSPE2112", Specialist))
+        ("Anthropology Specialist (Society, Culture, and Language) (Arts Program)", "ASSPE2112"))
     , ("Christianity and Culture: Major Program in Religious Education (Arts Program) - ASMAJ1021",
-        ("Christianity and Culture: Major Program in Religious Education (Arts Program)", "ASMAJ1021", Major))
+        ("Christianity and Culture: Major Program in Religious Education (Arts Program)", "ASMAJ1021"))
     , ("Minor in French Language (Arts Program) - ASMIN0120",
-        ("Minor in French Language (Arts Program)", "ASMIN0120", Minor))
+        ("Minor in French Language (Arts Program)", "ASMIN0120"))
     , ("Minor Program in Christianity and Education (Arts Program) - ASMIN1014",
-        ("Minor Program in Christianity and Education (Arts Program)", "ASMIN1014", Minor))
+        ("Minor Program in Christianity and Education (Arts Program)", "ASMIN1014"))
     , ("Psychology Research Specialist - Thesis (Science Program) - ASSPE1958)",
-        ("Psychology Research Specialist - Thesis (Science Program)", "ASSPE1958", Specialist))
+        ("Psychology Research Specialist - Thesis (Science Program)", "ASSPE1958"))
     , ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program) - ASMAJ1445B",
-        ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)", "ASMAJ1445B", Major))
+        ("Cognitive Science Major - Arts (Language and Cognition Stream) (Arts Program)", "ASMAJ1445B"))
     , ("Certificate in Business Fundamentals - ASCER2400",
-        ("Certificate in Business Fundamentals", "ASCER2400", Certificate))
+        ("Certificate in Business Fundamentals", "ASCER2400"))
     , ("Focus in Finance - ASFOC2431B",
-        ("Focus in Finance", "ASFOC2431B", Focus))
+        ("Focus in Finance", "ASFOC2431B"))
     , ("Focus in Green Chemistry",
-        ("Focus in Green Chemistry", "", Focus))
+        ("Focus in Green Chemistry", ""))
     , ("Biological Physics Specialist",
-        ("Biological Physics Specialist", "", Specialist))
+        ("Biological Physics Specialist", ""))
     ]
 
--- | Takes a tuple of (postDepartment, postCode, postName) and makes a Post data
--- | by filling postDescription and postRequirements with empty text
-makePost :: (T.Text, T.Text, PostType) -> Post
-makePost (postDepartment, postCode, postName) =
-    Post { postName, postDepartment, postCode, postDescription = T.empty, postRequirements = T.empty }
+getPostTypeInputs :: [((T.Text, T.Text), PostType)]
+getPostTypeInputs = [
+      (("ASSPE1958", "Psychology Specialist"), Specialist)
+    , (("ASMAJ2276", "Music Major"), Major)
+    , (("ASMIN0120", "Minor in French"), Minor)
+    , (("ASFOC1689B", "Focus in AI"), Focus)
+    , (("ASCER2400", "Certificate in Business"), Certificate)
+    , (("", "Psychology Specialist"), Specialist)
+    , (("", "Music Major"), Major)
+    , (("", "Minor in French"), Minor)
+    , (("", "Focus in AI"), Focus)
+    , (("", "Certificate in Business"), Certificate)
+    ]
 
 postInfoTests :: Test
-postInfoTests = createTest postInfoParser "Post requirements" postInfoInputs
+postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ map (second Right) postInfoInputs
+
+getPostTypeTests :: Test
+getPostTypeTests = createTest (uncurry getPostType) "Post requirements" getPostTypeInputs
 
 -- functions for running tests in REPL
 postTestSuite :: Test
-postTestSuite = TestLabel "PostParser tests" $ TestList [postInfoTests]
+postTestSuite = TestLabel "PostParser tests" $ TestList [postInfoTests, getPostTypeTests]

--- a/app/WebParsing/PostParser.hs
+++ b/app/WebParsing/PostParser.hs
@@ -1,6 +1,7 @@
 module WebParsing.PostParser
     ( addPostToDatabase
     , postInfoParser
+    , getPostType
     ) where
 
 import Control.Monad.Trans (liftIO)
@@ -34,8 +35,14 @@ addPostToDatabase programElements = do
 
     case P.parse postInfoParser "POSt information" fullPostName of
         Left _ -> return ()
-        Right post -> do
-            postExists <- insertUnique post { postDescription = descriptionText, postRequirements = intercalate "\n" $ concat requirementLines }
+        Right (department, code) -> do
+            postExists <- insertUnique Post {
+                postName = getPostType code department,
+                postDepartment = department,
+                postCode = code,
+                postDescription = descriptionText,
+                postRequirements = intercalate "\n" $ concat requirementLines
+                }
             case postExists of
                 Just key ->
                     mapM_ (insert_ . PostCategory key) requirements
@@ -47,7 +54,7 @@ addPostToDatabase programElements = do
 
 -- | Parse a Post value from its title.
 -- Titles are usually of the form "Actuarial Science Major (Science Program)".
-postInfoParser :: Parser Post
+postInfoParser :: Parser (T.Text, T.Text)
 postInfoParser = do
     deptName <- P.manyTill P.anyChar $ P.choice $ map (P.try . P.lookAhead) [
         void postCodeParser,
@@ -55,10 +62,7 @@ postInfoParser = do
         ]
     code <- postCodeParser P.<|> return T.empty
 
-    let deptNameText = T.pack deptName
-        postType = getPostType code deptNameText
-
-    return $ Post postType deptNameText code T.empty T.empty
+    return (T.pack deptName, code)
 
 -- | Extracts the post type (eg. major) from a post code if it is non-empty,
 -- | or from a dept name otherwise


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
`postInfoParser` currently returns a `Post` with only the name, department, and code filled in. The rest are filled with empty values (`T.empty`). When we introduce the created/modified timestamps into `Post`, they will need to be modified too.

Returning the current time in a parser feels wrong. Constructing a dummy UTCTime requires a dummy date and dummy diffTime, which is too much logic in the parser. I think making the parser only return the post info would be cleaner and easier to modify in the future.


## Your Changes
Moved the construction of `Post` outside of `postInfoParser` and construct it in `addPostToDatabase`.

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing
- Modified the existing tests to match the type signature of the new `postInfoParser`
- Added tests for `getPostType` since that function is not run in `postInfoParser` anymore

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->