### PR TITLE
Refactor tests to use tasty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🔧 Internal changes
 
 - Refactored navigation bar into a React component (for the graph, grid and generate pages only - the about page navigation bar is still rendered using Blaze)
+- Refactored backend tests to use `tasty` and `tasty-hunit` instead of `HUnit`
 
 ## [0.7.1] - 2025-06-16
 

--- a/backend-test/Controllers/ControllerTests.hs
+++ b/backend-test/Controllers/ControllerTests.hs
@@ -9,10 +9,13 @@ module Controllers.ControllerTests
 (  controllerTests  ) where
 
 import Test.HUnit (Test (..))
+import Test.Tasty
+import Test.Tasty.HUnit
 
 import Controllers.CourseControllerTests (courseControllerTestSuite)
 import Controllers.GraphControllerTests (graphControllerTestSuite)
 
 -- Single test encompassing all controller test suites
-controllerTests :: Test
-controllerTests = TestList [courseControllerTestSuite, graphControllerTestSuite]
+controllerTests :: TestTree
+-- controllerTests = TestList [courseControllerTestSuite, graphControllerTestSuite]
+controllerTests = testGroup "Controller tests" [graphControllerTestSuite]

--- a/backend-test/Controllers/ControllerTests.hs
+++ b/backend-test/Controllers/ControllerTests.hs
@@ -8,7 +8,6 @@ Module that contains the test suites for all the controllers.
 module Controllers.ControllerTests
 (  controllerTests  ) where
 
-import Test.HUnit (Test (..))
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -17,5 +16,4 @@ import Controllers.GraphControllerTests (graphControllerTestSuite)
 
 -- Single test encompassing all controller test suites
 controllerTests :: TestTree
--- controllerTests = TestList [courseControllerTestSuite, graphControllerTestSuite]
-controllerTests = testGroup "Controller tests" [graphControllerTestSuite]
+controllerTests = testGroup "Controller tests" [courseControllerTestSuite, graphControllerTestSuite]

--- a/backend-test/Controllers/ControllerTests.hs
+++ b/backend-test/Controllers/ControllerTests.hs
@@ -16,4 +16,4 @@ import Controllers.GraphControllerTests (graphControllerTestSuite)
 
 -- Single test encompassing all controller test suites
 controllerTests :: TestTree
-controllerTests = testGroup "Controller tests" [courseControllerTestSuite, graphControllerTestSuite]
+controllerTests = testGroup "Controller" [courseControllerTestSuite, graphControllerTestSuite]

--- a/backend-test/Controllers/ControllerTests.hs
+++ b/backend-test/Controllers/ControllerTests.hs
@@ -9,7 +9,6 @@ module Controllers.ControllerTests
 (  controllerTests  ) where
 
 import Test.Tasty
-import Test.Tasty.HUnit
 
 import Controllers.CourseControllerTests (courseControllerTestSuite)
 import Controllers.GraphControllerTests (graphControllerTestSuite)

--- a/backend-test/Controllers/ControllerTests.hs
+++ b/backend-test/Controllers/ControllerTests.hs
@@ -8,7 +8,7 @@ Module that contains the test suites for all the controllers.
 module Controllers.ControllerTests
 (  controllerTests  ) where
 
-import Test.Tasty
+import Test.Tasty (TestTree, testGroup)
 
 import Controllers.CourseControllerTests (courseControllerTestSuite)
 import Controllers.GraphControllerTests (graphControllerTestSuite)

--- a/backend-test/Controllers/CourseControllerTests.hs
+++ b/backend-test/Controllers/CourseControllerTests.hs
@@ -19,8 +19,8 @@ import qualified Data.Text as T
 import Database.Persist.Sqlite (SqlPersistM, insert_)
 import Database.Tables (Courses (..))
 import Happstack.Server (rsBody)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import TestHelpers (clearDatabase, runServerPart, runServerPartWithCourseInfoQuery,
                     runServerPartWithQuery)
 

--- a/backend-test/Controllers/GraphControllerTests.hs
+++ b/backend-test/Controllers/GraphControllerTests.hs
@@ -45,17 +45,7 @@ insertGraphs = mapM_ insertGraph
     where
         insertGraph title = insert_ (Graph title 0 0 False )
 
--- -- | Run a test case (case, input, expected output) on the index function.
--- runIndexTest :: String -> [T.Text] -> String -> Test
--- runIndexTest label graphs expected =
---     TestLabel label $ TestCase $ do
---         runDb $ do
---             clearDatabase
---             insertGraphs graphs
---         response <- runServerPart Controllers.Graph.index
---         let actual = BL.unpack $ rsBody response
---         assertEqual ("Unexpected response body for " ++ label) expected actual
-
+-- | Run a test case (case, input, expected output) on the index function.
 runIndexTest :: String -> [T.Text] -> String -> TestTree
 runIndexTest label graphs expected =
     testCase label $ do

--- a/backend-test/Controllers/GraphControllerTests.hs
+++ b/backend-test/Controllers/GraphControllerTests.hs
@@ -16,8 +16,8 @@ import qualified Data.Text as T
 import Database.Persist.Sqlite (SqlPersistM, insert_)
 import Database.Tables (Graph (..))
 import Happstack.Server (rsBody)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import TestHelpers (clearDatabase, runServerPart)
 
 -- | List of test cases as (label, input graphs, expected output)

--- a/backend-test/Controllers/GraphControllerTests.hs
+++ b/backend-test/Controllers/GraphControllerTests.hs
@@ -16,7 +16,6 @@ import qualified Data.Text as T
 import Database.Persist.Sqlite (SqlPersistM, insert_)
 import Database.Tables (Graph (..))
 import Happstack.Server (rsBody)
--- import Test.HUnit (Test (..), assertEqual)
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestHelpers (clearDatabase, runServerPart)

--- a/backend-test/Controllers/GraphControllerTests.hs
+++ b/backend-test/Controllers/GraphControllerTests.hs
@@ -16,7 +16,9 @@ import qualified Data.Text as T
 import Database.Persist.Sqlite (SqlPersistM, insert_)
 import Database.Tables (Graph (..))
 import Happstack.Server (rsBody)
-import Test.HUnit (Test (..), assertEqual)
+-- import Test.HUnit (Test (..), assertEqual)
+import Test.Tasty
+import Test.Tasty.HUnit
 import TestHelpers (clearDatabase, runServerPart)
 
 -- | List of test cases as (label, input graphs, expected output)
@@ -43,10 +45,20 @@ insertGraphs = mapM_ insertGraph
     where
         insertGraph title = insert_ (Graph title 0 0 False )
 
