### PR TITLE
Change background colour of application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed CSS styling to match the background colour of application with the graph
+
 ### 🔧 Internal changes
 
 - Refactored the `Courses` table to `Course` with a database migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed CSS styling to match the background colour of application with the graph
+- Fixed CSS styling of background colour and let the application have full height
 
 ### 🔧 Internal changes
 

--- a/style/app.scss
+++ b/style/app.scss
@@ -65,6 +65,7 @@ html {
 }
 
 body {
+  background-color: #f0f8f5;
   color: #222;
   font-family: "Trebuchet MS", Arial, sans-serif;
   font-size: 17pt;

--- a/style/app.scss
+++ b/style/app.scss
@@ -512,7 +512,7 @@ ol {
 
 #container {
   background: #f0f5f8;
-  height: calc(100% - 50px);
+  height: 100%;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
## Proposed Changes

This PR adds a background colour to the body HTML tag, changing it from white to light-grey. It changes the background in `/graph` and `/about` to be the same as the current background colour of the graph (as defined in the div with `id = 'container'`).  

This PR fixes the issue of an OSS mismatch at the bottom of the `/graph` page, that occurs because the application background colour (none, defaults to white) is not the same as the graph background colour (light-grey). 

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |   X      |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [X] I have verified that the CircleCI checks have passed.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

I noticed that there is a div with an id of `container`, which has a height of `calc(100% - 50px)`. I found that it was created using Blaze for the `/graph` webpage, along with a div with an id of `navbar`. Originally, I thought the 50px was for the navbar, but the NavBar is actually a React component placed inside the `container` div. I tried deleting the 50px, letting the height be 100%, and the white part at the bottom of the `/graph` disappeared. This could be a potential solution for the background colour change, without changing the background of the `/about` page. I tried tracing where the 50px came from, which I found it was originally `- 100px`, and I believe 50px for the navbar and 50px for the disclaimer (later moved). I'm not sure if this is a bug, or if it was intentional and I should leave it alone. 