### PR TITLE
Minor CSS Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Reorganized `.cabal` file
 - Added coverage report to test suite
 - Added test cases for the retrieveCourse function in `Controllers/Course`
+- Fixed CSS issues: modal padding, "and/or" centering, and FCE Count arrow alignment
 
 ## [0.6.0] - 2024-06-24
 

--- a/style/app.scss
+++ b/style/app.scss
@@ -233,7 +233,6 @@ a:active {
   justify-content: space-evenly;
   line-height: 1.8em;
   padding: 0;
-  padding-left: 25px;
   text-align: left;
 }
 

--- a/style/app.scss
+++ b/style/app.scss
@@ -336,6 +336,7 @@ ol {
   box-shadow: 0 0 30px;
   height: 550px;
   overflow-y: auto;
+  padding: 21px 34px;
   position: absolute;
   width: 1000px;
 }
@@ -523,7 +524,9 @@ div.sidebar.collapsed {
   background-color: #5c497e;
   border-radius: 10px;
   cursor: pointer;
+  display: flex;
   height: 15px;
+  justify-content: center;
   margin-left: 70px;
   margin-top: -5px;
   width: 30px;
@@ -978,6 +981,7 @@ g.bool > text {
   font-weight: bold;
   stroke: none;
   text-anchor: middle;
+  transform: translateY(-0.23em);
 }
 
 path {

--- a/style/app.scss
+++ b/style/app.scss
@@ -765,7 +765,7 @@ div.sidebar.collapsed {
   height: 30px;
   justify-content: center;
   margin-bottom: 10px;
-  margin-right: 20px;
+  margin-left: 20px;
   margin-top: 10px;
   width: 50px;
 }

--- a/style/app.scss
+++ b/style/app.scss
@@ -336,7 +336,7 @@ ol {
   box-shadow: 0 0 30px;
   height: 550px;
   overflow-y: auto;
-  padding: 21px 34px;
+  padding: 12px 30px;
   position: absolute;
   width: 1000px;
 }


### PR DESCRIPTION
## Proposed Changes

Fixed minor CSS issues in the UI to make it look better:
- No padding around course modal
- "and", "or" in the graph were not centered inside the ellipse
- FCE Count component's down arrow was outside the purple button

Here are the updated UI changes:

**Updated Modal:**
<img width="1031" alt="Screenshot 2025-01-25 at 1 03 21 PM" src="https://github.com/user-attachments/assets/4b369876-a964-406e-aaa4-08eeb7ec18ef" />

<img width="500" alt="Screenshot 2025-01-22 at 7 04 26 PM" src="https://github.com/user-attachments/assets/46dcb1f0-7bd3-4bcb-89ad-89cb32927203" />. 

<img width="200" alt="Screenshot 2025-01-22 at 7 02 42 PM" src="https://github.com/user-attachments/assets/b1c20f72-bf04-4596-8937-60312bf34b48" />

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |     X    |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

22nd Jan, 2025
To center the"and" and "or" I used translate with a hardcoded value and it seemed to look good based on various screen sizes. If required, I can look into a dynamic way of doing this.
Additionally, the timetable part of the course modal does not have padding when downward scrolling is possible. I can fix that also if required.

25th Jan, 2025
After removing the left padding, the arrows on the header had some spacing to their right. I removed that as well.