--- | Run a test case (case, input, expected output) on the index function.
-runIndexTest :: String -> [T.Text] -> String -> Test
+-- -- | Run a test case (case, input, expected output) on the index function.
+-- runIndexTest :: String -> [T.Text] -> String -> Test
+-- runIndexTest label graphs expected =
+--     TestLabel label $ TestCase $ do
+--         runDb $ do
+--             clearDatabase
+--             insertGraphs graphs
+--         response <- runServerPart Controllers.Graph.index
+--         let actual = BL.unpack $ rsBody response
+--         assertEqual ("Unexpected response body for " ++ label) expected actual
+
+runIndexTest :: String -> [T.Text] -> String -> TestTree
 runIndexTest label graphs expected =
-    TestLabel label $ TestCase $ do
+    testCase label $ do
         runDb $ do
             clearDatabase
             insertGraphs graphs
@@ -55,9 +67,9 @@ runIndexTest label graphs expected =
         assertEqual ("Unexpected response body for " ++ label) expected actual
 
 -- | Run all the index test cases
-runIndexTests :: [Test]
+runIndexTests :: [TestTree]
 runIndexTests = map (\(label, graphs, expected) -> runIndexTest label graphs expected) indexTestCases
 
 -- | Test suite for Graph Controller Module
-graphControllerTestSuite :: Test
-graphControllerTestSuite = TestLabel "Graph Controller tests" $ TestList runIndexTests
+graphControllerTestSuite :: TestTree
+graphControllerTestSuite = testGroup "Graph Controller tests" runIndexTests

--- a/backend-test/Database/CourseQueriesTests.hs
+++ b/backend-test/Database/CourseQueriesTests.hs
@@ -14,10 +14,11 @@ import Control.Monad.IO.Class (liftIO)
 import qualified Data.Text as T
 import Data.Time (getCurrentTime)
 import Database.CourseQueries (reqsForPost)
-import Database.DataType (PostType(..))
+import Database.DataType (PostType (..))
 import Database.Persist.Sqlite (insert_)
-import Database.Tables (Post(..))
-import Test.HUnit (Test(..), assertEqual)
+import Database.Tables (Post (..))
+import Test.Tasty
+import Test.Tasty.HUnit
 import TestHelpers (clearDatabase)
 
 -- | List of test cases as (label, requirements to insert, input program, expected output)
@@ -29,9 +30,9 @@ reqsForPostTestCases =
     ]
 
 -- | Run a test case (case, requirements, input, expected output) on the reqsForPost function.
-runReqsForPostTest :: String -> T.Text -> T.Text -> String -> Test
+runReqsForPostTest :: String -> T.Text -> T.Text -> String -> TestTree
 runReqsForPostTest label reqsToInsert program expected =
-    TestLabel label $ TestCase $ do
+    testCase label $ do
         currentTime <- liftIO getCurrentTime
         let testPost = Post Major "Computer Science" program "Sample post description" reqsToInsert currentTime currentTime
 
@@ -44,9 +45,9 @@ runReqsForPostTest label reqsToInsert program expected =
         assertEqual ("Unexpected response body for " ++ label) expected actual
 
 -- | Run all the reqsForPost test cases
-runReqsForPostTests :: [Test]
+runReqsForPostTests :: [TestTree]
 runReqsForPostTests = map (\(label, reqsToInsert, program, expected) -> runReqsForPostTest label reqsToInsert program expected) reqsForPostTestCases
 
 -- | Test suite for CourseQueries Module
-courseQueriesTestSuite :: Test
-courseQueriesTestSuite = TestLabel "Course Queries tests" $ TestList runReqsForPostTests
+courseQueriesTestSuite :: TestTree
+courseQueriesTestSuite = testGroup "Course Queries tests" runReqsForPostTests

--- a/backend-test/Database/CourseQueriesTests.hs
+++ b/backend-test/Database/CourseQueriesTests.hs
@@ -17,8 +17,8 @@ import Database.CourseQueries (reqsForPost)
 import Database.DataType (PostType (..))
 import Database.Persist.Sqlite (insert_)
 import Database.Tables (Post (..))
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import TestHelpers (clearDatabase)
 
 -- | List of test cases as (label, requirements to insert, input program, expected output)

--- a/backend-test/Database/DatabaseTests.hs
+++ b/backend-test/Database/DatabaseTests.hs
@@ -8,9 +8,9 @@ Module that contains the test suites for all the database functions.
 module Database.DatabaseTests
 (  databaseTests  ) where
 
-import Test.HUnit (Test (..))
 import Database.CourseQueriesTests (courseQueriesTestSuite)
+import Test.Tasty
 
 -- Single test encompassing all database test suites
-databaseTests :: Test
-databaseTests = TestList [courseQueriesTestSuite]
+databaseTests :: TestTree
+databaseTests = testGroup "Database" [courseQueriesTestSuite]

--- a/backend-test/Database/DatabaseTests.hs
+++ b/backend-test/Database/DatabaseTests.hs
@@ -9,7 +9,7 @@ module Database.DatabaseTests
 (  databaseTests  ) where
 
 import Database.CourseQueriesTests (courseQueriesTestSuite)
-import Test.Tasty
+import Test.Tasty (TestTree, testGroup)
 
 -- Single test encompassing all database test suites
 databaseTests :: TestTree

--- a/backend-test/Main.hs
+++ b/backend-test/Main.hs
@@ -32,4 +32,4 @@ main = do
     unsetEnv "APP_ENV"
 
 tests :: TestTree
-tests = testGroup "Tests" [controllerTests]
+tests = testGroup "Tests" [controllerTests, databaseTests]

--- a/backend-test/Main.hs
+++ b/backend-test/Main.hs
@@ -22,10 +22,6 @@ import Test.HUnit (Test (..), failures, runTestTT)
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- tests :: IO Test
--- tests = do
---     return $ TestList [requirementTests, controllerTests, svgTests, databaseTests]
-
 main :: IO ()
 main = do
     setEnv "APP_ENV" "test"

--- a/backend-test/Main.hs
+++ b/backend-test/Main.hs
@@ -32,4 +32,4 @@ main = do
     unsetEnv "APP_ENV"
 
 tests :: TestTree
-tests = testGroup "Tests" [controllerTests, databaseTests]
+tests = testGroup "Tests" [controllerTests, databaseTests, requirementTests, svgTests]

--- a/backend-test/Main.hs
+++ b/backend-test/Main.hs
@@ -7,30 +7,33 @@ Module that acts as interface for testing multiple test suites using cabal.
 
 module Main where
 
-import Control.Monad (when)
 import Config (databasePath)
+import Control.Monad (when)
+import Controllers.ControllerTests (controllerTests)
 import Data.Text (unpack)
