### PR TITLE
Fix a bug for toggling courses and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug that causes FCE count to increase when toggling course via sidebar
+
 ### 🔧 Internal changes
 
 - Started a changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix bug that causes FCE count to increase when toggling course via sidebar
+- Fixed bug that causes FCE count to increase when toggling course via sidebar
 
 ### 🔧 Internal changes
 

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -479,7 +479,7 @@ export class Graph extends React.Component {
     const courseLabelArray = this.state.nodesJSON[id].text
     const courseLabel = courseLabelArray[courseLabelArray.length - 1].text
     const temp = [...this.state.selectedNodes]
-    if (this.state.nodesStatus[id].isSelected) {
+    if (this.state.nodesStatus[id].selected) {
       this.setState({
         selectedNodes: new Set(temp.filter(course => course !== courseLabel)),
       })

--- a/js/components/graph/__tests__/Sidebar.test.js
+++ b/js/components/graph/__tests__/Sidebar.test.js
@@ -34,7 +34,7 @@ describe("Sidebar", () => {
     expect(container.getByText("FCE Count: 0.5")).toBeDefined()
   })
 
-  it("Click the course code on the sidebar should decrease the FCE count", async () => {
+  it("Clicking the course code on the sidebar should decrease the FCE count", async () => {
     const container = await TestContainer.build()
     expect(container.getByText("FCE Count: 0.0")).toBeDefined()
     fireEvent.click(container.getByTestId("aaa100"))

--- a/js/components/graph/__tests__/Sidebar.test.js
+++ b/js/components/graph/__tests__/Sidebar.test.js
@@ -34,6 +34,17 @@ describe("Sidebar", () => {
     expect(container.getByText("FCE Count: 0.5")).toBeDefined()
   })
 
+  it("Click the course code on the sidebar should decrease the FCE count", async () => {
+    const container = await TestContainer.build()
+    expect(container.getByText("FCE Count: 0.0")).toBeDefined()
+    fireEvent.click(container.getByTestId("aaa100"))
+    expect(container.getByText("FCE Count: 0.5")).toBeDefined()
+    const sidebar = await TestSidebar.build()
+    expect(sidebar.getByTestId("test AAA100")).toBeDefined()
+    fireEvent.click(sidebar.getByTestId("test AAA100"))
+    expect(container.getByText("FCE Count: 0.0")).toBeDefined()
+  })
+
   it("Clicking a graph button adds and removes the course to the Selected Courses", async () => {
     const container = await TestContainer.build()
     fireEvent.click(container.getByTestId("aaa100"))


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

In the current version of Courseography, users are able to click on nodes in a course graph to map out prerequisites and plan their future courses. The user can see the list of courses they toggled in the sidebar, with the total amount of FCE at the top. Unfortunately, when you click on a course code in the sidebar to toggle a course off, it actually increases the FCE count by 0.5 and doesn't remove the course from the list of selected courses. 

This pull request fixes this issue by fixing one line in the `handleCourseClick` function in the `Graph` component. The issue was the that the previous code was accessing a field of an object that didn't exist, so I changed it to the appropriate field. I also added an additional test case within the `Sidebar.test.js` file that fails on the old version of the code and succeeds on the new version. The test simulates toggling a course on then toggling it off via the sidebar.
...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |  X        |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
