### PR TITLE
SVG Graph Creation Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed choppiness of the graphs generated in the export modal
 - Fixed matrix transformation and intersection checking bug when sending graph data to front end
 - Fixed inverse matrix storage from column-major to row-major order
+- Fixed SVG Graph Creation (translation issue)
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed choppiness of the graphs generated in the export modal
 - Fixed matrix transformation and intersection checking bug when sending graph data to front end
 - Fixed inverse matrix storage from column-major to row-major order
-- Fixed the issue with transformation matricies not being applied to SVG attributes and as a result, the pdf generated in the export modal
+- Fixed the issue with transformation matricies not being applied to SVG attributes when generating PDFs in the export modal
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed choppiness of the graphs generated in the export modal
 - Fixed matrix transformation and intersection checking bug when sending graph data to front end
 - Fixed inverse matrix storage from column-major to row-major order
-- Fixed SVG Graph Creation (translation issue)
+- Fixed the issue with transformation matricies not being applied to SVG attributes and as a result, the pdf generated in the export modal
 
 ### 🔧 Internal changes
 

--- a/app/Svg/Generator.hs
+++ b/app/Svg/Generator.hs
@@ -177,7 +177,7 @@ rectToSVG styled courseMap rect
                          _ -> ""
 
         in S.g ! A.id_ (textValue $ sanitizeId $ shapeId_ rect)
-               ! A.transform (stringValue . show . formatTransform $ shapeTransform rect)
+               ! A.transform (stringValue . formatTransform $ shapeTransform rect)
                ! A.class_ (textValue class_)
                ! S.customAttribute "data-group" (textValue
                                                  (getArea (shapeId_ rect)))
@@ -207,7 +207,7 @@ rectToSVG styled courseMap rect
 ellipseToSVG :: Bool -> Shape -> S.Svg
 ellipseToSVG styled ellipse =
     S.g ! A.id_ (textValue (shapeId_ ellipse))
-        ! A.transform (stringValue . show . formatTransform $ shapeTransform ellipse)
+        ! A.transform (stringValue . formatTransform $ shapeTransform ellipse)
         ! A.class_ "bool" $ do
             S.ellipse ! A.cx (stringValue . show . fst $ shapePos ellipse)
                       ! A.cy (stringValue . show . snd $ shapePos ellipse)
@@ -229,7 +229,7 @@ textToSVG styled type_ xPos' text =
                       then xPos
                       else xPos')
             ! A.y (stringValue $ show yPos)
-            ! A.transform (stringValue . show . formatTransform $ textTransform text)
+            ! A.transform (stringValue . show $ textTransform text)
             ! (if styled then allStyles else baseStyles)
             $ toMarkup $ textText text
     where
@@ -266,7 +266,7 @@ edgeToSVG styled path =
     S.path ! A.id_ (textValue . T.append "path" . pathId_ $ path)
            ! A.class_ "path"
            ! A.d (textValue . T.cons 'M' . buildPathString . pathPoints $ path)
-           ! A.transform (stringValue . show . formatTransform $ pathTransform path)
+           ! A.transform (stringValue . formatTransform $ pathTransform path)
            ! A.markerEnd "url(#arrow)"
            ! S.customAttribute "data-source-node" (textValue $ sanitizeId
                                                           $ pathSource path)
@@ -288,7 +288,7 @@ regionToSVG styled path =
     S.path ! A.id_ (textValue $ T.append "region" (pathId_ path))
            ! A.class_ "region"
            ! A.d (textValue . T.cons 'M' . buildPathString . pathPoints $ path)
-           ! A.transform (stringValue . show . formatTransform $ pathTransform path)
+           ! A.transform (stringValue . formatTransform $ pathTransform path)
            ! A.style (textValue $ T.concat ["fill:", pathFill path, ";",
                       if styled
                       then

--- a/app/Svg/Generator.hs
+++ b/app/Svg/Generator.hs
@@ -229,6 +229,11 @@ textToSVG styled type_ xPos' text =
                       then xPos
                       else xPos')
             ! A.y (stringValue $ show yPos)
+            -- When applying the transformation matrix for text attributes, the ones
+            -- that are connected to nodes and ellipses are positioned based the positioning
+            -- of the respective nodes and ellipses. On the other hand, the text for the regions
+            -- is positioned based on database values, so the transformation matrix still has to
+            -- be applied. TODO: This is poor design and probably needs to be updated in the future.
             ! (if type_ == Region
                 then A.transform (stringValue . formatTransform $ textTransform text)
                 else mempty)

--- a/app/Svg/Generator.hs
+++ b/app/Svg/Generator.hs
@@ -229,7 +229,9 @@ textToSVG styled type_ xPos' text =
                       then xPos
                       else xPos')
             ! A.y (stringValue $ show yPos)
-            ! A.transform (stringValue . show $ textTransform text)
+            ! (if type_ == Region
+                then A.transform (stringValue . formatTransform $ textTransform text)
+                else mempty)
             ! (if styled then allStyles else baseStyles)
             $ toMarkup $ textText text
     where


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

The current SVG graph had an issue with the attributes (paths, nodes, text) being misaligned (translated left and down). This pull request is to remedy the SVG graph creation to have everything appear in the correct places.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

Before:
<img width="1144" alt="Screenshot 2025-03-28 at 3 25 36 AM" src="https://github.com/user-attachments/assets/333bfaa9-4f7a-49b8-9933-6c9dd1152b79" />

After:
<img width="1147" alt="Screenshot 2025-03-28 at 3 27 28 AM" src="https://github.com/user-attachments/assets/4582fb5f-319d-4422-80e0-d3b1ef0cdc62" />


</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |      x    |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_

So the way transformations are working is as follows: We take the database information (position + transformation matrix) and then apply the inverse to the transformation matrix and then apply the changes to each attribute. The text attribute has a caveat. For the text that is in the nodes and ellipses, the positioning is based on the positioning of their "parent attribute" so it gets passed into the function for formatting the text. On the other hand, region text is positioned based on the positional data in the database.

The current fix I applied is to only apply the transformation matrix if the text type is region. I do think this is bad design as I don't think there should be any dependencies between the different attributes and also the actual data for positions for text is available to use in the database. Moreover, only the x-position is being taken from nodes and ellipses.

Edit: I thought about the data we have and we it makes sense to do it this way to reduce the amount of data in the database as there are multiple ors and ands being used. On the other hand, I do not fully understand why there is only a dependence on nodes/ellipses only for the x position?