-import Database.Database(setupDatabase)
+import Database.Database (setupDatabase)
+import Database.DatabaseTests (databaseTests)
+import RequirementTests.RequirementTests (requirementTests)
+import SvgTests.SvgTests (svgTests)
 import System.Directory (removeFile)
 import System.Environment (setEnv, unsetEnv)
 import qualified System.Exit as Exit
 import Test.HUnit (Test (..), failures, runTestTT)
-import RequirementTests.RequirementTests (requirementTests)
-import Controllers.ControllerTests (controllerTests)
-import Database.DatabaseTests (databaseTests)
-import SvgTests.SvgTests (svgTests)
+import Test.Tasty
+import Test.Tasty.HUnit
 
-tests :: IO Test
-tests = do
-    return $ TestList [requirementTests, controllerTests, svgTests, databaseTests]
+-- tests :: IO Test
+-- tests = do
+--     return $ TestList [requirementTests, controllerTests, svgTests, databaseTests]
 
 main :: IO ()
 main = do
     setEnv "APP_ENV" "test"
     setupDatabase
-    testSuites <- tests
-    count <- runTestTT testSuites
-    when (failures count > 0) Exit.exitFailure
+    defaultMain tests
     path <- databasePath
     removeFile $ unpack path
     unsetEnv "APP_ENV"
+
+tests :: TestTree
+tests = testGroup "Tests" [controllerTests]

--- a/backend-test/Main.hs
+++ b/backend-test/Main.hs
@@ -17,10 +17,7 @@ import RequirementTests.RequirementTests (requirementTests)
 import SvgTests.SvgTests (svgTests)
 import System.Directory (removeFile)
 import System.Environment (setEnv, unsetEnv)
-import qualified System.Exit as Exit
-import Test.HUnit (Test (..), failures, runTestTT)
 import Test.Tasty
-import Test.Tasty.HUnit
 
 main :: IO ()
 main = do

--- a/backend-test/RequirementTests/ModifierTests.hs
+++ b/backend-test/RequirementTests/ModifierTests.hs
@@ -10,14 +10,14 @@ module RequirementTests.ModifierTests
 
 import Database.Requirement
 import DynamicGraphs.GraphNodeUtils (concatModOr, stringifyModAnd)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => (a -> String) -> String -> [(Int, (a, String))] -> TestTree
-createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+createTest :: (Eq a, Show a) => (a -> String) -> String -> [(a, String)] -> TestTree
+createTest function label input = testGroup label $ zipWith (\(x :: Int) (y, z) ->
                                 testCase ("Test " ++ show x) $ assertEqual ("for (" ++ z ++ ")")
-                                z (function y)) input
+                                z (function y)) [0..] input
 
 -- Global FCEs value so the expected output has the same FCEs as the partial function in createTest
 globalFces :: Float
@@ -49,13 +49,13 @@ modandModOrInputs = [
     ]
 
 concatModOrTests :: TestTree
-concatModOrTests = createTest concatModOr "joining ModOr with a delimiter" $ zip [0..] concatModOrInputs
+concatModOrTests = createTest concatModOr "joining ModOr with a delimiter" concatModOrInputs
 
 simpleModAndTests :: TestTree
-simpleModAndTests = createTest (stringifyModAnd globalFces) "ModAnd not containing ModOrs" $ zip [0..] simpleModAndInputs
+simpleModAndTests = createTest (stringifyModAnd globalFces) "ModAnd not containing ModOrs" simpleModAndInputs
 
 modandModOrTests :: TestTree
-modandModOrTests = createTest (stringifyModAnd globalFces) "ModAnd containing ModOrs" $ zip [0..] modandModOrInputs
+modandModOrTests = createTest (stringifyModAnd globalFces) "ModAnd containing ModOrs" modandModOrInputs
 
 -- functions for running tests in REPL
 modifierTestSuite :: TestTree

--- a/backend-test/RequirementTests/ModifierTests.hs
+++ b/backend-test/RequirementTests/ModifierTests.hs
@@ -10,12 +10,13 @@ module RequirementTests.ModifierTests
 
 import Database.Requirement
 import DynamicGraphs.GraphNodeUtils (concatModOr, stringifyModAnd)
-import Test.HUnit (Test (..), assertEqual)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => (a -> String) -> String -> [(a, String)] -> Test
-createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                TestCase $ assertEqual ("for (" ++ y ++ ")")
+createTest :: (Eq a, Show a) => (a -> String) -> String -> [(a, String)] -> TestTree
+createTest function label input = testGroup label $ map (\(x, y) ->
+                                testCase "" $ assertEqual ("for (" ++ y ++ ")")
                                 y (function x)) input
 
 -- Global FCEs value so the expected output has the same FCEs as the partial function in createTest
@@ -47,15 +48,15 @@ modandModOrInputs = [
     , ([ModOr [Level "300", Level "400"], ModOr [Department "CSC", Department "BCB"], Requirement (Raw "some raw text")], show globalFces ++ " CSC/BCB FCEs at the 300/400 level from some raw text")
     ]
 
-concatModOrTests :: Test
+concatModOrTests :: TestTree
 concatModOrTests = createTest concatModOr "joining ModOr with a delimiter" concatModOrInputs
 
-simpleModAndTests :: Test
+simpleModAndTests :: TestTree
 simpleModAndTests = createTest (stringifyModAnd globalFces) "ModAnd not containing ModOrs" simpleModAndInputs
 
-modandModOrTests :: Test
+modandModOrTests :: TestTree
 modandModOrTests = createTest (stringifyModAnd globalFces) "ModAnd containing ModOrs" modandModOrInputs
 
 -- functions for running tests in REPL
-modifierTestSuite :: Test
-modifierTestSuite = TestLabel "ReqParser tests" $ TestList [concatModOrTests, simpleModAndTests, modandModOrTests]
+modifierTestSuite :: TestTree
+modifierTestSuite = testGroup "ReqParser tests" [concatModOrTests, simpleModAndTests, modandModOrTests]

--- a/backend-test/RequirementTests/ModifierTests.hs
+++ b/backend-test/RequirementTests/ModifierTests.hs
@@ -14,10 +14,10 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => (a -> String) -> String -> [(a, String)] -> TestTree
-createTest function label input = testGroup label $ map (\(x, y) ->
-                                testCase "" $ assertEqual ("for (" ++ y ++ ")")
-                                y (function x)) input
+createTest :: (Eq a, Show a) => (a -> String) -> String -> [(Int, (a, String))] -> TestTree
+createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+                                testCase ("Test " ++ show x) $ assertEqual ("for (" ++ z ++ ")")
+                                z (function y)) input
 
 -- Global FCEs value so the expected output has the same FCEs as the partial function in createTest
 globalFces :: Float
