### PR TITLE
Fix MAT237 prerequisite parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed support for year-long ("Y" session) courses
 - Introduced `getShapesMinXY` in `js/components/graph/Graph.js` to fix graph centering in Generate page
 - Fixed course node dimensions and centering in Generate graph to match main graph
+- Fixed MAT237 prerequisite parsing by enabling `lParen` and `rParen` in `WebParsing.ReqParser` to handle square brackets
 
 ### 🔧 Internal changes
 

--- a/app/WebParsing/ReqParser.hs
+++ b/app/WebParsing/ReqParser.hs
@@ -127,10 +127,10 @@ includingSeparator =
         >> caseInsensitiveStr "including"
 
 lParen :: Parser Char
-lParen = Parsec.char '('
+lParen = Parsec.char '(' <|> Parsec.char '['
 
 rParen :: Parser Char
-rParen = Parsec.char ')'
+rParen = Parsec.char ')' <|> Parsec.char ']'
 
 orSeparator :: Parser String
 orSeparator =

--- a/backend-test/RequirementTests/ReqParserTests.hs
+++ b/backend-test/RequirementTests/ReqParserTests.hs
@@ -112,7 +112,7 @@ bracketInputs :: [(String, Req)]
 bracketInputs =
     [ ("[CSC108H1/CSC148H1]/CSC110Y1", ReqOr [J "CSC108H1" "", J "CSC148H1" "", J "CSC110Y1" ""])
     , ("[CSC108H1, CSC148H1]/CSC110Y1", ReqOr [ReqAnd [J "CSC108H1" "", J "CSC148H1" ""], J "CSC110Y1" ""])
-    , ("MAT237Y1/[MAT223H1/MAT240H1]", ReqOr [J "MAT237Y1" "", J "MAT223H1" "", J "MAT240H1" ""])
+    , ("MAT237Y1, [MAT223H1/MAT240H1]", ReqAnd [J "MAT237Y1" "", ReqOr [J "MAT223H1" "", J "MAT240H1" ""]])
     ,
         ( "[(MAT135H1, MAT136H1)/MAT137Y1], MAT223H1"
         , ReqAnd [ReqOr [ReqAnd [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" ""], J "MAT223H1" ""]

--- a/backend-test/RequirementTests/ReqParserTests.hs
+++ b/backend-test/RequirementTests/ReqParserTests.hs
@@ -108,6 +108,25 @@ parInputs =
         )
     ]
 
+bracketInputs :: [(String, Req)]
+bracketInputs =
+    [ ("[CSC108H1/CSC148H1]/CSC110Y1", ReqOr [J "CSC108H1" "", J "CSC148H1" "", J "CSC110Y1" ""])
+    , ("[CSC108H1, CSC148H1]/CSC110Y1", ReqOr [ReqAnd [J "CSC108H1" "", J "CSC148H1" ""], J "CSC110Y1" ""])
+    , ("MAT237Y1/[MAT223H1/MAT240H1]", ReqOr [J "MAT237Y1" "", J "MAT223H1" "", J "MAT240H1" ""])
+    ,
+        ( "[(MAT135H1, MAT136H1)/MAT137Y1], MAT223H1"
+        , ReqAnd [ReqOr [ReqAnd [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" ""], J "MAT223H1" ""]
+        )
+    ,
+        ( "[MAT133H1/[MAT135H1, MAT136H1]]/MAT137Y1"
+        , ReqOr [J "MAT133H1" "", ReqAnd [J "MAT135H1" "", J "MAT136H1" ""], J "MAT137Y1" ""]
+        )
+    ,
+        ( "[CSC148H1 with a minimum grade of 63%], CSC165H1"
+        , ReqAnd [Grade "63" (J "CSC148H1" ""), J "CSC165H1" ""]
+        )
+    ]
+
 fcesInputs :: [(String, Req)]
 fcesInputs =
     [ ("1.0 FCE from the following: (CSC148H1)", Fces 1.0 $ Requirement $ J "CSC148H1" "")
@@ -417,6 +436,9 @@ andorTests = createTest reqParser "Basic and-or-mixed Requirement" andorInputs
 parTests :: TestTree
 parTests = createTest reqParser "Basic and-or-parenthesized Requirement" parInputs
 
+bracketTests :: TestTree
+bracketTests = createTest reqParser "Square-bracketed Requirement" bracketInputs
+
 fcesTests :: TestTree
 fcesTests = createTest reqParser "Basic fces Requirement" fcesInputs
 
@@ -451,6 +473,7 @@ test_requirements =
         , andTests
         , andorTests
         , parTests
+        , bracketTests
         , fcesTests
         , gradeBefTests
         , gradeAftTests


### PR DESCRIPTION
## Proposed Changes

This pull request fixes the prerequisite parsing for MAT237 by enabling the `lParen` and `rParen` functions in `WebParsing.ReqParser` to handle square brackets. This PR closes https://github.com/Courseography/courseography/issues/1285.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>
<img width="1512" height="860" alt="Screenshot 2026-07-30 at 1 23 47 PM" src="https://github.com/user-attachments/assets/f1a85f6b-c1ef-4890-9720-1f1d538e59fa" /> (before)
<img width="1512" height="860" alt="Screenshot 2026-07-30 at 1 46 54 PM" src="https://github.com/user-attachments/assets/7c93d545-ede3-45d4-bfd4-da2f8ae64bb4" /> (after)
</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |X         |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

I also noticed there's an error in the prerequisite parsing for MAT309 due to the MAT1581 typo in the database/UofT Academic Calendar. How should we handle this?
