### PR TITLE
Clear timeouts 

### DIFF
--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -105,6 +105,8 @@ export class Graph extends React.Component {
   }
 
   componentWillUnmount() {
+    this.state.infoboxTimeouts.forEach(timeout => clearTimeout(timeout))
+    this.state.dropdownTimeouts.forEach(timeout => clearTimeout(timeout))
     document.body.removeEventListener("keydown", this.onKeyDown)
   }
 


### PR DESCRIPTION
## Motivation and Context

We need to clear timeouts in the componentWillUnmount method to fix memory leaks. It should resolve this error: "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method."

## Your Changes

**Description**: I used clearTimeout() to clear all the timeouts in the state.

**Type of change** (select all that apply):

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

- I ran all the tests in Graph.test.js.
- I verified that the console no longer returns the following error message: "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method."   

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->