@@ -49,13 +49,13 @@ modandModOrInputs = [
     ]
 
 concatModOrTests :: TestTree
-concatModOrTests = createTest concatModOr "joining ModOr with a delimiter" concatModOrInputs
+concatModOrTests = createTest concatModOr "joining ModOr with a delimiter" $ zip [0..] concatModOrInputs
 
 simpleModAndTests :: TestTree
-simpleModAndTests = createTest (stringifyModAnd globalFces) "ModAnd not containing ModOrs" simpleModAndInputs
+simpleModAndTests = createTest (stringifyModAnd globalFces) "ModAnd not containing ModOrs" $ zip [0..] simpleModAndInputs
 
 modandModOrTests :: TestTree
-modandModOrTests = createTest (stringifyModAnd globalFces) "ModAnd containing ModOrs" modandModOrInputs
+modandModOrTests = createTest (stringifyModAnd globalFces) "ModAnd containing ModOrs" $ zip [0..] modandModOrInputs
 
 -- functions for running tests in REPL
 modifierTestSuite :: TestTree

--- a/backend-test/RequirementTests/PostParserTests.hs
+++ b/backend-test/RequirementTests/PostParserTests.hs
@@ -11,16 +11,16 @@ module RequirementTests.PostParserTests
 import Data.Bifunctor (second)
 import qualified Data.Text as T
 import Database.DataType (PostType (..))
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import qualified Text.Parsec as Parsec
 import WebParsing.PostParser (getPostType, postInfoParser)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(Int, (a, b))] -> TestTree
-createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(a, b)] -> TestTree
+createTest function label input = testGroup label $ zipWith (\(x :: Int) (y, z) ->
                                 testCase ("Test " ++ show x) $ assertEqual ("for (" ++ show y ++ "),")
-                                z (function y)) input
+                                z (function y)) [0..] input
 
 -- | Input and output pair of each post
 -- | Output is in the order of (postDepartment, postCode, postName)
@@ -71,10 +71,10 @@ getPostTypeInputs = [
     ]
 
 postInfoTests :: TestTree
-postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ zip [0..] $ map (second Right) postInfoInputs
+postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ map (second Right) postInfoInputs
 
 getPostTypeTests :: TestTree
-getPostTypeTests = createTest (uncurry getPostType) "Post requirements" $ zip [0..] getPostTypeInputs
+getPostTypeTests = createTest (uncurry getPostType) "Post requirements" getPostTypeInputs
 
 -- functions for running tests in REPL
 postTestSuite :: TestTree

--- a/backend-test/RequirementTests/PostParserTests.hs
+++ b/backend-test/RequirementTests/PostParserTests.hs
@@ -17,10 +17,10 @@ import qualified Text.Parsec as Parsec
 import WebParsing.PostParser (getPostType, postInfoParser)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(a, b)] -> TestTree
-createTest function label input = testGroup label $ map (\(x, y) ->
-                                testCase "" $ assertEqual ("for (" ++ show x ++ "),")
-                                y (function x)) input
+createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(Int, (a, b))] -> TestTree
+createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+                                testCase ("Test " ++ show x) $ assertEqual ("for (" ++ show y ++ "),")
+                                z (function y)) input
 
 -- | Input and output pair of each post
 -- | Output is in the order of (postDepartment, postCode, postName)
@@ -71,10 +71,10 @@ getPostTypeInputs = [
     ]
 
 postInfoTests :: TestTree
-postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ map (second Right) postInfoInputs
+postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ zip [0..] $ map (second Right) postInfoInputs
 
 getPostTypeTests :: TestTree
-getPostTypeTests = createTest (uncurry getPostType) "Post requirements" getPostTypeInputs
+getPostTypeTests = createTest (uncurry getPostType) "Post requirements" $ zip [0..] getPostTypeInputs
 
 -- functions for running tests in REPL
 postTestSuite :: TestTree

--- a/backend-test/RequirementTests/PostParserTests.hs
+++ b/backend-test/RequirementTests/PostParserTests.hs
@@ -11,14 +11,15 @@ module RequirementTests.PostParserTests
 import Data.Bifunctor (second)
 import qualified Data.Text as T
 import Database.DataType (PostType (..))
-import Test.HUnit (Test (..), assertEqual)
+import Test.Tasty
+import Test.Tasty.HUnit
 import qualified Text.Parsec as Parsec
 import WebParsing.PostParser (getPostType, postInfoParser)
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(a, b)] -> Test
-createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                TestCase $ assertEqual ("for (" ++ show x ++ "),")
+createTest :: (Show a, Eq a, Show b, Eq b) => (a -> b) -> String -> [(a, b)] -> TestTree
+createTest function label input = testGroup label $ map (\(x, y) ->
+                                testCase "" $ assertEqual ("for (" ++ show x ++ "),")
                                 y (function x)) input
 
 -- | Input and output pair of each post
@@ -69,12 +70,12 @@ getPostTypeInputs = [
     , (("", "Certificate in Business"), Certificate)
     ]
 
-postInfoTests :: Test
+postInfoTests :: TestTree
 postInfoTests = createTest (Parsec.parse postInfoParser "") "Post requirements" $ map (second Right) postInfoInputs
 
-getPostTypeTests :: Test
+getPostTypeTests :: TestTree
 getPostTypeTests = createTest (uncurry getPostType) "Post requirements" getPostTypeInputs
 
 -- functions for running tests in REPL
-postTestSuite :: Test
-postTestSuite = TestLabel "PostParser tests" $ TestList [postInfoTests, getPostTypeTests]
+postTestSuite :: TestTree
+postTestSuite = testGroup "PostParser tests" [postInfoTests, getPostTypeTests]

--- a/backend-test/RequirementTests/PreProcessingTests.hs
+++ b/backend-test/RequirementTests/PreProcessingTests.hs
@@ -12,10 +12,10 @@ import Test.Tasty.HUnit
 import Text.HTML.TagSoup (Tag (..))
 import WebParsing.PostParser (pruneHtml)
 
-createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(a, b)] -> TestTree
-createTest function label input = testGroup label $ map (\(x, y) ->
-                                testCase "" $ assertEqual ("for (" ++ show y ++ ")")
-                                y (function x)) input
+createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(Int, (a, b))] -> TestTree
+createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+                                testCase ("Test " ++ show x) $ assertEqual ("for (" ++ show z ++ ")")
+                                z (function y)) input
 
 
 pruneHtmlInputs :: [([Tag T.Text], [Tag T.Text])]
@@ -35,7 +35,7 @@ pruneHtmlInputs = [
     ]
 
 pruneHtmlTests :: TestTree
