### PR TITLE
Update to lts-21.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-19
+      - image: fpco/stack-build:lts-21
     steps:
       - checkout
 
@@ -14,15 +14,14 @@ jobs:
 
       - run:
           name: Install Package Dependencies
-          # See https://github.com/NVIDIA/nvidia-docker/issues/1632
           command: |
-            wget -qO - https://packages.confluent.io/deb/5.2/archive.key | sudo apt-key add -
-            sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
             sudo apt-get update
             sudo apt-get install -y imagemagick texlive-latex-base
+            sudo dpkg --remove --force-remove-reinstreq nodejs
             stack update
 
-            curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - &&\
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - &&\
+            sudo dpkg --remove --force-remove-reinstreq libnode72:amd64
             sudo apt-get install -y nodejs
 
             corepack enable

--- a/app/Database/Tables.hs
+++ b/app/Database/Tables.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds, DeriveGeneric, DerivingStrategies, EmptyDataDecls, FlexibleContexts,
              FlexibleInstances, GADTs, GeneralizedNewtypeDeriving, MultiParamTypeClasses,
-             QuasiQuotes, StandaloneDeriving, TemplateHaskell, TypeFamilies,
+             QuasiQuotes, StandaloneDeriving, TemplateHaskell, TypeFamilies, TypeOperators,
              UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
@@ -19,9 +19,9 @@ straightforward.
 
 module Database.Tables where
 
-import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), genericToJSON, withObject,
-                    (.!=), (.:?), (.:))
-import Data.Aeson.Types (Options (..), Parser, Value(Object), Value, defaultOptions)
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), genericToJSON, withObject, (.!=), (.:),
+                   (.:?))
+import Data.Aeson.Types (Options (..), Parser, Value (Object), defaultOptions)
 import Data.Char (toLower)
 import qualified Data.Text as T
 import Data.Time.Clock (UTCTime)

--- a/app/Export/ImageConversion.hs
+++ b/app/Export/ImageConversion.hs
@@ -3,13 +3,10 @@
     Description : Includes functions for converting SVG files to PNG.
 -}
 module Export.ImageConversion
-    (createImageFile, removeFile) where
+    (createImageFile) where
 
-import Data.List.Split (splitOn)
-import Filesystem.Path.CurrentOS as Path
 import GHC.IO.Handle.Types
 import System.Process (ProcessHandle, createProcess, shell, waitForProcess)
-import Turtle.Prelude (rm)
 
 -- | Opens a new process to convert an SVG (inName) to a PNG (outName)
 -- Note: hGetContents can be used to read Handles. Useful when trying to read from
@@ -30,7 +27,3 @@ convertToImage :: String -> String -> IO
                       ProcessHandle)
 convertToImage inName outName =
     createProcess $ shell $ "convert " ++ inName ++ " " ++ outName
-
--- | Removes a file.
-removeFile :: String -> IO ()
-removeFile name = mapM_ (rm . Path.decodeString) (splitOn " " name)

--- a/app/Export/PdfGenerator.hs
+++ b/app/Export/PdfGenerator.hs
@@ -6,8 +6,8 @@ module Export.PdfGenerator
     (createPDF) where
 
 import Data.List.Utils (replace)
-import Export.ImageConversion (removeFile)
 import GHC.IO.Handle.Types
+import System.Directory (removeFile)
 import System.Process (ProcessHandle, createProcess, shell, waitForProcess)
 
 -- | Opens a new process to create a PDF from a TEX (texName) and deletes
@@ -19,7 +19,7 @@ createPDF texName  = do
   _ <- waitForProcess pid
   let auxFile = replace ".tex" ".aux" texName
       logFile = replace ".tex" ".log" texName
-  _ <- removeFile (auxFile ++ " " ++ logFile ++ " " ++ texName)
+  mapM_ removeFile [auxFile, logFile, texName]
   putStrLn "Process Complete"
 
 -- | Create a process to use the pdflatex program to create a PDF from a TEX

--- a/app/Response/Export.hs
+++ b/app/Response/Export.hs
@@ -7,11 +7,11 @@ import Data.ByteString.Base64.Lazy as BEnc
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Text as T
 import Export.GetImages
-import Export.ImageConversion (removeFile)
 import Export.LatexGenerator
 import Export.PdfGenerator
 import Happstack.Server
 import Response.Image (returnImageData)
+import System.Directory (removeFile)
 
 -- | Returns an image of the timetable requested by the user.
 exportTimetableImageResponse :: T.Text -> String -> ServerPart Response
@@ -44,5 +44,5 @@ returnPDF graphSvg graphImg fallTimetableSvg fallTimetableImg springTimetableSvg
         pdfName = rand ++ ".pdf"
     generateTex [graphImg, fallTimetableImg, springTimetableImg] texName -- generate a temporary TEX file
     createPDF texName                            -- create PDF using TEX and delete the TEX file afterwards
-    _ <- removeFile (graphSvg ++ " " ++ graphImg ++ " " ++ fallTimetableSvg ++ " " ++ fallTimetableImg ++ " " ++ springTimetableSvg ++ " " ++ springTimetableImg)
+    mapM_ removeFile [graphSvg, graphImg, fallTimetableSvg, fallTimetableImg, springTimetableSvg, springTimetableImg]
     return pdfName

--- a/app/Response/Image.hs
+++ b/app/Response/Image.hs
@@ -6,8 +6,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as BEnc
 import qualified Data.Text as T
 import Export.GetImages (getActiveGraphImage, getTimetableImage)
-import Export.ImageConversion
 import Happstack.Server
+import System.Directory (removeFile)
 
 -- | Returns an image of the graph requested by the user, given graphInfo stored in local storage.
 graphImageResponse :: String -> ServerPart Response

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -173,9 +173,7 @@ executable courseography
     old-locale,
     time,
     parsec,
-    HaTeX,
-    HUnit,
-    turtle
+    HaTeX
   default-language: Haskell2010
   ghc-options: -Wall -fwarn-tabs
   hs-source-dirs: app

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ allow-newer: true
 extra-deps:
   - stylish-haskell-0.13.0.0
 compiler-check: newer-minor
-resolver: lts-20.4
+resolver: lts-21.6
 dump-logs: all
 require-stack-version: ! ">= 1.6"
 ghc-options:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: stylish-haskell-0.13.0.0
 snapshots:
 - completed:
-    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
-    size: 648660
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
-  original: lts-20.4
+    sha256: 2e7d4a730d8eb5373b2d383fac84efcf7c81e3b7a5fce71b4c2e19a1768f25a6
+    size: 640239
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/6.yaml
+  original: lts-21.6


### PR DESCRIPTION
This updates to [lts-21.6](https://www.stackage.org/lts-21.6), and in particular to GHC 9.4.5.