### PR TITLE
Extraneous InfoBox on Generate Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed a bug that was causing the focus info popup to appear blank
 - Fixed a bug on the generate page causing extraneous ellipses to appear when hovering over a course to highlight its prerequisites
+- Fixed a bug on the generate page where an extraneous info popup would appear when hovering over the top left corner of the graph viewing window
 
 ### 🔧 Internal changes
 

--- a/js/components/graph/InfoBox.js
+++ b/js/components/graph/InfoBox.js
@@ -3,6 +3,11 @@ import PropTypes from "prop-types"
 
 export default class InfoBox extends React.Component {
   render() {
+    // guard against rendering with no course
+    if (!this.props.nodeId) {
+      return null
+    }
+
     const className = this.props.showInfoBox
       ? "tooltip-group-display"
       : "tooltip-group-hidden"

--- a/js/components/graph/__tests__/InfoBox.test.js
+++ b/js/components/graph/__tests__/InfoBox.test.js
@@ -11,7 +11,7 @@ describe("InfoBox", () => {
       onClick: jest.fn(),
       onMouseDown: jest.fn(),
       onMouseLeave: jest.fn(),
-      nodeId: "",
+      nodeId: "aaa100",
       showInfoBox: false,
       xPos: 0,
       yPos: 0,
@@ -26,9 +26,8 @@ describe("InfoBox", () => {
     const graph = await TestGraph.build()
     const aaa100 = graph.getByTestId("aaa100")
 
-    const infoBox = graph.getNodeByText("Info")
-    expect(infoBox.classList.contains("tooltip-group-hidden")).toBe(true)
     await user.hover(aaa100)
+    const infoBox = graph.getNodeByText("Info")
     expect(infoBox.classList.contains("tooltip-group-display")).toBe(true)
   })
 
@@ -75,5 +74,10 @@ describe("InfoBox", () => {
     await waitFor(() => {
       expect(graph.textExists(/AAA Thinking/)).toBe(true)
     })
+  })
+
+  it("should not render when no course is active (infoBoxNodeId is empty)", async () => {
+    const graph = await TestGraph.build()
+    expect(graph.rtlGraph.queryByText("Info")).toBeNull()
   })
 })

--- a/js/components/graph/__tests__/__snapshots__/InfoBox.test.js.snap
+++ b/js/components/graph/__tests__/__snapshots__/InfoBox.test.js.snap
@@ -8,7 +8,7 @@ exports[`InfoBox should match snapshot 1`] = `
   <rect
     fill="white"
     height="30"
-    id="-tooltip-rect"
+    id="aaa100-tooltip-rect"
     rx="4"
     ry="4"
     stroke="black"
@@ -18,7 +18,7 @@ exports[`InfoBox should match snapshot 1`] = `
     y="0"
   />
   <text
-    id="-tooltip-text"
+    id="aaa100-tooltip-text"
     x="12"
     y="21"
   >


### PR DESCRIPTION
## Proposed Changes

This change fixes a bug where an extraneous info box popup would appear on the top left corner of the generate page when initially loaded. 

### The Issue 

On initial load of the generate page, hovering over the top left corner of the graph view window would open an info box popup for a phantom course.

<img width="1920" height="904" alt="Screenshot (60)" src="https://github.com/user-attachments/assets/8bcdd2ee-54c8-4071-a784-b7909e03056f" />

This popup contained no information when clicked.

<img width="1920" height="898" alt="Screenshot (61)" src="https://github.com/user-attachments/assets/bac587d3-e3b8-46a7-a364-958e801990bf" />

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |    X      |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [N/A] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [N/A] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [X] I have verified that the CircleCI checks have passed.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.