-pruneHtmlTests = createTest pruneHtml "filtering out html attributes" pruneHtmlInputs
+pruneHtmlTests = createTest pruneHtml "filtering out html attributes" $ Prelude.zip [0..] pruneHtmlInputs
 
 -- functions for running tests in REPL
 preProcTestSuite :: TestTree

--- a/backend-test/RequirementTests/PreProcessingTests.hs
+++ b/backend-test/RequirementTests/PreProcessingTests.hs
@@ -7,13 +7,14 @@ module RequirementTests.PreProcessingTests
 ( preProcTestSuite ) where
 
 import Data.Text as T hiding (map)
-import Test.HUnit (Test (..), assertEqual)
+import Test.Tasty
+import Test.Tasty.HUnit
 import Text.HTML.TagSoup (Tag (..))
 import WebParsing.PostParser (pruneHtml)
 
-createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(a, b)] -> Test
-createTest function label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                TestCase $ assertEqual ("for (" ++ show y ++ ")")
+createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(a, b)] -> TestTree
+createTest function label input = testGroup label $ map (\(x, y) ->
+                                testCase "" $ assertEqual ("for (" ++ show y ++ ")")
                                 y (function x)) input
 
 
@@ -33,9 +34,9 @@ pruneHtmlInputs = [
     )
     ]
 
-pruneHtmlTests :: Test
+pruneHtmlTests :: TestTree
 pruneHtmlTests = createTest pruneHtml "filtering out html attributes" pruneHtmlInputs
 
 -- functions for running tests in REPL
-preProcTestSuite :: Test
-preProcTestSuite = TestLabel "Pre-processing tests" $ TestList [pruneHtmlTests]
+preProcTestSuite :: TestTree
+preProcTestSuite = testGroup "Pre-processing tests" [pruneHtmlTests]

--- a/backend-test/RequirementTests/PreProcessingTests.hs
+++ b/backend-test/RequirementTests/PreProcessingTests.hs
@@ -7,15 +7,15 @@ module RequirementTests.PreProcessingTests
 ( preProcTestSuite ) where
 
 import Data.Text as T hiding (map)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import Text.HTML.TagSoup (Tag (..))
 import WebParsing.PostParser (pruneHtml)
 
-createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(Int, (a, b))] -> TestTree
-createTest function label input = testGroup label $ map (\(x, (y, z)) ->
+createTest :: (Eq a, Show a, Eq b, Show b) => (a -> b) -> String -> [(a, b)] -> TestTree
+createTest function label input = testGroup label $ Prelude.zipWith (\(x :: Int) (y, z) ->
                                 testCase ("Test " ++ show x) $ assertEqual ("for (" ++ show z ++ ")")
-                                z (function y)) input
+                                z (function y)) [0..] input
 
 
 pruneHtmlInputs :: [([Tag T.Text], [Tag T.Text])]
@@ -35,7 +35,7 @@ pruneHtmlInputs = [
     ]
 
 pruneHtmlTests :: TestTree
-pruneHtmlTests = createTest pruneHtml "filtering out html attributes" $ Prelude.zip [0..] pruneHtmlInputs
+pruneHtmlTests = createTest pruneHtml "filtering out html attributes" pruneHtmlInputs
 
 -- functions for running tests in REPL
 preProcTestSuite :: TestTree

--- a/backend-test/RequirementTests/ReqParserTests.hs
+++ b/backend-test/RequirementTests/ReqParserTests.hs
@@ -9,22 +9,22 @@ module RequirementTests.ReqParserTests
 ( reqTestSuite ) where
 
 import Database.Requirement
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
 import WebParsing.ReqParser
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => Parser a -> String -> [(Int, (String, a))] -> TestTree
-createTest parser label input = testGroup label $ map (\(x, (y, z)) ->
+createTest :: (Eq a, Show a) => Parser a -> String -> [(String, a)] -> TestTree
+createTest parser label input = testGroup label $ zipWith (\(x :: Int) (y, z) ->
                                 testCase ("Test " ++ show x) $ assertEqual ("for (" ++ y ++ "),")
-                                (Right z) (Parsec.parse parser "" y)) input
+                                (Right z) (Parsec.parse parser "" y)) [0..] input
 
