### PR TITLE
Replacing timeouts

### DIFF
--- a/js/components/graph/__tests__/GraphDropdown.test.js
+++ b/js/components/graph/__tests__/GraphDropdown.test.js
@@ -16,6 +16,7 @@ describe("GraphDropdown", () => {
     const component = shallow(<GraphDropdown {...graphDropdownProps} />)
     expect(component).toMatchSnapshot()
   })
+
   it("should appear when hovering over the graph tab and be hidden before", async () => {
     const mouseEnter = new MouseEvent("mouseenter", {
       bubbles: false,
@@ -46,7 +47,7 @@ describe("GraphDropdown", () => {
     await waitFor(() => {
       expect(graphDropdown.classList.contains("hidden")).toBe(true)
     })
-  })
+  }, 5000)
 
   it("should disappear a second after the cursor isn't hovered on the graph tab", async () => {
     const mouseEnter = new MouseEvent("mouseenter", {
@@ -69,5 +70,5 @@ describe("GraphDropdown", () => {
     await waitFor(() => {
       expect(graphDropdown.classList.contains("hidden")).toBe(true)
     })
-  })
+  }, 5000)
 })

--- a/js/components/graph/__tests__/GraphDropdown.test.js
+++ b/js/components/graph/__tests__/GraphDropdown.test.js
@@ -2,11 +2,7 @@ import React from "react"
 import TestContainer from "./TestContainer"
 import GraphDropdown from "../GraphDropdown"
 import { shallow } from "enzyme"
-import { fireEvent } from "@testing-library/react"
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
+import { fireEvent, waitFor } from "@testing-library/react"
 
 describe("GraphDropdown", () => {
   it("should match shallow snapshot", () => {
@@ -47,9 +43,10 @@ describe("GraphDropdown", () => {
     expect(graphDropdown.classList.contains("graph-dropdown-display")).toBe(true)
 
     fireEvent.mouseOut(graphDropdown)
-    await sleep(600)
-    expect(graphDropdown.classList.contains("hidden")).toBe(true)
-  }, 5000)
+    await waitFor(() => {
+      expect(graphDropdown.classList.contains("hidden")).toBe(true)
+    })
+  })
 
   it("should disappear a second after the cursor isn't hovered on the graph tab", async () => {
     const mouseEnter = new MouseEvent("mouseenter", {
@@ -69,7 +66,8 @@ describe("GraphDropdown", () => {
     expect(graphDropdown.classList.contains("graph-dropdown-display")).toBe(true)
 
     fireEvent(graphNav, mouseLeave)
-    await sleep(600)
-    expect(graphDropdown.classList.contains("hidden")).toBe(true)
-  }, 5000)
+    await waitFor(() => {
+      expect(graphDropdown.classList.contains("hidden")).toBe(true)
+    })
+  })
 })

--- a/js/components/graph/__tests__/InfoBox.test.js
+++ b/js/components/graph/__tests__/InfoBox.test.js
@@ -2,7 +2,7 @@ import React from "react"
 import { shallow } from "enzyme"
 import InfoBox from "../InfoBox"
 import TestGraph from "./TestGraph"
-import { fireEvent } from "@testing-library/react"
+import { fireEvent, waitFor } from "@testing-library/react"
 
 describe("InfoBox", () => {
   it("should match shallow snapshot", () => {
@@ -39,9 +39,9 @@ describe("InfoBox", () => {
 
     fireEvent.mouseOut(aaa100)
 
-    setTimeout(() => {
+    await waitFor(() => {
       expect(infoBox.classList.contains("tooltip-group-hidden")).toBe(true)
-    }, 1000)
+    })
   }, 5000)
 
   it("Pressing on the info box should create a new pop up", async () => {
@@ -51,10 +51,8 @@ describe("InfoBox", () => {
     const infoBox = graph.getNodeByText("Info")
     fireEvent.click(infoBox)
 
-    // wait for fake fetch to finish
-    setTimeout(() => {
-      // expect description in the modal box to appear
+    await waitFor(() => {
       expect(graph.textExists(/AAA Thinking/)).toBe(true)
-    }, 1000)
+    })
   })
 })


### PR DESCRIPTION
## Motivation and Context

It is good practice to avoid setTimeout() in testing, because it introduces an arbitrary delay which can cause flaky tests.

## Your Changes

**Description**:

- I replaced instances of setTimeout() with waitFor() in GraphDropdown.test.js and InfoBox.test.js

**Type of change** (select all that apply):

- [X] Test update (change that modifies or updates tests only)

## Testing

- I ran `$ yarn run test -- GraphDropdown.test.js` and `$ yarn run test -- InfoBox.test.js` to ensure that all the tests still pass.

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have verified that the CircleCI tests have passed. <!-- (check after opening pull request) -->
