### PR TITLE
Fix dynamic graph centering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Updated `react-leaflet` to v5.0.0 and `@eslint/compat` to v2.1.0
 - Added peer dependency overrides for `eslint-plugin-react` (for `eslint` v10) and `@babel/plugin-syntax-*` (for `@babel/core` v8.0.1
 - Set `NODE_ENV=production` for webpack `build` command
-- Fixed dynamic graph centering bug by updating `parseTransform` in `app/Svg/Parser.hs` to parade multiple transform strings and removing `getShapesMinXY` in `js/components/graph/Graph.js`
+- Fixed dynamic graph centering bug by updating `parseTransform` in `app/Svg/Parser.hs` to parse multiple transform functions and removing `getShapesMinXY` in `js/components/graph/Graph.js`
 
 ## [0.8.1] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Updated `react-leaflet` to v5.0.0 and `@eslint/compat` to v2.1.0
 - Added peer dependency overrides for `eslint-plugin-react` (for `eslint` v10) and `@babel/plugin-syntax-*` (for `@babel/core` v8.0.1
 - Set `NODE_ENV=production` for webpack `build` command
+- Fixed dynamic graph centering bug by updating `parseTransform` in `app/Svg/Parser.hs` to parade multiple transform strings and removing `getShapesMinXY` in `js/components/graph/Graph.js`
 
 ## [0.8.1] - 2026-08-10
 

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -496,8 +496,8 @@ styleVal nameStr styleMap = fromMaybe "" $ lookup nameStr styleMap
 getTransform :: Tag T.Text -> Matrix
 getTransform = parseTransform . fromAttrib "transform"
 
--- | Parses a translation String into a 2D array of double (Matrix type),
--- ignoring scaling and rotation.
+-- | Parse a transform string into a single transformation matrix.
+-- Each function in the transform string is composed from left to right.
 parseTransform :: T.Text -> Matrix
 parseTransform "" =
     [ [1, 0, 0]
@@ -507,7 +507,13 @@ parseTransform "" =
 parseTransform transform =
     parseVal parser transform
   where
-    parser =
+    parser = do
+        -- Parse one or more occurrences of transformFunction, separated and optionally ended by whitespace.
+        transformMatrices <- P.sepEndBy1 transformFunction P.space
+        P.eof
+        -- Left-multiply all parsed transformation matrices to obtain a single tranformation matrix.
+        return $ foldl1 matrixMultiply transformMatrices
+    transformFunction =
         P.try scale
             <|> P.try rotate
             <|> P.try translate
@@ -517,6 +523,7 @@ parseTransform transform =
     scale = do
         _ <- P.string "scale("
         args <- double `P.sepBy` (P.char ',' *> P.many (P.char ' ') <|> P.many1 (P.char ' '))
+        _ <- P.char ')'
         let xScale = safeHead 1 args
             yScale = if length args > 1 then args !! 1 else xScale
         return
@@ -527,6 +534,7 @@ parseTransform transform =
     rotate = do
         _ <- P.string "rotate("
         args <- double `P.sepBy` (P.char ',' *> P.many (P.char ' ') <|> P.many1 (P.char ' '))
+        _ <- P.char ')'
         let angleDegrees = safeHead 0 args
             xRot = if length args > 1 then args !! 1 else 0
             yRot = if length args > 2 then args !! 2 else 0
@@ -539,6 +547,7 @@ parseTransform transform =
     translate = do
         _ <- P.string "translate("
         args <- double `P.sepBy` (P.char ',' *> P.many (P.char ' ') <|> P.many1 (P.char ' '))
+        _ <- P.char ')'
         let xPos = safeHead 0 args
             yPos = if length args > 1 then args !! 1 else 0
         return
@@ -554,6 +563,7 @@ parseTransform transform =
         d <- (P.char ',' <|> P.char ' ') >> double
         e <- (P.char ',' <|> P.char ' ') >> double
         f <- (P.char ',' <|> P.char ' ') >> double
+        _ <- P.char ')'
         return
             [ [a, c, e]
             , [b, d, f]
@@ -562,6 +572,7 @@ parseTransform transform =
     skewX = do
         _ <- P.string "skewX("
         angleDegrees <- double
+        _ <- P.char ')'
         let angle = angleDegrees * pi / 180
         return
             [ [1, tan angle, 0]
@@ -571,6 +582,7 @@ parseTransform transform =
     skewY = do
         _ <- P.string "skewY("
         angleDegrees <- double
+        _ <- P.char ')'
         let angle = angleDegrees * pi / 180
         return
             [ [1, 0, 0]

--- a/app/Svg/Parser.hs
+++ b/app/Svg/Parser.hs
@@ -509,7 +509,7 @@ parseTransform transform =
   where
     parser = do
         -- Parse one or more occurrences of transformFunction, separated and optionally ended by whitespace.
-        transformMatrices <- P.sepEndBy1 transformFunction P.space
+        transformMatrices <- P.sepEndBy1 transformFunction P.spaces
         P.eof
         -- Left-multiply all parsed transformation matrices to obtain a single tranformation matrix.
         return $ foldl1 matrixMultiply transformMatrices

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -1537,53 +1537,6 @@ export class Graph extends React.Component {
     return transform ? `matrix(${transform.join(", ")})` : ""
   }
 
-  /**
-   * Get the minimum xy-values of all valid shapes (node, hybrid, and bool) in the graph.
-   * @returns {?{minX, minY}} The minimum xy-values of all valid shapes in the graph,
-   * or null if every shape has no size or position.
-   */
-  getShapesMinXY = () => {
-    const shapes = Object.values(this.state.nodesJSON)
-      .concat(Object.values(this.state.hybridsJSON))
-      .concat(Object.values(this.state.boolsJSON))
-    let minX = Infinity
-    let minY = Infinity
-
-    for (let i = 0; i < shapes.length; i++) {
-      // Skip shapes with no position
-      if (!Array.isArray(shapes[i].pos)) {
-        continue
-      }
-
-      let shapeWidth = Number(shapes[i].width)
-      if (Number.isNaN(shapeWidth) || shapeWidth < 0) {
-        shapeWidth = 0
-      }
-
-      let shapeHeight = Number(shapes[i].height)
-      if (Number.isNaN(shapeHeight) || shapeHeight < 0) {
-        shapeHeight = 0
-      }
-
-      // Skip shapes with no size
-      if (shapeWidth === 0 && shapeHeight === 0) {
-        continue
-      }
-
-      const x = shapes[i].pos[0]
-      const y = shapes[i].pos[1]
-      minX = Math.min(minX, x)
-      minY = Math.min(minY, y)
-    }
-
-    // Return null if all shapes have no size or position
-    if (!Number.isFinite(minX) || !Number.isFinite(minX)) {
-      return null
-    }
-
-    return { x: minX, y: minY }
-  }
-
   render() {
     let containerWidth = 0
     let containerHeight = 0
@@ -1595,32 +1548,20 @@ export class Graph extends React.Component {
 
     let newViewboxWidth = this.state.width * this.state.zoomFactor
     let newViewboxHeight = this.state.height * this.state.zoomFactor
-    let viewboxCentreX = this.state.width / 2
-    let viewboxCentreY = this.state.height / 2
     if (document.getElementById("generateRoot") !== null) {
-      const minCoordinates = this.getShapesMinXY()
-      if (minCoordinates !== null) {
-        // Shift the viewBox's centre by the minimum xy-values of all valid shapes in the graph,
-        // aligning the viewBox on the graph
-        viewboxCentreX += minCoordinates.x
-        viewboxCentreY += minCoordinates.y
-      }
       newViewboxWidth =
         Math.max(this.state.width, containerWidth) * this.state.zoomFactor
       newViewboxHeight =
         Math.max(this.state.height, containerHeight) * this.state.zoomFactor
     }
 
-    // Centre the viewBox using viewboxCentreX/Y, then apply pan
     const viewboxContainerRatio =
       containerHeight !== 0 ? newViewboxHeight / containerHeight : 1
     const viewboxX =
-      viewboxCentreX -
-      newViewboxWidth / 2 +
+      (this.state.width - newViewboxWidth) / 2 +
       this.state.horizontalPanFactor * viewboxContainerRatio
     const viewboxY =
-      viewboxCentreY -
-      newViewboxHeight / 2 +
+      (this.state.height - newViewboxHeight) / 2 +
       this.state.verticalPanFactor * viewboxContainerRatio
 
     // not all of these properties are supported in React

--- a/js/components/graph/Graph.js
+++ b/js/components/graph/Graph.js
@@ -1569,7 +1569,7 @@ export class Graph extends React.Component {
       height: "100%",
       width: "100%",
       viewBox: `${viewboxX} ${viewboxY} ${newViewboxWidth} ${newViewboxHeight}`,
-      preserveAspectRatio: "xMidYMin",
+      preserveAspectRatio: "xMidYMid",
       "xmlns:svg": "http://www.w3.org/2000/svg",
       "xmlns:dc": "http://purl.org/dc/elements/1.1/",
       "xmlns:cc": "http://creativecommons.org/ns#",


### PR DESCRIPTION
## Proposed Changes

This pull request identifies and fixes a centering bug for graphs on the Generate page. It also reverts the centering changes previously made in https://github.com/Courseography/courseography/pull/1764.

When Graphviz converts from DOT to SVG, as it does when rendering a dynamic graph, it has to transform one coordinate system to the other. For example, when I ran `stack run generate` on `[MAT237, STA257]`, I got `<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 721.96)">` as part of the SVG output. However, the function that actually handles parsing of the transform string (`transform="scale(1 1) rotate(0) translate(4 721.96)"`), `parseTransform` in `app/Svg/Parser.hs`, only matches the first transform function it finds. So if the string starts with `scale`, as in the example, then `parseTransform` completely ignores anything else that comes after it, including the `translate`. 

This pull request fixes this issue by updating `parseTransform` to parade multiple transform functions.

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |X         |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] If this is my first contribution, I have added myself to the list of contributors.
- [X] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CircleCI checks have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

I had to clear the dynamic graph cache before I saw any changes.

Aside: I noticed the text in the nodes of dynamic graphs still isn't centred on the deployed site, despite https://github.com/Courseography/courseography/pull/1773 looking fine on my localhost. I can create an issue for it.