-createReqParserTest :: String -> [(Int, (String, Req))] -> TestTree
-createReqParserTest label input = testGroup label $ map (\(x, (y, z)) ->
+createReqParserTest :: String -> [(String, Req)] -> TestTree
+createReqParserTest label input = testGroup label $ zipWith (\(x :: Int) (y, z) ->
                                   testCase ("Test " ++ show x) $ assertEqual ("for (" ++ y ++ "),")
-                                  z (parseReqs y)) input
+                                  z (parseReqs y)) [0..] input
 
 orInputs :: [(String, Req)]
 orInputs = [
@@ -211,41 +211,41 @@ noPrereqInputs = [
     ]
 
 orTests :: TestTree
-orTests = createTest reqParser "Basic or Requirement" $ zip [0..] orInputs
+orTests = createTest reqParser "Basic or Requirement" orInputs
 
 andTests :: TestTree
-andTests = createTest reqParser "Basic and Requirement" $ zip [0..] andInputs
+andTests = createTest reqParser "Basic and Requirement" andInputs
 
 andorTests :: TestTree
-andorTests = createTest reqParser "Basic and-or-mixed Requirement" $ zip [0..] andorInputs
+andorTests = createTest reqParser "Basic and-or-mixed Requirement" andorInputs
 
 parTests :: TestTree
-parTests = createTest reqParser "Basic and-or-parenthesized Requirement" $ zip [0..] parInputs
+parTests = createTest reqParser "Basic and-or-parenthesized Requirement" parInputs
 
 fcesTests:: TestTree
-fcesTests = createTest reqParser "Basic fces Requirement" $ zip [0..] fcesInputs
+fcesTests = createTest reqParser "Basic fces Requirement" fcesInputs
 
 cgpaTests :: TestTree
-cgpaTests = createTest reqParser "Minimum cGpa Requirement" $ zip [0..] cgpaInputs
+cgpaTests = createTest reqParser "Minimum cGpa Requirement" cgpaInputs
 
 -- Outdated
 -- fromParTests :: Test
 -- fromParTests = createTest reqParser "Paranthesized From Requirements with integer or float fces" fromParInputs
 
 gradeBefTests :: TestTree
-gradeBefTests = createTest reqParser "Basic grade requirements which come before." $ zip [0..] gradeBefInputs
+gradeBefTests = createTest reqParser "Basic grade requirements which come before." gradeBefInputs
 
 gradeAftTests :: TestTree
-gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." $ zip [0..] gradeAftInputs
+gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." gradeAftInputs
 
 artSciTests :: TestTree
-artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" $ zip [0..] artSciInputs
+artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" artSciInputs
 
 programOrTests :: TestTree
-programOrTests = createTest reqParser "program requirements" $ zip [0..] programOrInputs
+programOrTests = createTest reqParser "program requirements" programOrInputs
 
 noPrereqTests :: TestTree
-noPrereqTests = createReqParserTest "No prerequisites required" $ zip [0..] noPrereqInputs
+noPrereqTests = createReqParserTest "No prerequisites required" noPrereqInputs
 
 -- functions for running tests in REPL
 reqTestSuite :: TestTree

--- a/backend-test/RequirementTests/ReqParserTests.hs
+++ b/backend-test/RequirementTests/ReqParserTests.hs
@@ -9,20 +9,22 @@ module RequirementTests.ReqParserTests
 ( reqTestSuite ) where
 
 import Database.Requirement
-import Test.HUnit (Test (..), assertEqual)
+import Test.Tasty
+import Test.Tasty.HUnit
 import qualified Text.Parsec as Parsec
 import Text.Parsec.String (Parser)
 import WebParsing.ReqParser
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => Parser a -> String -> [(String, a)] -> Test
-createTest parser label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                TestCase $ assertEqual ("for (" ++ x ++ "),")
+createTest :: (Eq a, Show a) => Parser a -> String -> [(String, a)] -> TestTree
+createTest parser label input = testGroup label $ map (\(x, y) ->
+                                testCase "" $ assertEqual ("for (" ++ x ++ "),")
                                 (Right y) (Parsec.parse parser "" x)) input
 
-createReqParserTest :: String -> [(String, Req)] -> Test
-createReqParserTest label input = TestLabel label $ TestList $ map (\(x, y) ->
-                                  TestCase $ assertEqual ("for (" ++ x ++ "),") y (parseReqs x)) input
+createReqParserTest :: String -> [(String, Req)] -> TestTree
+createReqParserTest label input = testGroup label $ map (\(x, y) ->
+                                  testCase "" $ assertEqual ("for (" ++ x ++ "),")
+                                  y (parseReqs x)) input
 
 orInputs :: [(String, Req)]
 orInputs = [
@@ -208,43 +210,43 @@ noPrereqInputs = [
     , ("no", None)
     ]
 
-orTests :: Test
+orTests :: TestTree
 orTests = createTest reqParser "Basic or Requirement" orInputs
 
-andTests :: Test
+andTests :: TestTree
 andTests = createTest reqParser "Basic and Requirement" andInputs
 
-andorTests :: Test
+andorTests :: TestTree
 andorTests = createTest reqParser "Basic and-or-mixed Requirement" andorInputs
 
-parTests :: Test
+parTests :: TestTree
 parTests = createTest reqParser "Basic and-or-parenthesized Requirement" parInputs
 
-fcesTests:: Test
+fcesTests:: TestTree
 fcesTests = createTest reqParser "Basic fces Requirement" fcesInputs
 
-cgpaTests :: Test
+cgpaTests :: TestTree
 cgpaTests = createTest reqParser "Minimum cGpa Requirement" cgpaInputs
 
 -- Outdated
 -- fromParTests :: Test
 -- fromParTests = createTest reqParser "Paranthesized From Requirements with integer or float fces" fromParInputs
 
-gradeBefTests :: Test
+gradeBefTests :: TestTree
 gradeBefTests = createTest reqParser "Basic grade requirements which come before." gradeBefInputs
 
-gradeAftTests :: Test
+gradeAftTests :: TestTree
 gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." gradeAftInputs
 
-artSciTests :: Test
+artSciTests :: TestTree
 artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" artSciInputs
 
-programOrTests :: Test
+programOrTests :: TestTree
 programOrTests = createTest reqParser "program requirements" programOrInputs
 
-noPrereqTests :: Test
+noPrereqTests :: TestTree
 noPrereqTests = createReqParserTest "No prerequisites required" noPrereqInputs
 
 -- functions for running tests in REPL
-reqTestSuite :: Test
-reqTestSuite = TestLabel "ReqParser tests" $ TestList [orTests, andTests, andorTests, parTests, fcesTests, gradeBefTests, gradeAftTests, artSciTests, programOrTests, cgpaTests, noPrereqTests]
+reqTestSuite :: TestTree
+reqTestSuite = testGroup "ReqParser tests" [orTests, andTests, andorTests, parTests, fcesTests, gradeBefTests, gradeAftTests, artSciTests, programOrTests, cgpaTests, noPrereqTests]

--- a/backend-test/RequirementTests/ReqParserTests.hs
+++ b/backend-test/RequirementTests/ReqParserTests.hs
@@ -16,15 +16,15 @@ import Text.Parsec.String (Parser)
 import WebParsing.ReqParser
 
 -- Function to facilitate test case creation given a string, Req tuple
-createTest :: (Eq a, Show a) => Parser a -> String -> [(String, a)] -> TestTree
-createTest parser label input = testGroup label $ map (\(x, y) ->
-                                testCase "" $ assertEqual ("for (" ++ x ++ "),")
-                                (Right y) (Parsec.parse parser "" x)) input
+createTest :: (Eq a, Show a) => Parser a -> String -> [(Int, (String, a))] -> TestTree
+createTest parser label input = testGroup label $ map (\(x, (y, z)) ->
+                                testCase ("Test " ++ show x) $ assertEqual ("for (" ++ y ++ "),")
+                                (Right z) (Parsec.parse parser "" y)) input
 
-createReqParserTest :: String -> [(String, Req)] -> TestTree
-createReqParserTest label input = testGroup label $ map (\(x, y) ->
-                                  testCase "" $ assertEqual ("for (" ++ x ++ "),")
-                                  y (parseReqs x)) input
+createReqParserTest :: String -> [(Int, (String, Req))] -> TestTree
+createReqParserTest label input = testGroup label $ map (\(x, (y, z)) ->
+                                  testCase ("Test " ++ show x) $ assertEqual ("for (" ++ y ++ "),")
+                                  z (parseReqs y)) input
 
 orInputs :: [(String, Req)]
 orInputs = [
@@ -211,41 +211,41 @@ noPrereqInputs = [
     ]
 
 orTests :: TestTree
-orTests = createTest reqParser "Basic or Requirement" orInputs
+orTests = createTest reqParser "Basic or Requirement" $ zip [0..] orInputs
 
 andTests :: TestTree
-andTests = createTest reqParser "Basic and Requirement" andInputs
+andTests = createTest reqParser "Basic and Requirement" $ zip [0..] andInputs
 
 andorTests :: TestTree
-andorTests = createTest reqParser "Basic and-or-mixed Requirement" andorInputs
+andorTests = createTest reqParser "Basic and-or-mixed Requirement" $ zip [0..] andorInputs
 
 parTests :: TestTree
-parTests = createTest reqParser "Basic and-or-parenthesized Requirement" parInputs
+parTests = createTest reqParser "Basic and-or-parenthesized Requirement" $ zip [0..] parInputs
 
 fcesTests:: TestTree
-fcesTests = createTest reqParser "Basic fces Requirement" fcesInputs
+fcesTests = createTest reqParser "Basic fces Requirement" $ zip [0..] fcesInputs
 
 cgpaTests :: TestTree
-cgpaTests = createTest reqParser "Minimum cGpa Requirement" cgpaInputs
+cgpaTests = createTest reqParser "Minimum cGpa Requirement" $ zip [0..] cgpaInputs
 
 -- Outdated
 -- fromParTests :: Test
 -- fromParTests = createTest reqParser "Paranthesized From Requirements with integer or float fces" fromParInputs
 
 gradeBefTests :: TestTree
-gradeBefTests = createTest reqParser "Basic grade requirements which come before." gradeBefInputs
+gradeBefTests = createTest reqParser "Basic grade requirements which come before." $ zip [0..] gradeBefInputs
 
 gradeAftTests :: TestTree
-gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." gradeAftInputs
+gradeAftTests = createTest reqParser "Basic grade requirements, where grades come after." $ zip [0..] gradeAftInputs
 
 artSciTests :: TestTree
-artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" artSciInputs
+artSciTests = createTest reqParser "Arts and Science requirements from Christine's output" $ zip [0..] artSciInputs
 
 programOrTests :: TestTree
-programOrTests = createTest reqParser "program requirements" programOrInputs
+programOrTests = createTest reqParser "program requirements" $ zip [0..] programOrInputs
 
 noPrereqTests :: TestTree
-noPrereqTests = createReqParserTest "No prerequisites required" noPrereqInputs
+noPrereqTests = createReqParserTest "No prerequisites required" $ zip [0..] noPrereqInputs
 
 -- functions for running tests in REPL
 reqTestSuite :: TestTree

--- a/backend-test/RequirementTests/RequirementTests.hs
+++ b/backend-test/RequirementTests/RequirementTests.hs
@@ -13,7 +13,6 @@ import RequirementTests.PostParserTests (postTestSuite)
 import RequirementTests.PreProcessingTests (preProcTestSuite)
 import RequirementTests.ReqParserTests (reqTestSuite)
 import Test.Tasty
-import Test.Tasty.HUnit
 
 -- Single test encompassing all requirement test suites
 requirementTests :: TestTree

--- a/backend-test/RequirementTests/RequirementTests.hs
+++ b/backend-test/RequirementTests/RequirementTests.hs
@@ -12,7 +12,7 @@ import RequirementTests.ModifierTests (modifierTestSuite)
 import RequirementTests.PostParserTests (postTestSuite)
 import RequirementTests.PreProcessingTests (preProcTestSuite)
 import RequirementTests.ReqParserTests (reqTestSuite)
-import Test.Tasty
+import Test.Tasty (TestTree, testGroup)
 
 -- Single test encompassing all requirement test suites
 requirementTests :: TestTree

--- a/backend-test/RequirementTests/RequirementTests.hs
+++ b/backend-test/RequirementTests/RequirementTests.hs
@@ -8,12 +8,13 @@ Module that contains the test suites for all the requirement tests.
 module RequirementTests.RequirementTests
 (  requirementTests  ) where
 
-import Test.HUnit (Test (..))
 import RequirementTests.ModifierTests (modifierTestSuite)
 import RequirementTests.PostParserTests (postTestSuite)
 import RequirementTests.PreProcessingTests (preProcTestSuite)
 import RequirementTests.ReqParserTests (reqTestSuite)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- Single test encompassing all requirement test suites
-requirementTests :: Test
-requirementTests = TestList [reqTestSuite, postTestSuite, preProcTestSuite, modifierTestSuite]
+requirementTests :: TestTree
+requirementTests = testGroup "Requirements" [modifierTestSuite, preProcTestSuite, postTestSuite, reqTestSuite]

--- a/backend-test/SvgTests/IntersectionTests.hs
+++ b/backend-test/SvgTests/IntersectionTests.hs
@@ -12,8 +12,8 @@ import Database.DataType (ShapeType (..))
 import Database.Persist.Sqlite (toSqlKey)
 import Database.Tables (Path (..), Shape (..), Text (..))
 import Svg.Builder (buildEllipses, buildPath, buildRect, intersectsWithShape)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 
 -- * Mocks
 

--- a/backend-test/SvgTests/IntersectionTests.hs
+++ b/backend-test/SvgTests/IntersectionTests.hs
@@ -7,12 +7,13 @@ Module that contains the tests for intersection checks in the SVG Builder module
 
 module SvgTests.IntersectionTests (intersectionTestSuite) where
 
-import Svg.Builder (buildRect, buildEllipses, buildPath, intersectsWithShape)
-import Database.Tables (Text(..), Shape(..), Path(..))
-import Database.DataType (ShapeType(..))
 import qualified Data.Text as T
-import Test.HUnit (Test(..), assertEqual, assertBool)
+import Database.DataType (ShapeType (..))
 import Database.Persist.Sqlite (toSqlKey)
+import Database.Tables (Path (..), Shape (..), Text (..))
+import Svg.Builder (buildEllipses, buildPath, buildRect, intersectsWithShape)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- * Mocks
 
@@ -456,39 +457,39 @@ testShapeBuilder :: ([Text] -> Shape -> Integer -> Shape)
                  -> String
                  -> String
                  -> ((Integer, [Text], Shape), (T.Text, [Text]), String)
-                 -> Test
+                 -> TestTree
 testShapeBuilder fn label shapeLabel input =
     let ((elementId, texts, rect), (expectedId_, expectedTexts), testLabel) = input
         result = fn texts rect elementId
-    in TestLabel (label ++ testLabel) $ TestCase $ do
+    in testCase (label ++ testLabel) $ do
         assertEqual ("Check id_ failed for " ++ shapeLabel ++ " " ++ show elementId) expectedId_ $ shapeId_ result
         assertBool ("Check texts failed for " ++ shapeLabel ++ " " ++ show elementId) $ compareTexts expectedTexts $ shapeText result
 
 -- Function for testing a intersectsWithShape test case
 testIntersectsWithShape :: String
                         -> ((Integer, Text, [Shape]), Bool, String)
-                        -> Test
+                        -> TestTree
 testIntersectsWithShape label input =
     let ((testId, text, shapes), expected, testLabel) = input
         actual = intersectsWithShape shapes text
-    in TestLabel (label ++ testLabel) $ TestCase $ do
+    in testCase (label ++ testLabel) $ do
         assertEqual ("Check intersection failed for case " ++ show testId) expected actual
 
 -- Function for testing a buildPath test case
 testBuildPath :: String
               -> ((Integer, Path, [Shape], [Shape]), (T.Text, T.Text, T.Text), String)
-              -> Test
+              -> TestTree
 testBuildPath label input =
     let ((elementId, path, rects, ellipses), (expectedId_, expectedSource, expectedTarget), testLabel) = input
         result = buildPath rects ellipses path elementId
-    in TestLabel (label ++ testLabel) $ TestCase $ do
+    in testCase (label ++ testLabel) $ do
         assertEqual ("Check id_ failed for path " ++ show elementId) expectedId_ $ pathId_ result
         assertEqual ("Check source node failed for path " ++ show elementId) expectedSource $ pathSource result
         assertEqual ("Check target node failed for path " ++ show elementId) expectedTarget $ pathTarget result
 
 
 -- Run all test cases for buildRect
-runBuildRectTests :: [Test]
+runBuildRectTests :: [TestTree]
 runBuildRectTests =
     map (testShapeBuilder buildRect "Test buildRect no transformation: " "rect") buildRectNoTransformInputs ++
     map (testShapeBuilder buildRect "Test buildRect translation: " "rect") buildRectTranslationInputs ++
@@ -497,7 +498,7 @@ runBuildRectTests =
     map (testShapeBuilder buildRect "Test buildRect mixed transformations: " "rect") buildRectMixedInputs
 
 -- Run all test cases for buildEllipses
-runBuildEllipsesTests :: [Test]
+runBuildEllipsesTests :: [TestTree]
 runBuildEllipsesTests =
     map (testShapeBuilder buildEllipses "Test buildEllipses no transformation: " "ellipse") buildEllipsesNoTransformationInputs ++
     map (testShapeBuilder buildEllipses "Test buildEllipses translation: " "ellipse") buildEllipsesTranslationInputs ++
@@ -506,7 +507,7 @@ runBuildEllipsesTests =
     map (testShapeBuilder buildEllipses "Test buildEllipses mixed transformations: " "ellipse") buildEllipsesMixedInputs
 
 -- Run all test cases for buildPath
-runIntersectsWithShape :: [Test]
+runIntersectsWithShape :: [TestTree]
 runIntersectsWithShape =
     map (testIntersectsWithShape "Test intersectsWithShape no transformation: ") intersectsWithShapeNoTransformationInputs ++
     map (testIntersectsWithShape "Test intersectsWithShape translation: ") intersectsWithShapeTranslationInputs ++
@@ -515,7 +516,7 @@ runIntersectsWithShape =
     map (testIntersectsWithShape "Test intersectsWithShape mixed transformations: ") intersectsWithShapeMixedInputs
 
 -- Run all test cases for buildPath
-runBuildPathTests :: [Test]
+runBuildPathTests :: [TestTree]
 runBuildPathTests =
     map (testBuildPath "Test buildPath no transformation: ") buildPathNoTransformationInputs ++
     map (testBuildPath "Test buildPath translation: ") buildPathTranslationInputs ++
@@ -525,6 +526,6 @@ runBuildPathTests =
 
 
 -- Test suite for intersection checks
-intersectionTestSuite :: Test
-intersectionTestSuite = TestLabel "Intersection tests" $
-    TestList $ runBuildRectTests ++ runBuildEllipsesTests ++ runIntersectsWithShape ++ runBuildPathTests
+intersectionTestSuite :: TestTree
+intersectionTestSuite = testGroup "Intersection tests" $
+    runBuildRectTests ++ runBuildEllipsesTests ++ runIntersectsWithShape ++ runBuildPathTests

--- a/backend-test/SvgTests/SvgTests.hs
+++ b/backend-test/SvgTests/SvgTests.hs
@@ -8,7 +8,7 @@ Module that contains the test suites for all the SVG tests.
 module SvgTests.SvgTests (svgTests) where
 
 import SvgTests.IntersectionTests (intersectionTestSuite)
-import Test.Tasty
+import Test.Tasty (TestTree, testGroup)
 
 -- Single test encompassing all svg test suites
 svgTests :: TestTree

--- a/backend-test/SvgTests/SvgTests.hs
+++ b/backend-test/SvgTests/SvgTests.hs
@@ -7,9 +7,10 @@ Module that contains the test suites for all the SVG tests.
 
 module SvgTests.SvgTests (svgTests) where
 
-import Test.HUnit (Test (..))
 import SvgTests.IntersectionTests (intersectionTestSuite)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- Single test encompassing all svg test suites
-svgTests :: Test
-svgTests = TestList [intersectionTestSuite]
+svgTests :: TestTree
+svgTests = testGroup "Svg" [intersectionTestSuite]

--- a/backend-test/SvgTests/SvgTests.hs
+++ b/backend-test/SvgTests/SvgTests.hs
@@ -9,7 +9,6 @@ module SvgTests.SvgTests (svgTests) where
 
 import SvgTests.IntersectionTests (intersectionTestSuite)
 import Test.Tasty
-import Test.Tasty.HUnit
 
 -- Single test encompassing all svg test suites
 svgTests :: TestTree

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -125,7 +125,6 @@ test-suite Tests
     courseography,
     directory,
     happstack-server,
-    HUnit,
     parsec,
     persistent-sqlite,
     QuickCheck,

--- a/courseography.cabal
+++ b/courseography.cabal
@@ -130,6 +130,8 @@ test-suite Tests
     persistent-sqlite,
     QuickCheck,
     tagsoup,
+    tasty >=1.5.3,
+    tasty-hunit,
     test-framework,
     test-framework-hunit,
     test-framework-quickcheck2,


### PR DESCRIPTION
## Proposed Changes

Refactors tests to use `tasty` and `tasty-hunit` instead of `HUnit`. `tasty` is more modern and has a much nicer console output!

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

New console output:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/0a879966-6414-41b5-98e1-95e5e7defed1" />

Old console output:

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/243e586f-055d-4b03-bc8f-9537f2301eef" />

The new output with `tasty` includes labels for each test and indicates which ones passed/failed much more clearly.

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |     x    |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the list of contributors.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Hi Professor! Hope you're doing well. I've refactored the tests, but I'm not sure how I should handle some test cases/assertions under `RequirementTests` that don't come with a label. I have temporarily passed in an empty string for such cases but it makes the console output look a bit strange (results in a wall of `:`s):

<details>

<img width="908" alt="image" src="https://github.com/user-attachments/assets/1e942d55-3ea7-45c0-8a88-db9ccee77a63" />

</details>

I'll leave a comment in the code for an example of what I'm talking about - please let me know if this is alright, or if I should look into ways to fix this!
