### PR TITLE
Graph Generation - Handle Bard Courses Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### ✨ New features/enhancements
 
+- For Generate, when no valid courses are inputted a message is shown and nothing is displayed on the graph.
+
 ### 🐛 Bug fixes
 
 - Fixed bug that causes FCE count to increase when toggling course via sidebar

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -18,7 +18,8 @@ module Database.CourseQueries
      getMeetingTime,
      buildTime,
      queryCourse,
-     getDeptCourses
+     getDeptCourses,
+     getAllCourseCodes
      ) where
 
 import Config (databasePath)
@@ -26,7 +27,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson (object, toJSON, (.=))
 import Data.List (partition)
 import Data.Maybe (fromJust, fromMaybe)
-import qualified Data.Text as T (Text, append, tail, isPrefixOf, toUpper, filter, snoc)
+import qualified Data.Text as T (Text, append, tail, isPrefixOf, toUpper, filter, snoc, unpack)
 import Database.DataType ( ShapeType( Node ) , ShapeType( Hybrid ), ShapeType( BoolNode ))
 import Database.Persist.Sqlite (Entity, PersistEntity, SqlPersistM, PersistValue( PersistInt64 ), runSqlite, selectList,
                                 entityKey, entityVal, selectFirst, (==.), (<-.), get, keyToValues, PersistValue( PersistText ),
@@ -244,3 +245,10 @@ getMeetingSection sec
     | T.isPrefixOf "P" sec = T.append "PRA" sectCode
     | otherwise            = sec
     where sectCode = T.tail sec
+
+getAllCourseCodes :: IO [String]
+getAllCourseCodes = runSqlite databasePath $ do
+    coursesList <- selectList [] []
+    let codes = map (T.unpack . coursesCode . entityVal) coursesList
+    return codes
+    

--- a/js/components/generate/generate.js
+++ b/js/components/generate/generate.js
@@ -74,7 +74,20 @@ class GenerateForm extends React.Component {
     }
 
     fetch("/graph-generate", putData)
-      .then(res => res.json())
+      .then(res => {
+        if (res.statusText === "OK") {
+          return res.json()
+        } else {
+          // "Bad Request"
+          this.graph.current.setState({
+            nodesJSON: [],
+            boolsJSON: [],
+            edgesJSON: [],
+          })
+          alert("No valid courses entered. Please check your input.")
+          throw new Error("No valid courses!")
+        }
+      })
       .then(data => {
         const labelsJSON = {}
         const regionsJSON = {}


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

In the Generate functionality, if no courses are found (e.g. an invalid course code is input), currently nothing happens. Instead, when no valid courses are inputted, we ant to have some kind of message is displayed to the user, and nothing in the graph to be drawn.


## How it currently works:
1. When we press the "Generate Graph" button on the `/generate` page, the `handleSubmit` function in `js/components/generate/generate.js` is triggered.
2. This handler makes a `PUT` request to the `/graph-generate` endpoint (with data including the user's selected courses):
```
fetch("/graph-generate", putData)
```
3. This (through the `Routes.hs` file) is mapped to the `Controllers.Graph.findAndSavePrereqsResponse`, which decodes the request body and passes it to a helper `findAndSavePrereqResponse` that does all the necesarry computations and returns the appropriate course information.
```
findAndSavePrereqsResponse :: ServerPart Response
findAndSavePrereqsResponse = do
    body <- getBody
    let coursesOptions :: CourseGraphOptions = fromJust $ decode body
    liftIO $ generateAndSavePrereqResponse coursesOptions
```

4. This is sent back as a response, fulfilling JS's `fetch` promise, and JS proceeds to handle the response data with a chain of promises.

## Strategy for task
In the case that none of the inputted courses are valid, we want to show an appropriate message to the user and show *nothing* on the graph section of the screen.

To do this, we somehow need to check the inputted course-codes against a (the) list of possible course code (so that we can determine if there exists a valid course).

The only way to get this list of "valid" courses if through the `"/courses"` endpoint, which maps to the `index` function of `Controllers.Course`. Therefore, I can think of two possible ways to perform the aforementioned check.

1. **The logic for checking valid courses in the front-end**: From within (the React component function) `handleSubmit`, first make a server request to `/courses` to get all valid courses so that you can compare against the user-selected courses. Then, if at least one course is valid, do the server request to `/graph-generate`, otherwise show an appropriate message and blank-out the graph section.

2. **The logic for checking valid courses in the backend**: The `findAndSavePrereqsResponse` Haskell function will receive the user's selected courses (through the original request made by JS), and it will check whether the courses are valid -with a custom function similar to `Controllers.Course.getCourses` and return an appropriate response.

I will choose option **2** because:
- Option **1** requires to separate requests to the server, raising performance concerns
- From a design perspective, checking whether the courses are valid is a backend task; it shouldn't be handled in the frontend.

## Changes
1. Create a `getAllCourses` function in the `CourseQueries` module which has the same logic as `Controllers.Course.index` (i.e. getting all course codes) but instead of returning `ServerPart Response` it returns `IO [String]` (NOTE: It has to be IO because the logic involves reading from a database, which is an inherently `impure` operation).
``` Haskell
getAllCourseCodes :: IO [String]
getAllCourseCodes = runSqlite databasePath $ do
    coursesList <- selectList [] []
    let codes = map (T.unpack . coursesCode . entityVal) coursesList
    return codes
```

2. Update `findAndSavePrereqsResponse` to check if the user-selected courses are valid by utilizing the new `getAllCourseCodes` function from (1). Compare this with the original version of the function attached above.
``` Haskell
findAndSavePrereqsResponse :: ServerPart Response
findAndSavePrereqsResponse = do
    body <- getBody
    let coursesOptions :: CourseGraphOptions = fromJust $ decode body
    let selectedCourses = courses coursesOptions
    allCourses <- liftIO CourseHelper.getAllCourseCodes
    let isValid = any (`elem` allCourses) (map TL.unpack selectedCourses)
    if isValid
        then
            liftIO $ generateAndSavePrereqResponse coursesOptions
        else do
            badRequest $ toResponse ("Invalid course selected" :: String)
```
- With `courses coursesOptions` we extract the courses attribute out of `coursesOptions` (whose data type if `CourseGraphOptions`)
- With `allCourses <- liftIO CourseHelper.getAllCourseCodes`, we invoke the newly defined function. But the return type of this functino is `IO [String]`. The `ServerPart` monad supports `IO`, so we have to lift up the IO action, allowing us to perform IO operations within the context of this `ServerPart` monad.
- With `any (`elem` allCourses) (map TL.unpack selectedCourses)` we
check if any of the  `selectedCourses` is present in `allCourses` (i.e. is a valid course). The `TL.unpack` is necessary because selectedCourses is of type `Data.Text.Lazy` but each element of `allCourses` is a string `Text`.
- Behave differently depending on whether the select courses were "valid" or not (responding with a `400` in the case of invalidity).

3. Update the `handleSubmit` handler from `generate.js` to handle the new response possibily of `400` appropriately.
```javascript
...
fetch("/graph-generate", putData)
      .then(res => {
        if (res.statusText === "OK") {
          return res.json()
        }
        else { // "Bad Request"
          this.graph.current.setState({
            nodesJSON: [],
            boolsJSON: [],
            edgesJSON: []}
          )
          alert("No valid courses entered. Please check your input.");
          throw new Error("No valid courses!");
        }
  })
      .then...
```
If we receive back a "Bad Response" (code 400) *--meaning that none of the inputted courses were valid--* we reset the state of the graph (to remove any currently displayed nodes) and alert an appropriate message. Othewise, we proceed as usual.

****
**Some intuition from the web**:
*When you have a monad that combines IO with other behaviors (e.g., StateT s IO a), you need a way to run IO actions within this combined monad. This is where liftIO comes in. It allows you to “lift” an IO action into the combined monad, enabling you to perform IO operations within the context of your more complex monad.*
****

Commit Command: git commit -m "Update graph generation handling to detect if the course input is invalid and show an appropriate message to user" -m "The logic of checking for course validity went into the Controllers.Graph.findAndSavePrereqsResponse controller action"


<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |    X      |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |     X     |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
