### PR TITLE
Fixed graph rendering bug introduced in PR 1461

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix React state mutation
 - Fixed timetable parsing issue, querying page numbers rather than course codes
 - Fixed bug to count FCE correctly
+- Fixed parsing of graph transformations
 
 ### 🔧 Internal changes
 

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -586,6 +586,8 @@ addTuples :: Point -> Point -> Point
 addTuples (a,b) (c,d) = (a + c, b + d)
 
 -- | Apply a matrix transformation to a point.
+-- The matrix must have dimensions 3x3, representing a transformation for a two-dimensional point,
+-- i.e., the transformation in the z-component is ignored, so the third row is expected to be [0,0,1]
 matrixPointMultiply :: Matrix -> Point -> Point
 matrixPointMultiply matrix (x, y) =
     case matrix of

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -587,21 +587,18 @@ addTuples (a,b) (c,d) = (a + c, b + d)
 
 -- | Apply a matrix transformation to a point.
 matrixPointMultiply :: Matrix -> Point -> Point
-matrixPointMultiply m p =
-    let [[x, y, _]] = matrixMultiply m (pointToMatrix p)
-    in (x, y)
+matrixPointMultiply matrix (x, y) =
+    case matrix of
+        [[a, b, tx], [c, d, ty], _] -> (a * x + b * y + tx, c * x + d * y + ty)
+        _ -> error "Matrix must be 3x3 for point transformation."
 
--- | Multiplies two matrices together.
+-- | Multiplies two 3x3 matrices together.
 matrixMultiply :: Matrix -> Matrix -> Matrix
 matrixMultiply m1 m2 = [[dotProduct row col | col <- transpose m2] | row <- m1]
 
 -- | Computes the dot product of two vectors.
 dotProduct :: Vector -> Vector -> Double
 dotProduct v1 v2 = sum $ zipWith (*) v1 v2
-
--- Converts a Point into a Matrix representing a 2D vector.
-pointToMatrix :: Point -> Matrix
-pointToMatrix (x, y) = [[x, y, 1]]
 
 -- | Helper to remove leading and trailing whitespace.
 trim :: T.Text -> T.Text


### PR DESCRIPTION
## Proposed Changes
This PR fixes the bug introduced in PR 1461.
As a result of the changes in PR 1461, the Courseography graphs did not render on the screen.
This PR proposes a new implementation of the function `matrixPointMultiply` which has exhaustive pattern matching and a logic specific to applying a 3D transformation to a 2D point. With this change, the graph is rendered with the correct translations.

#### How I tested my changes
- delete old database file
- recreate the database file running all commands (`stack run database-setup`, `stack run database-graphs`,` stack run database-calendar`, `stack run database-timetable`)
- verify that the rendered graph is shown with the correct translatiions by comparing it with the released version of Courseography

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |    X     |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [ ] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [X] I have verified that the CircleCI checks have passed.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

- The matrix operations do not currently extend to more general scenarios of operations on any dimensions that are not 3D for matrices and 2D for points. This is not an issue for the context in which these operations are used but does not generalize well.
- What is the best way to document this in the changelog? In theory, the update in my previous PR should already cover this change.
