### PR TITLE
Convert Node from a class based component to a function based component

### DIFF
--- a/js/components/graph/Node.js
+++ b/js/components/graph/Node.js
@@ -76,7 +76,6 @@ export default function Node(props) {
 
   const textXOffset = props.JSON.pos[0] + props.JSON.width / 2
 
-  // TODO: Look at this.props to see what we need to give the g
   return (
     <g
       {...gAttrs}

--- a/js/components/graph/Node.js
+++ b/js/components/graph/Node.js
@@ -23,92 +23,88 @@ import React from "react"
  *  - Hybrid nodes are the smaller, grey nodes on the graph that represent another course node
  *    farther away. They can only be either 'active' or 'inactive'
  */
-export default class Node extends React.Component {
-  getDataTestId = () => {
-    if (this.props.hybrid) {
-      return `h(${this.props.parents.join(",")})`
+export default function Node(props) {
+  const getDataTestId = () => {
+    if (props.hybrid) {
+      return `h(${props.parents.join(",")})`
     }
-    return this.props.JSON.id_
+    return props.JSON.id_
   }
 
-  render() {
-    let ellipse = null
-    const newClassName = this.props.className + " " + this.props.status
-    if (this.props.highlighted) {
-      const attrs = this.props.JSON
-      const width = parseFloat(attrs.width) / 2
-      const height = parseFloat(attrs.height) / 2
-      ellipse = (
-        <ellipse
-          className="spotlight"
-          cx={parseFloat(attrs.pos[0]) + width}
-          cy={parseFloat(attrs.pos[1]) + height}
-          rx={width + 9}
-          ry={height + 8.5}
-        />
-      )
-    }
-
-    const gAttrs = {
-      textRendering: "geometricPrecision",
-      shapeRendering: "geometricPrecision",
-      onKeyDown: this.props.onKeyDown,
-      onWheel: this.props.onWheel,
-      onMouseEnter: this.props.onMouseEnter,
-      onMouseLeave: this.props.onMouseLeave,
-      onClick: this.props.onClick,
-    }
-
-    const rectAttrs = {
-      height: this.props.JSON.height,
-      width: this.props.JSON.width,
-      x: this.props.JSON.pos[0],
-      y: this.props.JSON.pos[1],
-    }
-
-    if (this.props.className === "node") {
-      rectAttrs["rx"] = "8"
-      rectAttrs["ry"] = "8"
-    }
-
-    const rectStyle = {
-      fill: this.props.JSON.fill,
-    }
-
-    const textXOffset = this.props.JSON.pos[0] + this.props.JSON.width / 2
-
-    // TODO: Look at this.props to see what we need to give the g
-    return (
-      <g
-        {...gAttrs}
-        id={this.props.JSON.id_}
-        className={newClassName}
-        data-testid={this.getDataTestId()}
-      >
-        {ellipse}
-        <rect
-          {...rectAttrs}
-          style={rectStyle}
-          filter={
-            this.props.className === "hybrid"
-              ? ""
-              : `url(#${this.props.nodeDropshadowFilter})`
-          }
-        />
-        {this.props.JSON.text.map(function (textTag, i) {
-          const textAttrs = {
-            x: textXOffset,
-            y: textTag.pos[1],
-          }
-          return (
-            <text {...textAttrs} key={i}>
-              {textTag.text}
-            </text>
-          )
-        })}
-      </g>
+  let ellipse = null
+  const newClassName = props.className + " " + props.status
+  if (props.highlighted) {
+    const attrs = props.JSON
+    const width = parseFloat(attrs.width) / 2
+    const height = parseFloat(attrs.height) / 2
+    ellipse = (
+      <ellipse
+        className="spotlight"
+        cx={parseFloat(attrs.pos[0]) + width}
+        cy={parseFloat(attrs.pos[1]) + height}
+        rx={width + 9}
+        ry={height + 8.5}
+      />
     )
   }
+
+  const gAttrs = {
+    textRendering: "geometricPrecision",
+    shapeRendering: "geometricPrecision",
+    onKeyDown: props.onKeyDown,
+    onWheel: props.onWheel,
+    onMouseEnter: props.onMouseEnter,
+    onMouseLeave: props.onMouseLeave,
+    onClick: props.onClick,
+  }
+
+  const rectAttrs = {
+    height: props.JSON.height,
+    width: props.JSON.width,
+    x: props.JSON.pos[0],
+    y: props.JSON.pos[1],
+  }
+
+  if (props.className === "node") {
+    rectAttrs["rx"] = "8"
+    rectAttrs["ry"] = "8"
+  }
+
+  const rectStyle = {
+    fill: props.JSON.fill,
+  }
+
+  const textXOffset = props.JSON.pos[0] + props.JSON.width / 2
+
+  // TODO: Look at this.props to see what we need to give the g
+  return (
+    <g
+      {...gAttrs}
+      id={props.JSON.id_}
+      className={newClassName}
+      data-testid={getDataTestId()}
+    >
+      {ellipse}
+      <rect
+        {...rectAttrs}
+        style={rectStyle}
+        filter={
+          props.className === "hybrid" ? "" : `url(#${props.nodeDropshadowFilter})`
+        }
+      />
+      {props.JSON.text.map(function (textTag, i) {
+        const textAttrs = {
+          x: textXOffset,
+          y: textTag.pos[1],
+        }
+        return (
+          <text {...textAttrs} key={i}>
+            {textTag.text}
+          </text>
+        )
+      })}
+    </g>
+  )
 }
 
 Node.propTypes = {


### PR DESCRIPTION
## Motivation and Context

By converting Node from a class component to a functional component, Courseography can have more concise, cleaner, and less complex code.

## Your Changes

**Description**:  Node was a class-based component for the React graph. I converted Node into a function-based component.

- I redefined Node as a function.
- I passed props as an argument to Node (I did not use destructuring syntax and pass individual props because I felt that
passing the whole object props itself would better support changes to the code. i.e., If you add another property later on).
- I removed Node's render method.
- I removed references to 'this.'

**Type of change** (select all that apply):

- [X] Refactoring (internal change to codebase, without changing functionality)

## Testing

The Node.test.js file contained tests to ensure that the class-based component, Node, ran correctly. After converting Node into a functional component, I ran all the tests in Node.test.js again, and they passed. Thus, I could see that even as a functional component, Node did not change in its behavior.

## Questions and Comments (if applicable)

- Line 79 has the following statement **"TODO: Look at this.props to see what we need to give the g."** 
- Currently, we pass the following properties to g; gAttrs specifies textRendering, shapeRendering, onKeyDown, onWheel, onMouseEnter, onMouseLeave, and onClick. Additionally, we specify id, className, and data-testid. 
-  However, Node also includes properties like editMode, **highlighted**, hybrid, JSON, status, parents, and nodeDropshadowFilter. **Given that passing in a property to g implies that <ellipse>, <rect>, and <text> will also inherit those properties, should we pass this.highlighted to g?** (i.e., This property would ensure that if <ellipse> is highlighted, <rect> and <text> will also be highlighted. In other words, all the elements are highlighted or none at all). 

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
