### PR TITLE
Fix scrollbar bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed CSS styling of background colour and let the application have full height
+- Fixed a bug regarding the scrollbar appearing on the /graph and /generate pages
 
 ### 🔧 Internal changes
 

--- a/js/components/generate/GenerateForm.js
+++ b/js/components/generate/GenerateForm.js
@@ -324,7 +324,9 @@ export default class GenerateForm extends React.Component {
     return (
       <>
         <NavBar selected_page="generate" open_modal={undefined}></NavBar>
-        <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>
+        <div
+          style={{ display: "flex", flexDirection: "row", height: "calc(100% - 50px)" }}
+        >
           <Disclaimer />
           <div
             id="generateDiv"

--- a/style/app.scss
+++ b/style/app.scss
@@ -439,7 +439,7 @@ ol {
 
 #react-graph {
   display: inline-block;
-  height: 100%;
+  height: calc(100% - 50px);
   margin: 0;
   overflow: hidden;
   position: absolute;
@@ -2013,6 +2013,7 @@ div[id*="_inq"] .code::after {
 
 #generateRoot #react-graph {
   position: static;
+  height: 100%;
   background-color: #f0f5f8;
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR removes the scrollbar on the /graph and /generate webpages, which appeared because the page content overflowed by 50px (from the navbar height) past the viewport. 

This PR decreases the height of the div with id of `react-graph`, which holds the svg graph, to account for the 50px navbar. This change affects the /graph and /draw webpage. It fixes the scrollbar on the /graph webpage, but does not fix the remaining 50px overflow on the /draw webpage (because the about-div takes up another 50px). However, because the svg graph in /generate is held on the same level as another div, the height of the parent div was changed instead. Thus, at 100% zoom, the webpages should fit on the screen with no overflow. 

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |        X |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [X] I have verified that the CircleCI checks have passed.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
