### PR TITLE
Fix "Corequisite" field not showing up in the course info modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed course node dimensions and centering in Generate graph to match main graph
 - Fixed the positions of the Theory of Computing and Artificial Intelligence labels
 - Fixed MAT237 prerequisite parsing by enabling `lParen` and `rParen` in `WebParsing.ReqParser` to handle square brackets
+- Fixed "Corequisite" field not showing up in the course info modal
 
 ### 🔧 Internal changes
 

--- a/js/components/common/react_modal.js.jsx
+++ b/js/components/common/react_modal.js.jsx
@@ -106,7 +106,7 @@ class CourseModal extends React.Component {
             ...course,
             description: this.convertToLink(course.description),
             prereqString: this.convertToLink(course.prereqString),
-            coreqs: this.convertToLink(course.coreq),
+            coreqs: this.convertToLink(course.coreqs),
             prep: this.convertToLink(course.prep),
             exclusions: this.convertToLink(course.exclusions),
           }


### PR DESCRIPTION
## Proposed Changes

Fixes the Corequisite field being missing in the course info modal.

...

<details>
<summary>Screenshots of your changes</summary>
before:
<img width="2220" height="520" alt="image" src="https://github.com/user-attachments/assets/cf40d9f3-dd7e-4da8-ad1d-6361ca4334fd" />


after:
<img width="2228" height="584" alt="image" src="https://github.com/user-attachments/assets/913d1ff9-77b1-4769-a138-2a8437b7cbc5" />

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X       |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the list of contributors.
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
