### PR TITLE
Accept different versions of course codes for generating a prereq graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed bug that causes FCE count to increase when toggling course via sidebar
+- Fixed bug that forced users to input a course codes in a specific way when generating a dependency graph
 
 ### 🔧 Internal changes
 

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -202,16 +202,18 @@ getGraph graphName =
                 return (Just response) :: SqlPersistM (Maybe Response)
 
 -- | Retrieves the prerequisites for a course (code) as a string.
-prereqsForCourse :: T.Text -> IO (Either String T.Text)
+-- Also retrieves the actual course code in the database in case
+-- the one the user inputs doesn't match it exactly
+prereqsForCourse :: T.Text -> IO (Either String (T.Text, T.Text))
 prereqsForCourse courseCode = runSqlite databasePath $ do
-    course <- selectFirst [CoursesCode ==. courseCode] []
+    course <- selectFirst [CoursesCode <-. [T.toUpper courseCode, T.toUpper courseCode `T.append` "H1", courseCode `T.append` "Y1"]] []
     case course of
         Nothing -> return (Left "Course not found")
         Just courseEntity ->
-            return (Right $
-                fromMaybe "" $
+            return (Right
+                (coursesCode $ entityVal courseEntity, fromMaybe "" $
                 coursesPrereqString $
-                entityVal courseEntity) :: SqlPersistM (Either String T.Text)
+                entityVal courseEntity)) :: SqlPersistM (Either String (T.Text, T.Text))
 
 getDeptCourses :: MonadIO m => T.Text -> m [Course]
 getDeptCourses dept =

--- a/app/Database/CourseQueries.hs
+++ b/app/Database/CourseQueries.hs
@@ -206,14 +206,15 @@ getGraph graphName =
 -- the one the user inputs doesn't match it exactly
 prereqsForCourse :: T.Text -> IO (Either String (T.Text, T.Text))
 prereqsForCourse courseCode = runSqlite databasePath $ do
-    course <- selectFirst [CoursesCode <-. [T.toUpper courseCode, T.toUpper courseCode `T.append` "H1", courseCode `T.append` "Y1"]] []
+    let upperCaseCourseCode = T.toUpper courseCode
+    course <- selectFirst [CoursesCode <-. [upperCaseCourseCode, upperCaseCourseCode `T.append` "H1", upperCaseCourseCode `T.append` "Y1"]] []
     case course of
         Nothing -> return (Left "Course not found")
         Just courseEntity ->
             return (Right
-                (coursesCode $ entityVal courseEntity, fromMaybe "" $
-                coursesPrereqString $
-                entityVal courseEntity)) :: SqlPersistM (Either String (T.Text, T.Text))
+                     (coursesCode $ entityVal courseEntity, 
+                      fromMaybe "" $ coursesPrereqString $ entityVal courseEntity)
+                    ) :: SqlPersistM (Either String (T.Text, T.Text))
 
 getDeptCourses :: MonadIO m => T.Text -> m [Course]
 getDeptCourses dept =

--- a/app/DynamicGraphs/CourseFinder.hs
+++ b/app/DynamicGraphs/CourseFinder.hs
@@ -26,9 +26,9 @@ lookupCourse options code = do
     prereqResults <- lift $ prereqsForCourse $ T.toStrict code
     case prereqResults of
         Left _ -> return ()
-        Right prereqStr -> do
+        Right (courseCode, prereqStr) -> do
             let prereqs = parseReqs (T.unpack $ T.fromStrict prereqStr)
-            modify $ Map.insert code prereqs
+            modify $ Map.insert (T.fromStrict courseCode) prereqs
             lookupReqs options prereqs
 
 lookupReqs :: GraphOptions -> Req -> StateT (Map.Map T.Text Req) IO ()


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

When users want to generate a prerequisite graph for a course or list of courses, they're forced to to input the course code in a specific format: all caps and with an "H1" or "Y1" appended to it. i.e. CSC369H1 is valid, but csc369, csc369H1, csc369h1, etc are not valid. The issue is that when the backend code looks up the prerequisites for a given course, it does a strict equality check on the course code column within the database with the given course code.

The goal of this PR is to allow the user to input different (but ones we still consider valid) versions of a course code when generating the prerequisite graph. This involves changing the strict equality check to checking if the given course code matches one of the different ways of entering a course code
...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |      X    |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_

This PR does not include any additional tests since all changes (so far) have been for backend code since we don't currently have the infrastructure to support testing bug fixes like this. Manual testing was performed and the following screenshots have been added to show the fixes work

![image](https://github.com/Courseography/courseography/assets/60582433/b991223e-bcb5-4311-8449-6cbe552bb2aa)

![image](https://github.com/Courseography/courseography/assets/60582433/b66cb2ed-92c1-4c3b-a417-efe6036f5b46)



